### PR TITLE
Fix check for Python modules for cross-compilation [v2]

### DIFF
--- a/config/ax_python_module.m4
+++ b/config/ax_python_module.m4
@@ -25,20 +25,17 @@
 
 AU_ALIAS([AC_PYTHON_MODULE], [AX_PYTHON_MODULE])
 AC_DEFUN([AX_PYTHON_MODULE],[
-    AC_MSG_CHECKING($PYTHON_NAME module: $1)
 	$PYTHON -c "import $1" 2>/dev/null
 	if test $? -eq 0;
 	then
-		AC_MSG_RESULT(yes)
-		eval AS_TR_CPP(HAVE_PYMOD_$1)=yes
+		eval AS_TR_CPP([HAVE_PYMOD_$1])=yes
 	else
-		AC_MSG_RESULT(no)
-		eval AS_TR_CPP(HAVE_PYMOD_$1)=no
+		AC_MSG_RESULT([no])
+		eval AS_TR_CPP([HAVE_PYMOD_$1])=no
 		#
 		if test -n "$2"
 		then
-			AC_MSG_ERROR(failed to find required module $1)
-			exit 1
+			AC_MSG_ERROR([failed to find required module $1])
 		fi
 	fi
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -574,7 +574,10 @@ if test "${enable_python_libs}" = "yes"; then
   PYTHON="python"
  fi
  PYTHON_NAME=`basename $PYTHON`
- AX_PYTHON_MODULE("google.protobuf", "fatal")
+ AC_CACHE_CHECK([for $PYTHON_NAME module: google.protobuf],
+    [ac_cv_have_pymod_google_protobuf],
+    [AX_PYTHON_MODULE([google.protobuf], [fatal])
+     eval ac_cv_have_pymod_google_protobuf=\$AS_TR_CPP([HAVE_PYMOD_google.protobuf])])
 fi
 
 # Maybe build the logic sniffer tools


### PR DESCRIPTION
Here are two patches to enhance (fix) the check of Python modules while
cross-compiling.

There is extensive explanations in the commit log of each patch, but it
basically boils down to the fact that we can't check for Python modules
while doing cross-compilation:
- we can't execute the target Python (obviously)
- the host Python may not have the required module(s)

We've stumbled into this issue while building ola with Buildroot:
    http://buildroot.org/

Changes v1->v2:
- fix displaying the result of the test

Regards,
Yann E. MORIN.
