### PR TITLE
Fix FreeBSD compatibility with version.sh – no bash

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 VERSION_FILE="include/ola/base/Version.h"
 


### PR DESCRIPTION
In version.sh, replaced /bin/bash with /bin/sh, for FreeBSD compatibility
(No bash by default, and it's installed in /usr/local/bin/bash if so.)
If bash is required over sh for some reason, we can use '#!/usr/bin/env bash' instead.
