### PR TITLE
Added user configurable delay inbetween tests

### DIFF
--- a/tools/logic/README.md
+++ b/tools/logic/README.md
@@ -1,0 +1,13 @@
+In order to compile the logic rdm sniffer, you need to set the include path to your SaleaeDeviceSDK. Example:
+
+```
+./configure CPPFLAGS="-I/path/to/your/SaleaeDeviceSdk-1.1.9/include"
+```
+
+The configure script should output something like this:
+
+```
+checking SaleaeDeviceApi.h usability... yes
+checking SaleaeDeviceApi.h presence... yes
+checking for SaleaeDeviceApi.h... yes
+```


### PR DESCRIPTION
This patch adds a configurable delay inbetween tests. I used this to check when my RDM client device started to act strangely, even though it responded okay.
