### PR TITLE
Added small readme on how to compile the logic sniffer utility

### DIFF
--- a/tools/logic/README.md
+++ b/tools/logic/README.md
@@ -1,7 +1,7 @@
 In order to compile the logic rdm sniffer, you need to set the include path to your SaleaeDeviceSDK. Example:
 
 ```
-./configure CPPFLAGS="-I/path/to/your/SaleaeDeviceSdk-1.1.9/include""
+./configure CPPFLAGS="-I/path/to/your/SaleaeDeviceSdk-1.1.9/include"
 ```
 
 The configure script should output something like this:


### PR DESCRIPTION
Adds a small readme file to let users know how to compile the logic sniffer against the SaleaeDeviceSDK
