### PR TITLE
Added vendor string for Open DMX clone from KWMATIK

### DIFF
--- a/plugins/ftdidmx/FtdiWidget-libftdi.cpp
+++ b/plugins/ftdidmx/FtdiWidget-libftdi.cpp
@@ -293,6 +293,7 @@ void FtdiWidget::Widgets(vector<FtdiWidgetInfo> *widgets) {
     std::transform(v.begin(), v.end(), v.begin(), ::toupper);
     if (string::npos != v.find("FTDI") ||
         string::npos != v.find("KMTRONIC") ||
+        string::npos != v.find("KWMATIK") ||
         string::npos != v.find("WWW.SOH.CZ")) {
       widgets->push_back(FtdiWidgetInfo(sname, sserial, i));
     } else {


### PR DESCRIPTION
Recently I bought an inexpensive Open DMX clone from KWMATIK, a polish manufacturer, via ebay.

This is the product page for reference: http://www.kwmatik.cba.pl/en/edmx.html

I wanted to use it together with OLA to control some RGB lights. The FTDI driver did not seem to recognize the interface, so I checked the logs and found out that the vendor string is not whitelisted. After a small modification the interface was working flawlessly.
