### PR TITLE
Remove the override that prevents Sync Bulk Transfers from working in As...

### DIFF
--- a/plugins/usbdmx/LibUsbAdaptor.cpp
+++ b/plugins/usbdmx/LibUsbAdaptor.cpp
@@ -351,8 +351,22 @@ int AsyncronousLibUsbAdaptor::ControlTransfer(
     OLA_UNUSED unsigned char *data,
     OLA_UNUSED uint16_t wLength,
     OLA_UNUSED unsigned int timeout) {
-  OLA_WARN << "libusb_control_transfer in an AsyncronousLibUsbAdaptor";
-  return LIBUSB_ERROR_NOT_SUPPORTED;
+  OLA_DEBUG << "libusb_control_transfer in an AsyncronousLibUsbAdaptor";
+  return BaseLibUsbAdaptor::ControlTransfer(dev_handle, bmRequestType,
+                                            bRequest, wValue, wIndex, data,
+                                            wLength, timeout);
+}
+
+int AsyncronousLibUsbAdaptor::BulkTransfer(
+    struct libusb_device_handle *dev_handle,
+    unsigned char endpoint,
+    unsigned char *data,
+    int length,
+    int *transferred,
+    unsigned int timeout) {
+  OLA_DEBUG << "libusb_bulk_transfer in an AsyncronousLibUsbAdaptor";
+  return BaseLibUsbAdaptor::BulkTransfer(dev_handle, endpoint, data, length,
+                                         transferred, timeout);
 }
 
 int AsyncronousLibUsbAdaptor::InterruptTransfer(
@@ -362,8 +376,9 @@ int AsyncronousLibUsbAdaptor::InterruptTransfer(
     OLA_UNUSED int length,
     OLA_UNUSED int *actual_length,
     OLA_UNUSED unsigned int timeout) {
-  OLA_WARN << "libusb_interrupt_transfer in an AsyncronousLibUsbAdaptor";
-  return LIBUSB_ERROR_NOT_SUPPORTED;
+  OLA_DEBUG << "libusb_interrupt_transfer in an AsyncronousLibUsbAdaptor";
+  return BaseLibUsbAdaptor::InterruptTransfer(dev_handle, endpoint, data,
+                                              length, actual_length, timeout);
 }
 }  // namespace usbdmx
 }  // namespace plugin

--- a/plugins/usbdmx/LibUsbAdaptor.h
+++ b/plugins/usbdmx/LibUsbAdaptor.h
@@ -533,6 +533,13 @@ class AsyncronousLibUsbAdaptor : public BaseLibUsbAdaptor {
                       uint16_t wLength,
                       unsigned int timeout);
 
+  int BulkTransfer(struct libusb_device_handle *dev_handle,
+                   unsigned char endpoint,
+                   unsigned char *data,
+                   int length,
+                   int *transferred,
+                   unsigned int timeout);
+
   int InterruptTransfer(libusb_device_handle *dev_handle,
                         unsigned char endpoint,
                         unsigned char *data,


### PR DESCRIPTION
...ync mode.

This is required for the fadecandy init code to work, until such time as we
make it async.
