### PR TITLE
Update rdm_patcher.js to use correct "identify" command

### DIFF
--- a/javascript/ola/full/rdm_patcher.js
+++ b/javascript/ola/full/rdm_patcher.js
@@ -971,7 +971,7 @@ ola.RDMPatcher.prototype.toggleIdentify_ = function(e) {
   server.rdmSetSectionInfo(
       this.universe_id,
       this.active_device.uid,
-      'identify',
+      'identify_device',
       '',
       'bool=' + (e.target.isChecked() ? '1' : '0'),
       function(e) { patcher.identifyComplete_(e); });


### PR DESCRIPTION
The identify command string is "identify_device" not "identify".  This fix will allow identify checkbox to work in the patcher popup for a particular device in the patch panel