### PR TITLE
Fix small ola_protoc configure issues

### DIFF
--- a/config/ola.m4
+++ b/config/ola.m4
@@ -78,10 +78,10 @@ AC_ARG_WITH([ola-protoc-plugin],
 
 
 if test "$with_ola_protoc_plugin" != "no"; then
-  OLA_PROTOC="\$(PROTOC) --plugin=protoc-gen-cppservice=${with_ola_protoc_plugin}${EXEEXT}";
-  echo "set ola_protoc to $with_ola_protoc_plugin"
+  OLA_PROTOC="$PROTOC --plugin=protoc-gen-cppservice=${with_ola_protoc_plugin}";
+  echo "set ola_protoc to $OLA_PROTOC"
 else
-  OLA_PROTOC="\$(PROTOC) --plugin=protoc-gen-cppservice=\$(top_builddir)/protoc/ola_protoc_plugin${EXEEXT}";
+  OLA_PROTOC="$PROTOC --plugin=protoc-gen-cppservice=\$(top_builddir)/protoc/ola_protoc_plugin${EXEEXT}";
   AC_CHECK_HEADER(
       [google/protobuf/compiler/command_line_interface.h],
       [],


### PR DESCRIPTION
This fixes issues raised in #614.

- In the configure output, report the full OLA_PROTOC command used, not
  just the plugin path.
- Do not append EXEEXT at the end of the passed plugin.

For the configure output, I changed "\$(PROTOC)" to "$PROTOC", so it's
replaced immediately and the full path is printed. Normally, PROTOC
should always be defined at this point (it's done higher in the same
file).