### PR TITLE
Fix the build on Ubuntu 14.04

### DIFF
--- a/plugins/usbdmx/LibUsbThread.cpp
+++ b/plugins/usbdmx/LibUsbThread.cpp
@@ -60,7 +60,7 @@ void LibUsbThread::JoinThread() {
 // LibUsbHotplugThread
 // -----------------------------------------------------------------------------
 
-#if defined(LIBUSB_API_VERSION) && (LIBUSB_API_VERSION >= 0x01000102)
+#if HAVE_LIBUSB_HOTPLUG_API
 LibUsbHotplugThread::LibUsbHotplugThread(libusb_context *context,
                                          libusb_hotplug_callback_fn callback_fn,
                                          void *user_data)

--- a/plugins/usbdmx/LibUsbThread.h
+++ b/plugins/usbdmx/LibUsbThread.h
@@ -23,6 +23,10 @@
 
 #include <libusb.h>
 
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "ola/base/Macro.h"
 #include "ola/thread/Thread.h"
 
@@ -128,7 +132,7 @@ class LibUsbThread : private ola::thread::Thread {
   ola::thread::Mutex m_term_mutex;
 };
 
-#if defined(LIBUSB_API_VERSION) && (LIBUSB_API_VERSION >= 0x01000102)
+#if HAVE_LIBUSB_HOTPLUG_API
 
 /**
  * @brief The hotplug version of the LibUsbThread.


### PR DESCRIPTION
Final retrospective (hopefully) @nomis52 .

On 14.04 libusb-1.0-0-dev defines LIBUSBX_API_VERSION rather than LIBUSB_API_VERSION.

Should close #650