### PR TITLE
Python 3 compatibility

### DIFF
--- a/python/examples/ola_artnet_params.py
+++ b/python/examples/ola_artnet_params.py
@@ -26,9 +26,9 @@ from ola import ArtNetConfigMessages_pb2
 def ArtNetConfigureReply(state, response):
   reply = ArtNetConfigMessages_pb2.Reply()
   reply.ParseFromString(response)
-  print 'Short Name: %s' % reply.options.short_name
-  print 'Long Name: %s' % reply.options.long_name
-  print 'Subnet: %d' % reply.options.subnet
+  print('Short Name: %s' % reply.options.short_name)
+  print('Long Name: %s' % reply.options.long_name)
+  print('Subnet: %d' % reply.options.subnet)
   wrapper.Stop()
 
 

--- a/python/examples/ola_devices.py
+++ b/python/examples/ola_devices.py
@@ -30,13 +30,13 @@ def RDMString(port):
 
 def Devices(state, devices):
   for device in sorted(devices):
-    print 'Device %d: %s' % (device.alias, device.name)
-    print 'Input ports:'
+    print('Device %d: %s' % (device.alias, device.name))
+    print('Input ports:')
     for port in device.input_ports:
-      print '  port %d, %s %s' % (port.id, port.description, RDMString(port))
-    print 'Output ports:'
+      print('  port %d, %s %s' % (port.id, port.description, RDMString(port)))
+    print('Output ports:')
     for port in device.output_ports:
-      print '  port %d, %s %s' % (port.id, port.description, RDMString(port))
+      print('  port %d, %s %s' % (port.id, port.description, RDMString(port)))
   wrapper.Stop()
 
 

--- a/python/examples/ola_plugin_info.py
+++ b/python/examples/ola_plugin_info.py
@@ -47,8 +47,8 @@ def main():
 
   try:
       opts, args = getopt.getopt(sys.argv[1:], "hp:", ["help", "plugin="])
-  except getopt.GetoptError, err:
-    print str(err)
+  except getopt.GetoptError as err:
+    print(str(err))
     Usage()
     sys.exit(2)
 

--- a/python/examples/ola_plugin_info.py
+++ b/python/examples/ola_plugin_info.py
@@ -27,22 +27,22 @@ from ola.ClientWrapper import ClientWrapper
 from ola.OlaClient import Universe
 
 def Usage():
-  print textwrap.dedent("""
+  print(textwrap.dedent("""
   Usage: ola_plugin_info.py [--plugin <plugin_id>]
 
   Display a list of plugins, or a description for a particular plugin.
 
   -h, --help                Display this help message and exit.
-  -p, --plugin <plugin_id>  Plugin ID number.""")
+  -p, --plugin <plugin_id>  Plugin ID number."""))
 
 def main():
   def Plugins(state, plugins):
     for plugin in plugins:
-      print '%d %s' % (plugin.id, plugin.name)
+      print('%d %s' % (plugin.id, plugin.name))
     wrapper.Stop()
 
   def PluginDescription(state, description):
-    print description;
+    print(description);
     wrapper.Stop()
 
   try:

--- a/python/examples/ola_rdm_discover.py
+++ b/python/examples/ola_rdm_discover.py
@@ -41,8 +41,8 @@ def main():
   try:
       opts, args = getopt.getopt(sys.argv[1:], 'fjiu:',
                                  ['help', 'full', 'incremental', 'universe='])
-  except getopt.GetoptError, err:
-    print str(err)
+  except getopt.GetoptError as err:
+    print(str(err))
     Usage()
     sys.exit(2)
 

--- a/python/examples/ola_rdm_discover.py
+++ b/python/examples/ola_rdm_discover.py
@@ -26,7 +26,7 @@ import sys
 from ola.ClientWrapper import ClientWrapper
 
 def usage():
-  print textwrap.dedent("""\
+  print(textwrap.dedent("""\
   Usage: ola_rdm_discover.py --universe <universe> [--force_discovery]
 
   Fetch the UID list for a universe.
@@ -34,7 +34,7 @@ def usage():
     -h, --help                Display this help message and exit.
     -f, --full                Full RDM Discovery for this universe.
     -i, --incremental         Incremental RDM Discovery for this universe.
-    -u, --universe <universe> Universe number.""")
+    -u, --universe <universe> Universe number."""))
 
 
 def main():
@@ -66,7 +66,7 @@ def main():
     sys.exit()
 
   if incremental_discovery and full_discovery:
-    print 'Only one of --incremental or --full can be specified'
+    print('Only one of --incremental or --full can be specified')
     sys.exit()
 
   wrapper = ClientWrapper()
@@ -75,7 +75,7 @@ def main():
   def show_uids(state, uids):
     if state.Succeeded():
       for uid in uids:
-        print str(uid)
+        print(str(uid))
     wrapper.Stop()
 
   if full_discovery:

--- a/python/examples/ola_rdm_get.py
+++ b/python/examples/ola_rdm_get.py
@@ -92,7 +92,7 @@ class ResponsePrinter(object):
 
   def Default(self, uid, response_data):
     if isinstance(response_data, dict):
-      for key, value in response_data.iteritems():
+      for key, value in response_data.items():
         print('%s: %r' % (key, value))
     else:
       print(response_data)

--- a/python/examples/ola_rdm_get.py
+++ b/python/examples/ola_rdm_get.py
@@ -316,7 +316,7 @@ class InteractiveModeController(cmd.Cmd):
                 args[1:]):
         self._outstanding_request = (self._sub_device, request_type, pid)
         self.wrapper.Run()
-    except PidStore.ArgsValidationError, e:
+    except PidStore.ArgsValidationError as e:
       args, help_string = pid.GetRequestDescription(request_type)
       print 'Usage: %s %s %s' % (command, pid.name.lower(), args)
       print help_string
@@ -423,8 +423,8 @@ def main():
                                ['sub-device=', 'help', 'interactive',
                                  'list-pids', 'pid-location=', 'uid=',
                                  'universe='])
-  except getopt.GetoptError, err:
-    print str(err)
+  except getopt.GetoptError as err:
+    print(str(err))
     Usage()
     sys.exit(2)
 

--- a/python/examples/ola_rdm_get.py
+++ b/python/examples/ola_rdm_get.py
@@ -74,8 +74,7 @@ class ResponsePrinter(object):
         self.Default(uid, response_data)
 
   def SupportedParameters(self, uid, response_data):
-    params = [p['param_id'] for p in response_data['params']]
-    params.sort()
+    params = sorted([p['param_id'] for p in response_data['params']])
     for pid_value in params:
       pid = self.pid_store.GetPid(pid_value, uid.manufacturer_id)
       if pid:
@@ -269,10 +268,9 @@ class InteractiveModeController(cmd.Cmd):
           pids.append(pid)
 
     # now check if this type of request is supported
-    pid_names = [pid.name.lower() for pid in pids
-                 if pid.RequestSupported(request_type)]
+    pid_names = sorted([pid.name.lower() for pid in pids
+                 if pid.RequestSupported(request_type)])
 
-    pid_names.sort()
     return pid_names
 
   def GetOrSet(self, request_type, line):

--- a/python/examples/ola_rdm_get.py
+++ b/python/examples/ola_rdm_get.py
@@ -34,7 +34,7 @@ from ola.RDMAPI import RDMAPI
 from ola.UID import UID
 
 def Usage():
-  print textwrap.dedent("""\
+  print(textwrap.dedent("""\
   Usage: ola_rdm_get.py --universe <universe> --uid <uid> <pid>
 
   Get the value of a pid for a device.
@@ -46,7 +46,7 @@ def Usage():
     -l, --list-pids           display a list of pids
     -p, --pid-location        the directory to read PID definitions from
     --uid                     the UID to send to
-    -u, --universe <universe> Universe number.""")
+    -u, --universe <universe> Universe number."""))
 
 wrapper = None
 
@@ -64,10 +64,10 @@ class ResponsePrinter(object):
   def PrintResponse(self, uid, pid_value, response_data):
     pid = self.pid_store.GetPid(pid_value, uid.manufacturer_id)
     if pid is None:
-      print 'PID: 0x%04hx' % pid_value
+      print('PID: 0x%04hx' % pid_value)
       self.Default(uid, response_data)
     else:
-      print pid
+      print(pid)
       if pid.name in self._handlers:
         self._handlers[pid.name](uid, response_data)
       else:
@@ -79,23 +79,23 @@ class ResponsePrinter(object):
     for pid_value in params:
       pid = self.pid_store.GetPid(pid_value, uid.manufacturer_id)
       if pid:
-        print pid
+        print(pid)
       else:
-        print '0x%hx' % pid_value
+        print('0x%hx' % pid_value)
 
   def ProxiedDevices(self, uid, response_data):
     uids = []
     for uid_data in response_data['uids']:
       uids.append(UID(uid_data['manufacturer_id'], uid_data['device_id']))
     for uid in sorted(uids):
-      print uid
+      print(uid)
 
   def Default(self, uid, response_data):
     if isinstance(response_data, dict):
       for key, value in response_data.iteritems():
-        print '%s: %r' % (key, value)
+        print('%s: %r' % (key, value))
     else:
-      print response_data
+      print(response_data)
 
 
 class InteractiveModeController(cmd.Cmd):
@@ -134,27 +134,27 @@ class InteractiveModeController(cmd.Cmd):
     return True
 
   def do_EOF(self, s):
-    print ''
+    print('')
     return self.do_exit('')
 
   def do_uid(self, line):
     """Sets the active UID."""
     args = line.split()
     if len(args) != 1:
-      print '*** Requires a single UID argument'
+      print('*** Requires a single UID argument')
       return
 
     uid = UID.FromString(args[0])
     if uid is None:
-      print '*** Invalid UID'
+      print('*** Invalid UID')
       return
 
     if uid not in self._uids:
-      print '*** UID not found'
+      print('*** UID not found')
       return
 
     self._uid = uid
-    print 'Fetching queued messages...'
+    print('Fetching queued messages...')
     self._FetchQueuedMessages()
     self.wrapper.Run()
 
@@ -170,30 +170,30 @@ class InteractiveModeController(cmd.Cmd):
     """Sets the sub device."""
     args = line.split()
     if len(args) != 1:
-      print '*** Requires a single int argument'
+      print('*** Requires a single int argument')
       return
 
     try:
       sub_device = int(args[0])
     except ValueError:
-      print '*** Requires a single int argument'
+      print('*** Requires a single int argument')
       return
 
     if sub_device < 0 or sub_device > PidStore.ALL_SUB_DEVICES:
-      print ('*** Argument must be between 0 and 0x%hx' %
+      print('*** Argument must be between 0 and 0x%hx' %
              PidStore.ALL_SUB_DEVICES)
       return
     self._sub_device = sub_device
 
   def do_print(self, l):
     """Prints the current universe, UID and sub device."""
-    print textwrap.dedent("""\
+    print(textwrap.dedent("""\
       Universe: %d
       UID: %s
       Sub Device: %d""" % (
         self._universe,
         self._uid,
-        self._sub_device))
+        self._sub_device)))
 
   def do_uids(self, l):
     """List the UIDs for this universe."""
@@ -205,7 +205,7 @@ class InteractiveModeController(cmd.Cmd):
     if state.Succeeded():
       self._UpdateUids(uids)
       for uid in uids:
-        print str(uid)
+        print(str(uid))
     self.wrapper.Stop()
 
   def do_full_discovery(self, l):
@@ -237,7 +237,7 @@ class InteractiveModeController(cmd.Cmd):
       for pid in self.pid_store.ManufacturerPids(self._uid.manufacturer_id):
         names.append('%s (0x%04hx)' % (pid.name.lower(), pid.value))
     names.sort()
-    print '\n'.join(names)
+    print('\n'.join(names))
 
   def do_queued(self, line):
     """Fetch all the queued messages."""
@@ -277,7 +277,7 @@ class InteractiveModeController(cmd.Cmd):
 
   def GetOrSet(self, request_type, line):
     if self._uid is None:
-      print '*** No UID selected, use the uid command'
+      print('*** No UID selected, use the uid command')
       return
 
     args = line.split()
@@ -285,7 +285,7 @@ class InteractiveModeController(cmd.Cmd):
     if request_type == PidStore.RDM_SET:
       command = 'set'
     if len(args) < 1:
-      print '%s <pid> [args]' % command
+      print('%s <pid> [args]' % command)
       return
 
     pid = None
@@ -294,12 +294,12 @@ class InteractiveModeController(cmd.Cmd):
     except ValueError:
       pid = self.pid_store.GetName(args[0].upper(), self._uid.manufacturer_id)
     if pid is None:
-      print '*** Unknown pid %s' % args[0]
+      print('*** Unknown pid %s' % args[0])
       return
 
     rdm_args = args[1:]
     if not pid.RequestSupported(request_type):
-      print '*** PID does not support command'
+      print('*** PID does not support command')
       return
 
     if request_type == PidStore.RDM_SET:
@@ -318,10 +318,10 @@ class InteractiveModeController(cmd.Cmd):
         self.wrapper.Run()
     except PidStore.ArgsValidationError as e:
       args, help_string = pid.GetRequestDescription(request_type)
-      print 'Usage: %s %s %s' % (command, pid.name.lower(), args)
-      print help_string
-      print ''
-      print '*** %s' % e
+      print('Usage: %s %s %s' % (command, pid.name.lower(), args))
+      print(help_string)
+      print('')
+      print('*** %s' % e)
       return
 
   def _FetchQueuedMessages(self):
@@ -343,15 +343,15 @@ class InteractiveModeController(cmd.Cmd):
     self.wrapper.Stop()
 
     if response.response_type == OlaClient.RDM_NACK_REASON:
-      print 'Got nack with reason: %s' % response.nack_reason
+      print('Got nack with reason: %s' % response.nack_reason)
     elif unpack_exception:
-      print unpack_exception
+      print(unpack_exception)
     else:
       self._response_printer.PrintResponse(self._uid, response.pid,
                                            unpacked_data)
 
     if response.queued_messages:
-      print '%d queued messages remain' % response.queued_messages
+      print('%d queued messages remain' % response.queued_messages)
 
   def _QueuedMessageComplete(self, response, unpacked_data, unpack_exception):
     if not self._CheckForAckOrNack(response):
@@ -368,14 +368,14 @@ class InteractiveModeController(cmd.Cmd):
 
       elif (response.nack_reason == RDMNack.NR_UNKNOWN_PID and
             response.pid == self.pid_store.GetName('QUEUED_MESSAGE').value):
-        print 'Device doesn\'t support queued messages'
+        print('Device doesn\'t support queued messages')
         self.wrapper.StopIfNoEvents()
       else:
-        print 'Got nack for 0x%04hx with reason: %s' % (
-            response.pid, response.nack_reason)
+        print('Got nack for 0x%04hx with reason: %s' % (
+            response.pid, response.nack_reason))
 
     elif unpack_exception:
-      print 'Invalid Param data: %s' % unpack_exception
+      print('Invalid Param data: %s' % unpack_exception)
     else:
       status_messages_pid = self.pid_store.GetName('STATUS_MESSAGES')
       if (response.pid == status_messages_pid.value and
@@ -399,12 +399,12 @@ class InteractiveModeController(cmd.Cmd):
       True if this response was an ACK or NACK, False for all other cases.
     """
     if not response.status.Succeeded():
-      print response.status.message
+      print(response.status.message)
       self.wrapper.Stop()
       return False
 
     if response.response_code != OlaClient.RDM_COMPLETED_OK:
-      print response.ResponseCodeAsString()
+      print(response.ResponseCodeAsString())
       self.wrapper.Stop()
       return False
 

--- a/python/examples/ola_recv_dmx.py
+++ b/python/examples/ola_recv_dmx.py
@@ -40,8 +40,8 @@ def Usage():
 def main():
   try:
       opts, args = getopt.getopt(sys.argv[1:], "hu:", ["help", "universe="])
-  except getopt.GetoptError, err:
-    print str(err)
+  except getopt.GetoptError as err:
+    print(str(err))
     Usage()
     sys.exit(2)
 

--- a/python/examples/ola_recv_dmx.py
+++ b/python/examples/ola_recv_dmx.py
@@ -26,16 +26,16 @@ import sys
 from ola.ClientWrapper import ClientWrapper
 
 def NewData(data):
-  print data
+  print(data)
 
 def Usage():
-  print textwrap.dedent("""
+  print(textwrap.dedent("""
   Usage: ola_recv_dmx.py --universe <universe>
 
   Display the DXM512 data for the universe.
 
   -h, --help                Display this help message and exit.
-  -u, --universe <universe> Universe number.""")
+  -u, --universe <universe> Universe number."""))
 
 def main():
   try:

--- a/python/examples/ola_universe_info.py
+++ b/python/examples/ola_universe_info.py
@@ -25,7 +25,7 @@ from ola.OlaClient import Universe
 
 def Universes(state, universes):
   for uni in universes:
-    print '%d %s %r' % (uni.id, uni.name, uni.merge_mode == Universe.LTP)
+    print('%d %s %r' % (uni.id, uni.name, uni.merge_mode == Universe.LTP))
   wrapper.Stop()
 
 wrapper = ClientWrapper()

--- a/python/examples/rdm_compare.py
+++ b/python/examples/rdm_compare.py
@@ -178,8 +178,8 @@ def main():
         sys.argv[1:],
         'hb',
         ['help', 'browser'])
-  except getopt.GetoptError, err:
-    print str(err)
+  except getopt.GetoptError as err:
+    print(str(err))
     Usage()
     sys.exit(2)
 

--- a/python/examples/rdm_compare.py
+++ b/python/examples/rdm_compare.py
@@ -56,7 +56,7 @@ def ReadFile(filename):
   raw_data = pickle.load(f)
   f.close()
   data = {}
-  for uid, settings in raw_data.iteritems():
+  for uid, settings in raw_data.items():
     data[UID.FromString(uid)] = settings
   return data
 
@@ -77,7 +77,7 @@ def Diff(configuration1, configuration2):
   added = set()
   changed = []
   removed = set()
-  for uid, config1 in configuration1.iteritems():
+  for uid, config1 in configuration1.items():
     config2 = configuration2.get(uid)
     if config2 is None:
       removed.add(uid)

--- a/python/examples/rdm_compare.py
+++ b/python/examples/rdm_compare.py
@@ -38,13 +38,13 @@ class LoadException(Error):
   """Raised when we can't write to the output file."""
 
 def Usage():
-  print textwrap.dedent("""\
+  print(textwrap.dedent("""\
   Usage: rdm_compare.py <file1> <file2>
 
   Compare two RDM configurations saved with rdm_snapshot.
 
   Flags:
-    -h, --help    Display this help message and exit.""")
+    -h, --help    Display this help message and exit."""))
 
 
 def ReadFile(filename):
@@ -163,12 +163,12 @@ def DiffToStdout(configuration1, configuration2):
   """Diff the configurations and write to STDOUT."""
   added, changed, removed = Diff(configuration1, configuration2)
   for uid in added:
-    print 'Device %s was added' % uid
+    print('Device %s was added' % uid)
   for uid in removed:
-      print 'Device %s was removed' % uid
+      print('Device %s was removed' % uid)
 
   for uid, human_field, value1, value2 in changed:
-    print ('%s: %s changed from %s to %s' %
+    print('%s: %s changed from %s to %s' %
            (uid, human_field, value1, value2))
 
 

--- a/python/examples/rdm_snapshot.py
+++ b/python/examples/rdm_snapshot.py
@@ -49,7 +49,7 @@ class LoadException(Error):
 class ConfigReader(object):
   """A controller that fetches data for responders."""
 
-  (EMPTYING_QUEUE, DMX_START_ADDRESS, DEVICE_LABEL, PERSONALITY) = xrange(4)
+  (EMPTYING_QUEUE, DMX_START_ADDRESS, DEVICE_LABEL, PERSONALITY) = range(4)
 
   def __init__(self, wrapper, pid_store):
     self.wrapper = wrapper
@@ -303,7 +303,7 @@ class ConfigReader(object):
 
 class ConfigWriter(object):
   """A controller that applies configuration to a universe."""
-  (DMX_START_ADDRESS, DEVICE_LABEL, PERSONALITY, COMPLETE) = xrange(4)
+  (DMX_START_ADDRESS, DEVICE_LABEL, PERSONALITY, COMPLETE) = range(4)
 
   def __init__(self, wrapper, pid_store):
     self.wrapper = wrapper

--- a/python/examples/rdm_snapshot.py
+++ b/python/examples/rdm_snapshot.py
@@ -226,10 +226,10 @@ class ConfigReader(object):
 
     # at this stage the response is either a ack or nack
     if response.response_type == OlaClient.RDM_NACK_REASON:
-      print 'Got nack with reason: %s' % response.nack_reason
+      print('Got nack with reason: %s' % response.nack_reason)
       self._NextState()
     elif unpack_exception:
-      print unpack_exception
+      print(unpack_exception)
       self.wrapper.Stop()
     else:
       self._HandleResponse(unpacked_data)
@@ -244,7 +244,7 @@ class ConfigReader(object):
           response.command_class == OlaClient.RDM_GET_RESPONSE and
           response.pid == self.outstanding_pid.value):
         # we found what we were looking for
-        print "found, but nacked"
+        print("found, but nacked")
         self.outstanding_pid = None
         self._NextState()
 
@@ -253,11 +253,11 @@ class ConfigReader(object):
         logging.debug('Device doesn\'t support queued messages')
         self._NextState()
       else:
-        print 'Got nack for 0x%04hx with reason: %s' % (
-            response.pid, response.nack_reason)
+        print('Got nack for 0x%04hx with reason: %s' % (
+            response.pid, response.nack_reason))
 
     elif unpack_exception:
-      print 'Invalid Param data: %s' % unpack_exception
+      print('Invalid Param data: %s' % unpack_exception)
     else:
       status_messages_pid = self.pid_store.GetName('STATUS_MESSAGES')
       queued_message_pid = self.pid_store.GetName('QUEUED_MESSAGE')
@@ -284,12 +284,12 @@ class ConfigReader(object):
       True if this response was an ACK or NACK, False for all other cases.
     """
     if not response.status.Succeeded():
-      print response.status.message
+      print(response.status.message)
       self.wrapper.Stop()
       return False
 
     if response.response_code != OlaClient.RDM_COMPLETED_OK:
-      print response.ResponseCodeAsString()
+      print(response.ResponseCodeAsString())
       self.wrapper.Stop()
       return False
 
@@ -337,7 +337,7 @@ class ConfigWriter(object):
 
     for uid in self.configuration.keys():
       if uid not in found_uids:
-        print 'Device %s has been removed' % uid
+        print('Device %s has been removed' % uid)
     self._SetNextUID()
 
   def _SetNextUID(self):
@@ -347,7 +347,7 @@ class ConfigWriter(object):
       return
 
     self.uid = self.uids.pop()
-    print 'Doing %s' % self.uid
+    print('Doing %s' % self.uid)
     self.work_state = self.DMX_START_ADDRESS
     self._NextState()
 
@@ -392,12 +392,12 @@ class ConfigWriter(object):
 
   def _RDMRequestComplete(self, response, unpacked_data, unpack_exception):
     if not response.status.Succeeded():
-      print response.status.message
+      print(response.status.message)
       self.wrapper.Stop()
       return
 
     if response.response_code != OlaClient.RDM_COMPLETED_OK:
-      print response.ResponseCodeAsString()
+      print(response.ResponseCodeAsString())
       self.wrapper.Stop()
       return
 
@@ -409,12 +409,12 @@ class ConfigWriter(object):
 
     # at this stage the response is either a ack or nack
     if response.response_type == OlaClient.RDM_NACK_REASON:
-      print 'Got nack with reason: %s' % response.nack_reason
+      print('Got nack with reason: %s' % response.nack_reason)
     self._NextState()
 
 
 def Usage():
-  print textwrap.dedent("""\
+  print(textwrap.dedent("""\
   Usage: rdm_snapshot.py --universe <universe> [--input <file>] [--output <file>]
 
   Save and restore RDM settings for a universe. This includes the start address,
@@ -433,7 +433,7 @@ def Usage():
     -o, --output              File to save configuration to.
     --skip-queued-messages    Don't attempt to fetch queued messages for the
                               device.
-    -u, --universe <universe> Universe number.""")
+    -u, --universe <universe> Universe number."""))
 
 
 def WriteToFile(filename, output):
@@ -502,7 +502,7 @@ def main():
     sys.exit()
 
   if input_file and output_file:
-    print 'Only one of --input and --output can be provided.'
+    print('Only one of --input and --output can be provided.')
     sys.exit()
 
   logging.basicConfig(

--- a/python/examples/rdm_snapshot.py
+++ b/python/examples/rdm_snapshot.py
@@ -320,7 +320,7 @@ class ConfigWriter(object):
     """
     self.universe = universe
     self.configuration = configuration
-    self.uids = configuration.keys()
+    self.uids = list(configuration.keys())
 
     self.client.RunRDMDiscovery(self.universe, True, self._HandleUIDList)
     self.wrapper.Run()
@@ -335,7 +335,7 @@ class ConfigWriter(object):
       found_uids.add(uid)
       logging.debug(uid)
 
-    for uid in self.configuration.keys():
+    for uid in list(self.configuration.keys()):
       if uid not in found_uids:
         print('Device %s has been removed' % uid)
     self._SetNextUID()
@@ -457,7 +457,7 @@ def ReadFile(filename):
   raw_data = pickle.load(f)
   f.close()
   data = {}
-  for uid, settings in raw_data.iteritems():
+  for uid, settings in raw_data.items():
     data[UID.FromString(uid)] = settings
   return data
 

--- a/python/examples/rdm_snapshot.py
+++ b/python/examples/rdm_snapshot.py
@@ -335,7 +335,7 @@ class ConfigWriter(object):
       found_uids.add(uid)
       logging.debug(uid)
 
-    for uid in list(self.configuration.keys()):
+    for uid in self.configuration.keys():
       if uid not in found_uids:
         print('Device %s has been removed' % uid)
     self._SetNextUID()

--- a/python/examples/rdm_snapshot.py
+++ b/python/examples/rdm_snapshot.py
@@ -469,8 +469,8 @@ def main():
         'dhi:o:p:u:',
         ['debug', 'help', 'input=', 'skip-queued-messages', 'output=',
          'pid-location=', 'universe='])
-  except getopt.GetoptError, err:
-    print str(err)
+  except getopt.GetoptError as err:
+    print(str(err))
     Usage()
     sys.exit(2)
 

--- a/python/ola/ClientWrapper.py
+++ b/python/ola/ClientWrapper.py
@@ -191,9 +191,9 @@ class SelectServer(object):
       if len(self._events):
         sleep_time = min(1.0, self._events[0].TimeLeft(now))
 
-      i, o, e = select.select(list(self._read_descriptors.keys()),
-                              list(self._write_descriptors.keys()),
-                              list(self._error_descriptors.keys()),
+      i, o, e = select.select(self._read_descriptors.keys(),
+                              self._write_descriptors.keys(),
+                              self._error_descriptors.keys(),
                               sleep_time)
       now = datetime.datetime.now()
       self._CheckTimeouts(now)

--- a/python/ola/ClientWrapper.py
+++ b/python/ola/ClientWrapper.py
@@ -191,9 +191,9 @@ class SelectServer(object):
       if len(self._events):
         sleep_time = min(1.0, self._events[0].TimeLeft(now))
 
-      i, o, e = select.select(self._read_descriptors.keys(),
-                              self._write_descriptors.keys(),
-                              self._error_descriptors.keys(),
+      i, o, e = select.select(list(self._read_descriptors.keys()),
+                              list(self._write_descriptors.keys()),
+                              list(self._error_descriptors.keys()),
                               sleep_time)
       now = datetime.datetime.now()
       self._CheckTimeouts(now)
@@ -228,7 +228,7 @@ class SelectServer(object):
 
   def _CheckDescriptors(self, ready_set, all_descriptors):
     runnables = []
-    for fd, runnable in all_descriptors.iteritems():
+    for fd, runnable in all_descriptors.items():
       if fd in ready_set:
         runnables.append(runnable)
     for runnable in runnables:

--- a/python/ola/DUBDecoderTest.py
+++ b/python/ola/DUBDecoderTest.py
@@ -54,8 +54,8 @@ class UIDTest(unittest.TestCase):
   def testValidResponse(self):
     uid = DecodeResponse(self.TEST_DATA)
     self.assertNotEqual(None, uid)
-    self.assertEquals(0x00a1, uid.manufacturer_id)
-    self.assertEquals(0x00020020, uid.device_id)
+    self.assertEqual(0x00a1, uid.manufacturer_id)
+    self.assertEqual(0x00020020, uid.device_id)
 
 if __name__ == '__main__':
   unittest.main()

--- a/python/ola/MACAddressTest.py
+++ b/python/ola/MACAddressTest.py
@@ -27,8 +27,8 @@ class MACAddressTest(unittest.TestCase):
 
   def testBasic(self):
     mac = MACAddress(bytearray([0x01, 0x23, 0x45, 0x67, 0x89, 0xab]))
-    self.assertEquals(b'\x01\x23\x45\x67\x89\xab', bytes(mac.mac_address))
-    self.assertEquals('01:23:45:67:89:ab', str(mac))
+    self.assertEqual(b'\x01\x23\x45\x67\x89\xab', bytes(mac.mac_address))
+    self.assertEqual('01:23:45:67:89:ab', str(mac))
 
     self.assertTrue(mac > None)
     mac2 = MACAddress(bytearray([0x01, 0x23, 0x45, 0x67, 0x89, 0xcd]))
@@ -36,24 +36,24 @@ class MACAddressTest(unittest.TestCase):
     mac3 = MACAddress(bytearray([0x01, 0x23, 0x45, 0x67, 0x88, 0xab]))
     self.assertTrue(mac > mac3)
     macs = [mac, mac2, mac3]
-    self.assertEquals([mac3, mac, mac2], sorted(macs))
+    self.assertEqual([mac3, mac, mac2], sorted(macs))
 
   def testFromString(self):
-    self.assertEquals(None, MACAddress.FromString(''))
-    self.assertEquals(None, MACAddress.FromString('abc'))
-    self.assertEquals(None, MACAddress.FromString(':'))
-    self.assertEquals(None, MACAddress.FromString('0:1:2'))
-    self.assertEquals(None, MACAddress.FromString('12345:1234'))
+    self.assertEqual(None, MACAddress.FromString(''))
+    self.assertEqual(None, MACAddress.FromString('abc'))
+    self.assertEqual(None, MACAddress.FromString(':'))
+    self.assertEqual(None, MACAddress.FromString('0:1:2'))
+    self.assertEqual(None, MACAddress.FromString('12345:1234'))
 
     mac = MACAddress.FromString('01:23:45:67:89:ab')
     self.assertTrue(mac)
-    self.assertEquals(b'\x01\x23\x45\x67\x89\xab', bytes(mac.mac_address))
-    self.assertEquals('01:23:45:67:89:ab', str(mac))
+    self.assertEqual(b'\x01\x23\x45\x67\x89\xab', bytes(mac.mac_address))
+    self.assertEqual('01:23:45:67:89:ab', str(mac))
 
     mac2 = MACAddress.FromString('98.76.54.fe.dc.ba')
     self.assertTrue(mac2)
-    self.assertEquals(b'\x98\x76\x54\xfe\xdc\xba', bytes(mac2.mac_address))
-    self.assertEquals('98:76:54:fe:dc:ba', str(mac2))
+    self.assertEqual(b'\x98\x76\x54\xfe\xdc\xba', bytes(mac2.mac_address))
+    self.assertEqual('98:76:54:fe:dc:ba', str(mac2))
 
   def testSorting(self):
     m1 = MACAddress(bytearray([0x48, 0x45, 0xff, 0xff, 0xff, 0xfe]))
@@ -61,7 +61,7 @@ class MACAddressTest(unittest.TestCase):
     m3 = MACAddress(bytearray([0x48, 0x44, 0x00, 0x00, 0x02, 0x2e]))
     m4 = MACAddress(bytearray([0x48, 0x46, 0x00, 0x00, 0x02, 0x2e]))
     macs = sorted([m1, m2, m3, m4])
-    self.assertEquals([m3, m2, m1, m4], macs)
+    self.assertEqual([m3, m2, m1, m4], macs)
 
 if __name__ == '__main__':
   unittest.main()

--- a/python/ola/MACAddressTest.py
+++ b/python/ola/MACAddressTest.py
@@ -60,8 +60,7 @@ class MACAddressTest(unittest.TestCase):
     m2 = MACAddress(bytearray([0x48, 0x45, 0x00, 0x00, 0x02, 0x2e]))
     m3 = MACAddress(bytearray([0x48, 0x44, 0x00, 0x00, 0x02, 0x2e]))
     m4 = MACAddress(bytearray([0x48, 0x46, 0x00, 0x00, 0x02, 0x2e]))
-    macs = [m1, m2, m3, m4]
-    macs.sort()
+    macs = sorted([m1, m2, m3, m4])
     self.assertEquals([m3, m2, m1, m4], macs)
 
 if __name__ == '__main__':

--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -23,6 +23,7 @@ import array
 import logging
 import socket
 import struct
+from functools import total_ordering
 from ola.rpc.StreamRpcChannel import StreamRpcChannel
 from ola.rpc.SimpleRpcController import SimpleRpcController
 from ola import Ola_pb2
@@ -41,7 +42,7 @@ class Error(Exception):
 class OLADNotRunningException(Error):
   """Thrown if we try to connect and olad isn't running."""
 
-
+@total_ordering
 class Plugin(object):
   """Represents a plugin.
 
@@ -73,9 +74,6 @@ class Plugin(object):
   def enabled(self):
     return self._enabled
 
-  def __cmp__(self, other):
-    return cmp(self._id, other._id)
-
   def __repr__(self):
     s = 'Plugin(id={id}, name="{name}", active={active}, enabled={enabled})'
     return s.format(id=self.id,
@@ -83,12 +81,19 @@ class Plugin(object):
                     active=self.active,
                     enabled=self.enabled)
 
+  def __lt__(self, other):
+      return self._id < other._id
+
+  def __eq__(self, other):
+      return self._id == other._id
+
 
 # Populate the Plugin class attributes from the protobuf
 for value in Ola_pb2._PLUGINIDS.values:
   setattr(Plugin, value.name, value.number)
 
 
+@total_ordering
 class Device(object):
   """Represents a device.
 
@@ -133,8 +138,11 @@ class Device(object):
   def output_ports(self):
     return self._output_ports
 
-  def __cmp__(self, other):
-    return cmp(self._alias, other._alias)
+  def __lt__(self, other):
+      return self._alias < other._alias
+
+  def __eq__(self, other):
+      return self._alias == other._alias
 
   def __repr__(self):
     s = 'Device(id="{id}", alias={alias}, name="{name}", ' \
@@ -147,6 +155,7 @@ class Device(object):
                     nr_outputs=len(self.output_ports))
 
 
+@total_ordering
 class Port(object):
   """Represents a port.
 
@@ -184,9 +193,6 @@ class Port(object):
   def supports_rdm(self):
     return self._supports_rdm
 
-  def __cmp__(self, other):
-    return cmp(self._id, other._id)
-
   def __repr__(self):
     s = 'Port(id={id}, universe={universe}, active={active}, ' \
         'description="{desc}", supports_rdm={supports_rdm})'
@@ -196,7 +202,14 @@ class Port(object):
                     desc=self.description,
                     supports_rdm=self.supports_rdm)
 
+  def __lt__(self, other):
+      return self._id < other._id
 
+  def __eq__(self, other):
+      return self._id == other._id
+
+
+@total_ordering
 class Universe(object):
   """Represents a universe.
 
@@ -226,8 +239,11 @@ class Universe(object):
   def merge_mode(self):
     return self._merge_mode
 
-  def __cmp__(self, other):
-    return cmp(self._id, other._id)
+  def __lt__(self, other):
+      return self._id < other._id
+
+  def __eq__(self, other):
+      return self._id == other._id
 
   def __repr__(self):
     merge_mode = 'LTP' if self.merge_mode == Universe.LTP else 'HTP'
@@ -270,6 +286,7 @@ class RequestStatus(object):
     return self._message
 
 
+@total_ordering
 class RDMNack(object):
   NACK_SYMBOLS_TO_VALUES = {
     'NR_UNKNOWN_PID': (0, 'Unknown PID'),
@@ -305,8 +322,11 @@ class RDMNack(object):
     return s.format(value=self.value,
                     desc=self.description)
 
-  def __cmp__(self, other):
-    return cmp(self.value, other.value)
+  def __lt__(self, other):
+      return self.value < other.value
+
+  def __eq__(self, other):
+      return self.value == other.value
 
   @classmethod
   def LookupCode(cls, code):

--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -23,7 +23,6 @@ import array
 import logging
 import socket
 import struct
-from functools import total_ordering
 from ola.rpc.StreamRpcChannel import StreamRpcChannel
 from ola.rpc.SimpleRpcController import SimpleRpcController
 from ola import Ola_pb2
@@ -42,7 +41,7 @@ class Error(Exception):
 class OLADNotRunningException(Error):
   """Thrown if we try to connect and olad isn't running."""
 
-@total_ordering
+
 class Plugin(object):
   """Represents a plugin.
 
@@ -82,10 +81,24 @@ class Plugin(object):
                     enabled=self.enabled)
 
   def __lt__(self, other):
-      return self._id < other._id
+    return self.id < other.id
 
   def __eq__(self, other):
-      return self._id == other._id
+    return self.id == other.id
+
+  # These 4 could be replaced by functools.total_ordering when support
+  # for 2.6 is dropped.
+  def __le__(self, other):
+    return self.id <= other.id
+
+  def __gt__(self, other):
+    return self.id > other.id
+
+  def __ge__(self, other):
+    return self.id >= other.id
+
+  def __ne__(self, other):
+    return self.id != other.id
 
 
 # Populate the Plugin class attributes from the protobuf
@@ -93,7 +106,6 @@ for value in Ola_pb2._PLUGINIDS.values:
   setattr(Plugin, value.name, value.number)
 
 
-@total_ordering
 class Device(object):
   """Represents a device.
 
@@ -138,12 +150,6 @@ class Device(object):
   def output_ports(self):
     return self._output_ports
 
-  def __lt__(self, other):
-      return self._alias < other._alias
-
-  def __eq__(self, other):
-      return self._alias == other._alias
-
   def __repr__(self):
     s = 'Device(id="{id}", alias={alias}, name="{name}", ' \
         'plugin_id={plugin_id}, {nr_inputs} inputs, {nr_outputs} outputs)'
@@ -154,8 +160,27 @@ class Device(object):
                     nr_inputs=len(self.input_ports),
                     nr_outputs=len(self.output_ports))
 
+  def __lt__(self, other):
+    return self.alias < other.alias
 
-@total_ordering
+  def __eq__(self, other):
+    return self.alias == other.alias
+
+  # These 3 could be replaced by functools.total_ordering when support
+  # for 2.6 is dropped.
+  def __le__(self, other):
+    return self.alias <= other.alias
+
+  def __gt__(self, other):
+    return self.alias > other.alias
+
+  def __ge__(self, other):
+    return self.alias >= other.alias
+
+  def __ne__(self, other):
+    return self.alias != other.alias
+
+
 class Port(object):
   """Represents a port.
 
@@ -203,13 +228,26 @@ class Port(object):
                     supports_rdm=self.supports_rdm)
 
   def __lt__(self, other):
-      return self._id < other._id
+    return self.id < other.id
 
   def __eq__(self, other):
-      return self._id == other._id
+    return self.id == other.id
+
+  # These 4 could be replaced by functools.total_ordering when support
+  # for 2.6 is dropped.
+  def __le__(self, other):
+    return self.id <= other.id
+
+  def __gt__(self, other):
+    return self.id > other.id
+
+  def __ge__(self, other):
+    return self.id >= other.id
+
+  def __ne__(self, other):
+    return self.id != other.id
 
 
-@total_ordering
 class Universe(object):
   """Represents a universe.
 
@@ -239,18 +277,32 @@ class Universe(object):
   def merge_mode(self):
     return self._merge_mode
 
-  def __lt__(self, other):
-      return self._id < other._id
-
-  def __eq__(self, other):
-      return self._id == other._id
-
   def __repr__(self):
     merge_mode = 'LTP' if self.merge_mode == Universe.LTP else 'HTP'
     s = 'Universe(id={id}, name="{name}", merge_mode={merge_mode})'
     return s.format(id=self.id,
                     name=self.name,
                     merge_mode=merge_mode)
+
+  def __lt__(self, other):
+    return self.id < other.id
+
+  def __eq__(self, other):
+    return self.id == other.id
+
+  # These 4 could be replaced by functools.total_ordering when support
+  # for 2.6 is dropped.
+  def __le__(self, other):
+    return self.id <= other.id
+
+  def __gt__(self, other):
+    return self.id > other.id
+
+  def __ge__(self, other):
+    return self.id >= other.id
+
+  def __ne__(self, other):
+    return self.id != other.id
 
 
 class RequestStatus(object):
@@ -286,7 +338,6 @@ class RequestStatus(object):
     return self._message
 
 
-@total_ordering
 class RDMNack(object):
   NACK_SYMBOLS_TO_VALUES = {
     'NR_UNKNOWN_PID': (0, 'Unknown PID'),
@@ -323,10 +374,24 @@ class RDMNack(object):
                     desc=self.description)
 
   def __lt__(self, other):
-      return self.value < other.value
+    return self.value < other.value
 
   def __eq__(self, other):
-      return self.value == other.value
+    return self.value == other.value
+
+  # These 4 could be replaced by functools.total_ordering when support
+  # for 2.6 is dropped.
+  def __le__(self, other):
+    return self.value <= other.value
+
+  def __gt__(self, other):
+    return self.value > other.value
+
+  def __ge__(self, other):
+    return self.value >= other.value
+
+  def __ne__(self, other):
+    return self.value != other.value
 
   @classmethod
   def LookupCode(cls, code):

--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -316,7 +316,7 @@ class RDMNack(object):
     return obj
 
 
-for symbol, (value, description) in RDMNack.NACK_SYMBOLS_TO_VALUES.iteritems():
+for symbol, (value, description) in RDMNack.NACK_SYMBOLS_TO_VALUES.items():
   nack = RDMNack(value, description)
   setattr(RDMNack, symbol, nack)
   RDMNack._CODE_TO_OBJECT[value] = nack

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -247,7 +247,7 @@ class FixedSizeAtom(Atom):
     format_string = self._FormatString()
     try:
       data = struct.pack(format_string, args[0])
-    except struct.error, e:
+    except struct.error as e:
       raise ArgsValidationError("Can't pack data: %s" % e)
     return data, 1
 
@@ -398,7 +398,7 @@ class IntAtom(FixedSizeAtom):
     if self._multiplier >= 0:
       try:
         new_value = int(value)
-      except ValueError, e:
+      except ValueError as e:
         raise ArgsValidationError(e)
 
       multiplier = 10 ** self._multiplier
@@ -411,7 +411,7 @@ class IntAtom(FixedSizeAtom):
     else:
       try:
         new_value = float(value)
-      except ValueError, e:
+      except ValueError as e:
         raise ArgsValidationError(e)
 
       scaled_value = new_value * 10 ** abs(self._multiplier)
@@ -469,7 +469,7 @@ class IPV4(IntAtom):
   def Unpack(self, data):
     try:
       return socket.inet_ntoa(data)
-    except socket.error, e:
+    except socket.error as e:
       raise ArgsValidationError("Can't unpack data: %s" % e)
 
   def Pack(self, args):
@@ -477,7 +477,7 @@ class IPV4(IntAtom):
     #inet_aton, we may want to restrict that in future
     try:
       value = struct.unpack("!I", socket.inet_aton(args[0]))
-    except socket.error, e:
+    except socket.error as e:
       raise ArgsValidationError("Can't pack data: %s" % e)
     return super(IntAtom, self).Pack(value)
 
@@ -519,7 +519,7 @@ class MACAtom(FixedSizeAtom):
                          mac.mac_address[3],
                          mac.mac_address[4],
                          mac.mac_address[5])
-    except struct.error, e:
+    except struct.error as e:
       raise ArgsValidationError("Can't pack data: %s" % e)
     return data, 1
 
@@ -550,7 +550,7 @@ class UIDAtom(FixedSizeAtom):
     format_string = self._FormatString()
     try:
       data = struct.pack(format_string, uid.manufacturer_id, uid.device_id)
-    except struct.error, e:
+    except struct.error as e:
       raise ArgsValidationError("Can't pack data: %s" % e)
     return data, 1
 
@@ -593,7 +593,7 @@ class String(Atom):
 
     try:
       data = struct.unpack('%ds' % arg_size, arg)
-    except struct.error, e:
+    except struct.error as e:
       raise ArgsValidationError("Can't pack data: %s" % e)
     return data[0], 1
 
@@ -609,7 +609,7 @@ class String(Atom):
 
     try:
       value = struct.unpack('%ds' % data_size, data)
-    except struct.error, e:
+    except struct.error as e:
       raise UnpackException(e)
 
     return value[0].rstrip('\x00')
@@ -935,7 +935,7 @@ class PidStore(object):
 
     try:
       text_format.Merge('\n'.join(lines), self._pid_store)
-    except text_format.ParseError, e:
+    except text_format.ParseError as e:
       raise InvalidPidFormat(str(e))
 
     for pid_pb in self._pid_store.pid:
@@ -1074,7 +1074,7 @@ class PidStore(object):
 
       try:
         group = self._FrameFormatToGroup(getattr(pid_pb, field_name))
-      except PidStructureException, e:
+      except PidStructureException as e:
         raise PidStructureException(
             "The structure for the %s in %s isn't valid: %s" %
             (field_name, pid_pb.name, e))

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -18,6 +18,8 @@
 
 """The PID Store."""
 
+from __future__ import print_function
+
 __author__ = 'nomis52@gmail.com (Simon Newton)'
 
 import binascii
@@ -868,8 +870,7 @@ class Group(Atom):
 def RootDeviceValidator(args):
   """Ensure the sub device is the root device."""
   if args.get('sub_device') != ROOT_DEVICE:
-    print >> sys.stderr, (
-        "Can't send GET %s to non root sub devices" % args['pid'].name)
+    print("Can't send GET %s to non root sub devices" % args['pid'].name, file=sys.stderr)
     return False
   return True
 
@@ -879,8 +880,7 @@ def SubDeviceValidator(args):
   sub_device = args.get('sub_device')
   if (sub_device is None or
       (sub_device > MAX_VALID_SUB_DEVICE and sub_device != ALL_SUB_DEVICES)):
-    print >> sys.stderr, (
-        "%s isn't a valid sub device" % sub_device)
+    print("%s isn't a valid sub device" % sub_device, file=sys.stderr)
     return False
   return True
 
@@ -889,8 +889,7 @@ def NonBroadcastSubDeviceValidator(args):
   """Ensure the sub device is in the range 0 - 512."""
   sub_device = args.get('sub_device')
   if (sub_device is None or sub_device > MAX_VALID_SUB_DEVICE):
-    print >> sys.stderr, (
-        "Sub device %s needs to be between 0 and 512" % sub_device)
+    print("Sub device %s needs to be between 0 and 512" % sub_device, file=sys.stderr)
     return False
   return True
 
@@ -900,8 +899,7 @@ def SpecificSubDeviceValidator(args):
   sub_device = args.get('sub_device')
   if (sub_device is None or sub_device == ROOT_DEVICE or
       sub_device > MAX_VALID_SUB_DEVICE):
-    print >> sys.stderr, (
-        "Sub device %s needs to be between 1 and 512" % sub_device)
+    print("Sub device %s needs to be between 1 and 512" % sub_device, file=sys.stderr)
     return False
   return True
 

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -377,7 +377,7 @@ class IntAtom(FixedSizeAtom):
     return self._AccountForMultiplierPack(value)
 
   def _GetAllowedRanges(self):
-    values = self._labels.keys()
+    values = list(self._labels.keys())
 
     for range in self._ranges:
       if range.min == range.max:
@@ -997,7 +997,7 @@ class PidStore(object):
     Returns:
       A list of Pid objects.
     """
-    return self._pids.values()
+    return list(self._pids.values())
 
   def ManufacturerPids(self, esta_id):
     """Return a list of all Manufacturer PIDs for a given esta_id.
@@ -1008,7 +1008,7 @@ class PidStore(object):
     Returns:
       A list of Pid objects.
     """
-    return self._manufacturer_pids.get(esta_id, {}).values()
+    return list(self._manufacturer_pids.get(esta_id, {}).values())
 
   def GetPid(self, pid_value, esta_id=None):
     """Look up a PIDs by the 2-byte PID value.

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -122,8 +122,8 @@ class Pid(object):
     return self._requests.get(command_class)
 
   def GetRequestField(self, command_class, field_name):
-    fields = filter(lambda field: field.name == field_name,
-                    self.GetRequest(command_class).GetAtoms())
+    fields = self.GetRequest(command_class).GetAtoms()
+    fields = [f for f in fields if f.name == field_name]
     return fields[0] if fields else None
 
   def ResponseSupported(self, command_class):
@@ -134,8 +134,8 @@ class Pid(object):
     return self._responses.get(command_class)
 
   def GetResponseField(self, command_class, field_name):
-    fields = filter(lambda field: field.name == field_name,
-                    self.GetResponse(command_class).GetAtoms())
+    fields = self.GetResponse(command_class).GetAtoms()
+    fields = [f for f in fields if f.name == field_name]
     return fields[0] if fields else None
 
   def ValidateAddressing(self, args, command_class):

--- a/python/ola/RDMAPI.py
+++ b/python/ola/RDMAPI.py
@@ -239,7 +239,7 @@ class RDMAPI(object):
       if pid_descriptor:
         try:
           obj = pid_descriptor.Unpack(response.data, request_type)
-        except PidStore.UnpackException, e:
+        except PidStore.UnpackException as e:
           obj = None
           unpack_exception = e
       else:

--- a/python/ola/RDMAPI.py
+++ b/python/ola/RDMAPI.py
@@ -17,6 +17,8 @@
 
 """The Python RDM API."""
 
+from __future__ import print_function
+
 __author__ = 'nomis52@gmail.com (Simon Newton)'
 
 import sys
@@ -96,7 +98,7 @@ class RDMAPI(object):
       True if sent ok, False otherwise.
     """
     if self._strict_checks and uid.IsBroadcast():
-      print >> sys.stderr, "Can't send GET to broadcast address %s" % uid
+      print("Can't send GET to broadcast address %s" % uid, file=sys.stderr)
       return False
 
     return self._SendRequest(universe, uid, sub_device, pid, callback, args,
@@ -117,7 +119,7 @@ class RDMAPI(object):
       True if sent ok, False otherwise.
     """
     if self._strict_checks and uid.IsBroadcast():
-      print >> sys.stderr, "Can't send GET to broadcast address %s" % uid
+      print("Can't send GET to broadcast address %s" % uid, file=sys.stderr)
       return False
 
     return self._SendRawRequest(universe, uid, sub_device, pid, callback, data,
@@ -176,7 +178,7 @@ class RDMAPI(object):
     """
     data = pid.Pack(args, request_type)
     if data is None:
-      print >> sys.stderr, 'Could not pack data'
+      print('Could not pack data', file=sys.stderr)
       return False
 
     return self._SendRawRequest(universe, uid, sub_device, pid, callback, data,

--- a/python/ola/RDMConstants.py
+++ b/python/ola/RDMConstants.py
@@ -30,7 +30,7 @@ RDM_MANUFACTURER_SD_MAX = 0xFFDF
 
 def _ReverseDict(input):
   output = {}
-  for key, value in input.iteritems():
+  for key, value in input.items():
     output[value] = key
   return output
 

--- a/python/ola/UIDTest.py
+++ b/python/ola/UIDTest.py
@@ -62,8 +62,7 @@ class UIDTest(unittest.TestCase):
     u2 = UID(0x4845, 0x0000022e)
     u3 = UID(0x4844, 0x0000022e)
     u4 = UID(0x4846, 0x0000022e)
-    uids = [u1, u2, u3, u4]
-    uids.sort()
+    uids = sorted([u1, u2, u3, u4])
     self.assertEquals([u3, u2, u1, u4], uids)
 
   def testNextAndPrevious(self):

--- a/python/ola/UIDTest.py
+++ b/python/ola/UIDTest.py
@@ -27,9 +27,9 @@ class UIDTest(unittest.TestCase):
 
   def testBasic(self):
     uid = UID(0x707a, 0x12345678)
-    self.assertEquals(0x707a, uid.manufacturer_id)
-    self.assertEquals(0x12345678, uid.device_id)
-    self.assertEquals('707a:12345678', str(uid))
+    self.assertEqual(0x707a, uid.manufacturer_id)
+    self.assertEqual(0x12345678, uid.device_id)
+    self.assertEqual('707a:12345678', str(uid))
 
     self.assertTrue(uid > None)
     uid2 = UID(0x707a, 0x12345679)
@@ -37,7 +37,7 @@ class UIDTest(unittest.TestCase):
     uid3 = UID(0x7079, 0x12345678)
     self.assertTrue(uid > uid3)
     uids = [uid, uid2, uid3]
-    self.assertEquals([uid3, uid, uid2], sorted(uids))
+    self.assertEqual([uid3, uid, uid2], sorted(uids))
 
     vendorcast_uid = UID.VendorcastAddress(0x707a)
     self.assertTrue(vendorcast_uid.IsBroadcast())
@@ -45,17 +45,17 @@ class UIDTest(unittest.TestCase):
     self.assertTrue(broadcast_uid.IsBroadcast())
 
   def testFromString(self):
-    self.assertEquals(None, UID.FromString(''))
-    self.assertEquals(None, UID.FromString('abc'))
-    self.assertEquals(None, UID.FromString(':'))
-    self.assertEquals(None, UID.FromString('0:1:2'))
-    self.assertEquals(None, UID.FromString('12345:1234'))
+    self.assertEqual(None, UID.FromString(''))
+    self.assertEqual(None, UID.FromString('abc'))
+    self.assertEqual(None, UID.FromString(':'))
+    self.assertEqual(None, UID.FromString('0:1:2'))
+    self.assertEqual(None, UID.FromString('12345:1234'))
 
     uid = UID.FromString('00a0:12345678')
     self.assertTrue(uid)
-    self.assertEquals(0x00a0, uid.manufacturer_id)
-    self.assertEquals(0x12345678, uid.device_id)
-    self.assertEquals('00a0:12345678', str(uid))
+    self.assertEqual(0x00a0, uid.manufacturer_id)
+    self.assertEqual(0x12345678, uid.device_id)
+    self.assertEqual('00a0:12345678', str(uid))
 
   def testSorting(self):
     u1 = UID(0x4845, 0xfffffffe)
@@ -63,19 +63,19 @@ class UIDTest(unittest.TestCase):
     u3 = UID(0x4844, 0x0000022e)
     u4 = UID(0x4846, 0x0000022e)
     uids = sorted([u1, u2, u3, u4])
-    self.assertEquals([u3, u2, u1, u4], uids)
+    self.assertEqual([u3, u2, u1, u4], uids)
 
   def testNextAndPrevious(self):
     u1 = UID(0x4845, 0xfffffffe)
     u2 = UID.NextUID(u1)
-    self.assertEquals('4845:ffffffff', str(u2))
+    self.assertEqual('4845:ffffffff', str(u2))
     u3 = UID.NextUID(u2)
-    self.assertEquals('4846:00000000', str(u3))
+    self.assertEqual('4846:00000000', str(u3))
 
     u4 = UID.PreviousUID(u3)
-    self.assertEquals(u2, u4)
+    self.assertEqual(u2, u4)
     u5 = UID.PreviousUID(u4)
-    self.assertEquals(u1, u5)
+    self.assertEqual(u1, u5)
 
     first_uid = UID(0, 0)
     self.assertRaises(UIDOutOfRangeException, UID.PreviousUID, first_uid)

--- a/python/ola/rpc/SimpleRpcControllerTest.py
+++ b/python/ola/rpc/SimpleRpcControllerTest.py
@@ -35,7 +35,7 @@ class SimpleRpcControllerTest(unittest.TestCase):
     controller = SimpleRpcController()
     self.assertFalse(controller.Failed())
     self.assertFalse(controller.IsCanceled())
-    self.assertEquals(None, controller.ErrorText())
+    self.assertEqual(None, controller.ErrorText())
     self.assertFalse(self.callback_run)
 
     # cancel
@@ -43,26 +43,26 @@ class SimpleRpcControllerTest(unittest.TestCase):
     controller.StartCancel()
     self.assertFalse(controller.Failed())
     self.assertFalse(not controller.IsCanceled())
-    self.assertEquals(None, controller.ErrorText())
+    self.assertEqual(None, controller.ErrorText())
     self.assertFalse(not self.callback_run)
 
     self.callback_run = False
     controller.Reset()
     self.assertFalse(controller.Failed())
     self.assertFalse(controller.IsCanceled())
-    self.assertEquals(None, controller.ErrorText())
+    self.assertEqual(None, controller.ErrorText())
 
     # fail
     failure_string = 'foo'
     controller.SetFailed(failure_string)
     self.assertFalse(not controller.Failed())
     self.assertFalse(controller.IsCanceled())
-    self.assertEquals(failure_string, controller.ErrorText())
+    self.assertEqual(failure_string, controller.ErrorText())
 
     controller.Reset()
     self.assertFalse(controller.Failed())
     self.assertFalse(controller.IsCanceled())
-    self.assertEquals(None, controller.ErrorText())
+    self.assertEqual(None, controller.ErrorText())
     self.assertFalse(self.callback_run)
 
 if __name__ == '__main__':

--- a/python/ola/rpc/StreamRpcChannel.py
+++ b/python/ola/rpc/StreamRpcChannel.py
@@ -22,8 +22,8 @@ __author__ = 'nomis52@gmail.com (Simon Newton)'
 import logging
 import struct
 from google.protobuf import service
-import Rpc_pb2
-from SimpleRpcController import SimpleRpcController
+from ola.rpc import Rpc_pb2
+from ola.rpc.SimpleRpcController import SimpleRpcController
 
 
 class OutstandingRequest(object):

--- a/python/ola/rpc/StreamRpcChannel.py
+++ b/python/ola/rpc/StreamRpcChannel.py
@@ -228,7 +228,7 @@ class StreamRpcChannel(service.RpcChannel):
         data.append(chunk)
         size_left -= len(chunk)
 
-    return ''.join(data)
+    return b''.join(data)
 
   def _ProcessIncomingData(self):
     """Process the received data."""


### PR DESCRIPTION
Here are a few patches improving the compatibility with Python 3.

The sad thing is that protobuf does not support Python 3 yet. Hopefully it will come soon. We can at least make OLA ready for when that happens. In the mean time, I am testing/using protobuf from this PR:
https://github.com/google/protobuf/pull/166

One of the patches (Python client: Replace __cmp__ with __lt__/__eq__) requires Python 2.7, but if we want to support 2.6 it would be possible to do things differently (but not as nicely).

I couldn't test everything. Hopefully the testsuite will validate a bit that I did not break Python 2, although there doesn't seem to be much testing of the Python OlaClient.