### PR TITLE
Python client: check if universe field is present when deserializing a Port

### DIFF
--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -1038,15 +1038,19 @@ class OlaClient(Ola_pb2.OlaClientService):
       input_ports = []
       output_ports = []
       for port in device.input_port:
+        universe = port.universe if port.HasField('universe') else None
+
         input_ports.append(Port(port.port_id,
-                                port.universe,
+                                universe,
                                 port.active,
                                 port.description,
                                 port.supports_rdm))
 
       for port in device.output_port:
+        universe = port.universe if port.HasField('universe') else None
+
         output_ports.append(Port(port.port_id,
-                                 port.universe,
+                                 universe,
                                  port.active,
                                  port.description,
                                 port.supports_rdm))


### PR DESCRIPTION
Right now, there is no way to distinguish a Port bound to universe 0
from a Port not bound to any unverse (its universe field will also be
0). This is because protobuf returns 0 by default if you ask for an
optional field that happens not to be present.

With this patch, an unbound Port will have universe=None.