### PR TITLE
Add GetCandidatePorts to Python client

### DIFF
--- a/python/examples/Makefile.mk
+++ b/python/examples/Makefile.mk
@@ -1,6 +1,7 @@
 # example python scripts
 dist_noinst_SCRIPTS += \
     python/examples/ola_artnet_params.py \
+    python/examples/ola_candidate_ports.py \
     python/examples/ola_devices.py \
     python/examples/ola_plugin_info.py \
     python/examples/ola_rdm_discover.py \

--- a/python/examples/ola_candidate_ports.py
+++ b/python/examples/ola_candidate_ports.py
@@ -27,31 +27,31 @@ __author__ = 'simon.marchi@polymtl.ca (Simon Marchi)'
 
 
 def ParseArgs():
-    desc = 'Show the candidate ports to patch to a universe.'
-    argparser = argparse.ArgumentParser(description=desc)
-    argparser.add_argument('--universe', '-u',
-                           type=int,
-                           help='Universe for which to get the candidates.')
-    return argparser.parse_args()
+  desc = 'Show the candidate ports to patch to a universe.'
+  argparser = argparse.ArgumentParser(description=desc)
+  argparser.add_argument('--universe', '-u',
+                         type=int,
+                         help='Universe for which to get the candidates.')
+  return argparser.parse_args()
 
 
 def GetCandidatePortsCallback(status, devices):
-    if status.Succeeded():
-        for device in devices:
-            print('Device {d.alias}: {d.name}'.format(d=device))
-            print('Candidate input ports:')
-            for port in device.input_ports:
-                s = '  port {p.id}, {p.description}, supports RDM: ' \
-                    '{p.supports_rdm}'
-                print(s.format(p=port))
-            print('Candidate output ports:')
-            for port in device.output_ports:
-                s = '  port {p.id}, {p.description}, supports RDM: ' \
-                    '{p.supports_rdm}'
-                print(s.format(p=port))
-    else:
-        print('Error: {}'.format(status.message), file=sys.stderr)
-    wrapper.Stop()
+  if status.Succeeded():
+    for device in devices:
+      print('Device {d.alias}: {d.name}'.format(d=device))
+      print('Candidate input ports:')
+      for port in device.input_ports:
+        s = '  port {p.id}, {p.description}, supports RDM: ' \
+            '{p.supports_rdm}'
+        print(s.format(p=port))
+      print('Candidate output ports:')
+      for port in device.output_ports:
+        s = '  port {p.id}, {p.description}, supports RDM: ' \
+            '{p.supports_rdm}'
+        print(s.format(p=port))
+  else:
+    print('Error: {}'.format(status.message), file=sys.stderr)
+  wrapper.Stop()
 
 
 args = ParseArgs()

--- a/python/examples/ola_candidate_ports.py
+++ b/python/examples/ola_candidate_ports.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# ola_candidate_ports.py
+# Copyright (C) 2015 Simon Marchi
+
+"""List candidate ports for patching."""
+
+from __future__ import print_function
+from ola.ClientWrapper import ClientWrapper
+import argparse
+import sys
+
+__author__ = 'simon.marchi@polymtl.ca (Simon Marchi)'
+
+
+def ParseArgs():
+    desc = 'Show the candidate ports to patch to a universe.'
+    argparser = argparse.ArgumentParser(description=desc)
+    argparser.add_argument('--universe', '-u',
+                           type=int,
+                           help='Universe for which to get the candidates.')
+    return argparser.parse_args()
+
+
+def GetCandidatePortsCallback(status, devices):
+    if status.Succeeded():
+        for device in devices:
+            print('Device {d.alias}: {d.name}'.format(d=device))
+            print('Candidate input ports:')
+            for port in device.input_ports:
+                s = '  port {p.id}, {p.description}, supports RDM: ' \
+                    '{p.supports_rdm}'
+                print(s.format(p=port))
+            print('Candidate output ports:')
+            for port in device.output_ports:
+                s = '  port {p.id}, {p.description}, supports RDM: ' \
+                    '{p.supports_rdm}'
+                print(s.format(p=port))
+    else:
+        print('Error: {}'.format(status.message), file=sys.stderr)
+    wrapper.Stop()
+
+
+args = ParseArgs()
+universe = args.universe
+
+wrapper = ClientWrapper()
+client = wrapper.Client()
+client.GetCandidatePorts(GetCandidatePortsCallback, universe)
+wrapper.Run()

--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -968,6 +968,41 @@ class OlaClient(Ola_pb2.OlaClientService):
       raise OLADNotRunningException()
     return True
 
+  def GetCandidatePorts(self, callback, universe=None):
+    """Send a GetCandidatePorts request. The result is similar to FetchDevices
+    (GetDeviceInfo), except that returned devices will only contain ports
+    available for patching to the given universe. If universe is None, then the
+    devices will list their ports available for patching to a potential new
+    universe.
+
+    Args:
+      callback: The function to call once complete, takes a RequestStatus
+        object and a list of Device objects.
+      universe: The universe to get the candidate ports for. If unspecified,
+        return the candidate ports for a new universe.
+
+    Returns:
+      True if the request was sent, False otherwise.
+    """
+    if self._socket is None:
+      return False
+
+    controller = SimpleRpcController()
+    request = Ola_pb2.OptionalUniverseRequest()
+
+    if universe is not None:
+      request.universe = universe
+
+    # GetCandidatePorts works very much like GetDeviceInfo, so we can re-use
+    # its complete method.
+    done = lambda x, y: self._DeviceInfoComplete(callback, x, y)
+    try:
+      self._stub.GetCandidatePorts(controller, request, done)
+    except socket.error:
+      raise OLADNotRunningException()
+
+    return True
+
   def _RDMMessage(self, universe, uid, sub_device, param_id, callback, data,
                   set = False):
     controller = SimpleRpcController()


### PR DESCRIPTION
This patch adds the ability to call the GetCandidatePorts remote
procedure from the Python RPC client.

It also adds a corresponding example.