### PR TITLE
Use std::string::c_str instead of ::data where appropriate

### DIFF
--- a/common/http/HTTPServer.cpp
+++ b/common/http/HTTPServer.cpp
@@ -297,7 +297,7 @@ const string HTTPRequest::GetHeader(const string &key) const {
 const string HTTPRequest::GetParameter(const string &key) const {
   const char *value = MHD_lookup_connection_value(m_connection,
                                                   MHD_GET_ARGUMENT_KIND,
-                                                  key.data());
+                                                  key.c_str());
   if (value)
     return string(value);
   else
@@ -312,7 +312,7 @@ const string HTTPRequest::GetParameter(const string &key) const {
 bool HTTPRequest::CheckParameterExists(const string &key) const {
   const char *value = MHD_lookup_connection_value(m_connection,
                                                   MHD_GET_ARGUMENT_KIND,
-                                                  key.data());
+                                                  key.c_str());
   if (value != NULL) {
     return true;
   } else {
@@ -781,7 +781,7 @@ int HTTPServer::ServeStaticContent(static_file_info *file_info,
   string file_path = m_data_dir;
   file_path.push_back(ola::file::PATH_SEPARATOR);
   file_path.append(file_info->file_path);
-  ifstream i_stream(file_path.data(), ifstream::binary);
+  ifstream i_stream(file_path.c_str(), ifstream::binary);
 
   if (!i_stream.is_open()) {
     OLA_WARN << "Missing file: " << file_path;
@@ -806,7 +806,7 @@ int HTTPServer::ServeStaticContent(static_file_info *file_info,
   if (!file_info->content_type.empty())
     MHD_add_response_header(mhd_response,
                             MHD_HTTP_HEADER_CONTENT_TYPE,
-                            file_info->content_type.data());
+                            file_info->content_type.c_str());
 
   int ret = MHD_queue_response(response->Connection(),
                                MHD_HTTP_OK,

--- a/olad/DeviceManager.cpp
+++ b/olad/DeviceManager.cpp
@@ -334,7 +334,7 @@ void DeviceManager::RestorePortSettings(const vector<PortClass*> &ports) const {
       continue;
 
     errno = 0;
-    int id = static_cast<int>(strtol(uni_id.data(), NULL, 10));
+    int id = static_cast<int>(strtol(uni_id.c_str(), NULL, 10));
     if ((id == 0 && errno) || id < 0)
       continue;
 


### PR DESCRIPTION
I was looking for something else and this caught my attention.

std::string::data does not guarantee to return a null-terminated
string. That's what std::string::c_str does. Even though they will
likely always return the same thing, it would be safer to use the right
one.