### PR TITLE
Clean up the RDM Discovery Agent.

### DIFF
--- a/common/rdm/DiscoveryAgent.cpp
+++ b/common/rdm/DiscoveryAgent.cpp
@@ -16,22 +16,6 @@
  * DiscoveryAgent.cpp
  * Implements the RDM Discovery algorithm.
  * Copyright (C) 2011 Simon Newton
- *
- * The discovery process goes something like this:
- *   - if incremental, copy all previously discovered UIDs to the mute list
- *   - push (0, 0xffffffffffff) onto the resolution stack
- *   - unmute all
- *   - mute all previously discovered UIDs, for any that fail to mute remove
- *     them from the UIDSet.
- *   - Send a discovery unique branch message
- *     - If we get a valid response, mute, and send the same branch again
- *     - If we get a collision, split the UID range, and try each branch
- *       separately.
- *
- * We also track responders that fail to ack a mute request (we attempt to mute
- * MAX_MUTE_ATTEMPTS times) and branches that contain responders which continue
- * to responde once muted. The latter causes a branch to be marked as corrupt,
- * which prevents us from looping forver.
  */
 
 #include "ola/Callback.h"
@@ -39,15 +23,11 @@
 #include "ola/rdm/DiscoveryAgent.h"
 #include "ola/rdm/UID.h"
 #include "ola/rdm/UIDSet.h"
+#include "ola/strings/Format.h"
 
 namespace ola {
 namespace rdm {
 
-
-/**
- * Create a new DiscoveryAgent
- * @param target the DiscoveryTargetInterface to use for sending messages.
- */
 DiscoveryAgent::DiscoveryAgent(DiscoveryTargetInterface *target)
     : m_target(target),
       m_on_complete(NULL),
@@ -64,22 +44,10 @@ DiscoveryAgent::DiscoveryAgent(DiscoveryTargetInterface *target)
       m_tree_corrupt(false) {
 }
 
-
-/**
- * Clean up
- */
 DiscoveryAgent::~DiscoveryAgent() {
   Abort();
-  delete m_unmute_callback;
-  delete m_incremental_mute_callback;
-  delete m_branch_mute_callback;
-  delete m_branch_callback;
 }
 
-
-/**
- * Cancel the running discovery
- */
 void DiscoveryAgent::Abort() {
   while (!m_uid_ranges.empty()) {
     UIDRange *range = m_uid_ranges.top();
@@ -95,28 +63,17 @@ void DiscoveryAgent::Abort() {
   }
 }
 
-
-/**
- * Initiate full discovery
- * @param on_complete the callback to run once discovery completes.
- */
 void DiscoveryAgent::StartFullDiscovery(
     DiscoveryCompleteCallback *on_complete) {
   InitDiscovery(on_complete, false);
 }
 
-
-/**
- * Initiate incremental discovery
- * @param on_complete the callback to run once discovery completes.
- */
 void DiscoveryAgent::StartIncrementalDiscovery(
     DiscoveryCompleteCallback *on_complete) {
   InitDiscovery(on_complete, true);
 }
 
-
-/**
+/*
  * Start the discovery process
  * @param on_complete the callback to run when discovery completes
  * @param incremental true if this is incremental, false otherwise
@@ -155,22 +112,27 @@ void DiscoveryAgent::InitDiscovery(
   UID lower(0, 0);
   m_uid_ranges.push(new UIDRange(lower, UID::AllDevices(), NULL));
 
-  m_target->UnMuteAll(m_unmute_callback);
+  m_unmute_count = 0;
+  m_target->UnMuteAll(m_unmute_callback.get());
 }
 
-
-/**
- * Called when the UnMute completes. This starts muting previously known
- * devices, or proceeeds immediately to the DUB stage if there are none.
+/*
+ * Called when the UnMute completes. This resends the Unmute command up to
+ * BROADCAST_UNMUTE_REPEATS times and then starts muting previously known
+ * devices (incremental only).
  */
 void DiscoveryAgent::UnMuteComplete() {
+  m_unmute_count++;
+  if (m_unmute_count < BROADCAST_UNMUTE_REPEATS) {
+    m_target->UnMuteAll(m_unmute_callback.get());
+    return;
+  }
   MaybeMuteNextDevice();
 }
 
-
-/**
- * If any previously discovered devices remain, mute them. Otherwise proceed to
- * the branch phase.
+/*
+ * If we're in incremental mode, mute previously discovered devices. Otherwise
+ * proceed to the branch stage.
  */
 void DiscoveryAgent::MaybeMuteNextDevice() {
   if (m_uids_to_mute.empty()) {
@@ -179,10 +141,9 @@ void DiscoveryAgent::MaybeMuteNextDevice() {
     m_muting_uid = m_uids_to_mute.front();
     m_uids_to_mute.pop();
     OLA_DEBUG << "Muting previously discovered responder: " << m_muting_uid;
-    m_target->MuteDevice(m_muting_uid, m_incremental_mute_callback);
+    m_target->MuteDevice(m_muting_uid, m_incremental_mute_callback.get());
   }
 }
-
 
 /**
  * Called when we mute a device during incremental discovery.
@@ -197,8 +158,7 @@ void DiscoveryAgent::IncrementalMuteComplete(bool status) {
   MaybeMuteNextDevice();
 }
 
-
-/**
+/*
  * Send a Discovery Unique Branch request.
  */
 void DiscoveryAgent::SendDiscovery() {
@@ -232,17 +192,17 @@ void DiscoveryAgent::SendDiscovery() {
       ", attempt " << range->attempt << ", uids found: " <<
       range->uids_discovered << ", failures " << range->failures <<
       ", corrupted " << range->branch_corrupt;
-    m_target->Branch(range->lower, range->upper, m_branch_callback);
+    m_target->Branch(range->lower, range->upper, m_branch_callback.get());
   }
 }
 
-
-/**
- * Called when we get a response (or timeout) to a branch request.
+/*
+ * Handle a DUB response (inc. timeouts).
  * @param data the raw response, excluding the start code
  * @param length the length of the response, 0 if no response was received.
  */
 void DiscoveryAgent::BranchComplete(const uint8_t *data, unsigned int length) {
+  OLA_INFO << "BranchComplete, got " << length;
   if (length == 0) {
     // timeout
     FreeCurrentRange();
@@ -250,25 +210,35 @@ void DiscoveryAgent::BranchComplete(const uint8_t *data, unsigned int length) {
     return;
   }
 
-  if (length < MIN_DUB_RESPONSE_SIZE || length > MAX_DUB_RESPONSE_SIZE) {
+  // Must at least have the separator, the EUID and the checksum
+  if (length < 1 + EUID_SIZE + CHECKSUM_SIZE) {
     HandleCollision();
     return;
   }
 
-  unsigned int preamble_size = length - MIN_DUB_RESPONSE_SIZE;
-  for (unsigned int i = 0; i < preamble_size; i++) {
-    if (data[i] != 0xfe) {
-      OLA_INFO << "preamble " << i << " " << std::hex <<
-        static_cast<int>(data[i]);
+  unsigned int offset = 0;
+  while (data[offset] != 0xaa && offset < PREAMBLE_SIZE - 1) {
+    if (data[offset] != 0xfe) {
+      OLA_INFO << "preamble " << offset << " " << strings::ToHex(data[offset]);
       HandleCollision();
       return;
     }
+    offset++;
   }
 
-  unsigned int offset = preamble_size;
-  if (data[offset++] != 0xaa) {
-    OLA_INFO << "preamble separator is " << std::hex <<
-      static_cast<int>(data[offset]);
+  if (data[offset] != 0xaa) {
+    OLA_INFO << "Preamble separator" << offset << " "
+             << strings::ToHex(data[offset]);
+    HandleCollision();
+    return;
+  }
+
+  offset++;
+  unsigned int remaining = length - offset;
+  OLA_INFO << "length was " << length << ", offset " << offset
+           << ", remaining " << remaining;
+  if (remaining < EUID_SIZE + CHECKSUM_SIZE) {
+    OLA_INFO << "Insufficient data remaining, was " << remaining;
     HandleCollision();
     return;
   }
@@ -296,8 +266,9 @@ void DiscoveryAgent::BranchComplete(const uint8_t *data, unsigned int length) {
       reinterpret_cast<const dub_response_structure*>(data + offset);
 
   uint16_t calculated_checksum = 0;
-  for (unsigned int i = offset; i < offset + 12; i++)
+  for (unsigned int i = offset; i < offset + EUID_SIZE; i++) {
     calculated_checksum += data[i];
+  }
 
   uint16_t recovered_checksum =
     ((response->ecs3 & response->ecs2) << 8) +
@@ -339,13 +310,12 @@ void DiscoveryAgent::BranchComplete(const uint8_t *data, unsigned int length) {
     m_muting_uid = located_uid;
     m_mute_attempts = 0;
     OLA_INFO << "muting " << m_muting_uid;
-    m_target->MuteDevice(m_muting_uid, m_branch_mute_callback);
+    m_target->MuteDevice(m_muting_uid, m_branch_mute_callback.get());
   }
 }
 
-
-/**
- * Called when we successfull mute a device during the branch phase
+/*
+ * Called when we successfull mute a device during the branch stage.
  */
 void DiscoveryAgent::BranchMuteComplete(bool status) {
   m_mute_attempts++;
@@ -356,7 +326,7 @@ void DiscoveryAgent::BranchMuteComplete(bool status) {
     // failed to mute, if we haven't reached the limit try it again
     if (m_mute_attempts < MAX_MUTE_ATTEMPTS) {
       OLA_INFO << "muting " << m_muting_uid;
-      m_target->MuteDevice(m_muting_uid, m_branch_mute_callback);
+      m_target->MuteDevice(m_muting_uid, m_branch_mute_callback.get());
       return;
     } else {
       // this UID is bad, either it was a phantom or it doesn't response to
@@ -368,9 +338,8 @@ void DiscoveryAgent::BranchMuteComplete(bool status) {
   SendDiscovery();
 }
 
-
-/**
- * Handle a collision
+/*
+ * Handle a DUB collision.
  */
 void DiscoveryAgent::HandleCollision() {
   UIDRange *range = m_uid_ranges.top();
@@ -403,8 +372,7 @@ void DiscoveryAgent::HandleCollision() {
   SendDiscovery();
 }
 
-
-/**
+/*
  * Deletes the current range from the stack, and pops it.
  */
 void DiscoveryAgent::FreeCurrentRange() {
@@ -412,7 +380,7 @@ void DiscoveryAgent::FreeCurrentRange() {
   if (m_uid_ranges.size() == 1) {
     // top of stack
     if (range->branch_corrupt) {
-      OLA_INFO << "top of tree is corrupted";
+      OLA_INFO << "Discovery tree is corrupted";
       m_tree_corrupt = true;
     }
   } else {

--- a/common/rdm/DiscoveryAgentTest.cpp
+++ b/common/rdm/DiscoveryAgentTest.cpp
@@ -119,8 +119,9 @@ void DiscoveryAgentTest::PopulateResponderListFromUIDs(
     const UIDSet &uids,
     ResponderList *responders) {
   UIDSet::Iterator iter = uids.Begin();
-  for (; iter != uids.End(); iter++)
+  for (; iter != uids.End(); iter++) {
     responders->push_back(new MockResponder(*iter));
+  }
 }
 
 
@@ -133,21 +134,22 @@ void DiscoveryAgentTest::testNoReponders() {
   PopulateResponderListFromUIDs(uids, &responders);
   MockDiscoveryTarget target(responders);
   DiscoveryAgent agent(&target);
-  OLA_INFO << "starting discovery with no responders";
 
   agent.StartFullDiscovery(
       ola::NewSingleCallback(this,
                              &DiscoveryAgentTest::DiscoverySuccessful,
                              static_cast<const UIDSet*>(&uids)));
   OLA_ASSERT_TRUE(m_callback_run);
+  OLA_ASSERT_EQ(3u, target.UnmuteCallCount());
 
   // now try incremental
-  OLA_INFO << "starting incremental discovery with no responders";
+  target.ResetCounters();
   agent.StartIncrementalDiscovery(
       ola::NewSingleCallback(this,
                              &DiscoveryAgentTest::DiscoverySuccessful,
                              static_cast<const UIDSet*>(&uids)));
   OLA_ASSERT_TRUE(m_callback_run);
+  OLA_ASSERT_EQ(3u, target.UnmuteCallCount());
 }
 
 
@@ -259,20 +261,23 @@ void DiscoveryAgentTest::testObnoxiousResponder() {
  * Test a responder that replies with responses larger than the DUB size
  */
 void DiscoveryAgentTest::testRamblingResponder() {
+  const UID normal_responder_uid(0x7a70, 0x00002002);
+  const UID rambling_responder_uid(0x7a77, 0x0002002);
+
   UIDSet uids;
   ResponderList responders;
-  uids.AddUID(UID(0x7a70, 0x00002002));
+  uids.AddUID(normal_responder_uid);
   PopulateResponderListFromUIDs(uids, &responders);
   // add the RamblingResponder
-  UID rambling_uid = UID(0x7a77, 0x00002002);
-  responders.push_back(new RamblingResponder(rambling_uid));
+  responders.push_back(new RamblingResponder(rambling_responder_uid));
   MockDiscoveryTarget target(responders);
 
   DiscoveryAgent agent(&target);
+  uids.AddUID(rambling_responder_uid);
   OLA_INFO << "starting discovery with rambling responder";
   agent.StartFullDiscovery(
       ola::NewSingleCallback(this,
-                             &DiscoveryAgentTest::DiscoveryFailed,
+                             &DiscoveryAgentTest::DiscoverySuccessful,
                              static_cast<const UIDSet*>(&uids)));
   OLA_ASSERT_TRUE(m_callback_run);
 }

--- a/common/rdm/DiscoveryAgentTestHelper.h
+++ b/common/rdm/DiscoveryAgentTestHelper.h
@@ -339,13 +339,22 @@ class ProxyResponder: public MockResponder {
 class MockDiscoveryTarget: public ola::rdm::DiscoveryTargetInterface {
  public:
     explicit MockDiscoveryTarget(const ResponderList &responders)
-        : m_responders(responders) {
+        : m_responders(responders),
+          m_unmute_calls(0) {
     }
 
     ~MockDiscoveryTarget() {
       ResponderList::const_iterator iter = m_responders.begin();
       for (; iter != m_responders.end(); ++iter)
         delete *iter;
+    }
+
+    void ResetCounters() {
+      m_unmute_calls = 0;
+    }
+
+    unsigned int UnmuteCallCount() const {
+      return m_unmute_calls;
     }
 
     // Mute a device
@@ -365,8 +374,10 @@ class MockDiscoveryTarget: public ola::rdm::DiscoveryTargetInterface {
     // Un Mute all devices
     void UnMuteAll(UnMuteDeviceCallback *unmute_complete) {
       ResponderList::const_iterator iter = m_responders.begin();
-      for (; iter != m_responders.end(); ++iter)
+      for (; iter != m_responders.end(); ++iter) {
         (*iter)->UnMute();
+      }
+      m_unmute_calls++;
       unmute_complete->Run();
     }
 
@@ -414,5 +425,6 @@ class MockDiscoveryTarget: public ola::rdm::DiscoveryTargetInterface {
 
  private:
     ResponderList m_responders;
+    unsigned int m_unmute_calls;
 };
 #endif  // COMMON_RDM_DISCOVERYAGENTTESTHELPER_H_

--- a/include/ola/rdm/DiscoveryAgent.h
+++ b/include/ola/rdm/DiscoveryAgent.h
@@ -32,129 +32,222 @@
 #include <ola/Callback.h>
 #include <ola/rdm/UID.h>
 #include <ola/rdm/UIDSet.h>
+#include <memory>
 #include <queue>
 #include <stack>
 #include <utility>
-
 
 namespace ola {
 namespace rdm {
 
 /**
- * This is the interface for classes which want to act as a discovery
- * controller. Such clases must implement the Mute, UnMute & Discovery Unique
- * Branch (DUB) methods.
+ * @brief The interface used by the DiscoveryTarget to send RDM commands.
+ *
+ * This class abstracts away the method of sending RDM commands from the
+ * discovery algorithm in DiscoveryAgent.
+ *
+ * For each of the MuteDevice, UnMuteAll and Branch methods, the implementation
+ * should send the appropriate RDM command and then run the provided callback
+ * when the command has been sent.
  */
 class DiscoveryTargetInterface {
  public:
-    // Argument is true if the device responded
-    typedef ola::BaseCallback1<void, bool> MuteDeviceCallback;
-    typedef ola::BaseCallback0<void> UnMuteDeviceCallback;
-    // Arguments are a pointer to the data & length of the DUB response,
-    // excluding the RDM start code.
-    typedef ola::BaseCallback2<void, const uint8_t*, unsigned int>
-      BranchCallback;
+  /**
+   * @brief The callback run when a mute command completes.
+   * @tparam ok true if the device muted correctly, false if the device failed
+   *   to ack the mute.
+   */
+  typedef ola::BaseCallback1<void, bool> MuteDeviceCallback;
 
-    virtual ~DiscoveryTargetInterface() {}
+  /**
+   * @brief The callback run when an unmute command completes.
+   */
+  typedef ola::BaseCallback0<void> UnMuteDeviceCallback;
 
-    // Mute a device
-    virtual void MuteDevice(const UID &target,
-                            MuteDeviceCallback *mute_complete) = 0;
-    // Un Mute all devices
-    virtual void UnMuteAll(UnMuteDeviceCallback *unmute_complete) = 0;
+  /**
+   * @brief The callback run when a DUB command completes.
+   * @tparam data The DUB response, if any was received. Otherwise pass NULL.
+   * @tparam length The length of the DUB response.
+   */
+  typedef ola::BaseCallback2<void, const uint8_t*, unsigned int>
+    BranchCallback;
 
-    // Send a branch request
-    virtual void Branch(const UID &lower,
-                        const UID &upper,
-                        BranchCallback *callback) = 0;
+  virtual ~DiscoveryTargetInterface() {}
+
+  /**
+   * @brief Mute a device.
+   * @param target the device to mute
+   * @param mute_complete the callback to run when the mute operations
+   * completes.
+   */
+  virtual void MuteDevice(const UID &target,
+                          MuteDeviceCallback *mute_complete) = 0;
+
+  /**
+   * @brief Unmute all devices.
+   * @param unmute_complete the callback to run when the unmute operation
+   * completes.
+   */
+  virtual void UnMuteAll(UnMuteDeviceCallback *unmute_complete) = 0;
+
+  /**
+   * @brief Send a DUB command
+   * @param lower the lower bound UID.
+   * @param upper the upper bound UID.
+   * @param callback the callback to run when the DUB completes.
+   *
+   * Any data received in response to the DUB command should be passed back
+   * when the callback is run.
+   */
+  virtual void Branch(const UID &lower,
+                      const UID &upper,
+                      BranchCallback *callback) = 0;
 };
 
 
 /**
- * This class controls the discovery algorithm.
+ * @brief An asyncronous RDM Discovery algorithm.
+ *
+ * This implements the binary search algorithm from the E1.20 standard. The
+ * implementation is asyncronous and relies on callbacks to indicate when each
+ * step completes.
+ *
+ * To use the DiscoveryAgent, one should write a class that implements the
+ * DiscoveryTargetInterface interface and then pass a pointer to that object to
+ * the DiscoveryAgent.
+ *
+ * The discovery process goes something like this:
+ *   - if incremental, copy all previously discovered UIDs to the mute list
+ *   - push (0, 0xffffffffffff) onto the resolution stack
+ *   - unmute all
+ *   - mute all previously discovered UIDs, for any that fail to mute remove
+ *     them from the UIDSet.
+ *   - Send a discovery unique branch message
+ *     - If we get a valid response, mute, and send the same branch again
+ *     - If we get a collision, split the UID range, and try each branch
+ *       separately.
+ *
+ * We also track responders that fail to ack a mute request (we attempt to mute
+ * MAX_MUTE_ATTEMPTS times) and branches that contain responders which continue
+ * to respond once muted. The latter causes a branch to be marked as corrupt,
+ * which prevents us from looping forver.
  */
 class DiscoveryAgent {
  public:
-    explicit DiscoveryAgent(DiscoveryTargetInterface *target);
-    ~DiscoveryAgent();
+  /**
+   * @brief Create a new DiscoveryAgent
+   * @param target the DiscoveryTargetInterface to use for sending commands.
+   */
+  explicit DiscoveryAgent(DiscoveryTargetInterface *target);
 
-    typedef ola::SingleUseCallback2<void, bool, const UIDSet&>
-      DiscoveryCompleteCallback;
+  /**
+   * @brief Destructor.
+   */
+  ~DiscoveryAgent();
 
-    void Abort();
-    void StartFullDiscovery(DiscoveryCompleteCallback *on_complete);
-    void StartIncrementalDiscovery(DiscoveryCompleteCallback *on_complete);
+  typedef ola::SingleUseCallback2<void, bool, const UIDSet&>
+    DiscoveryCompleteCallback;
+
+  /**
+   * @brief Cancel any in-progress discovery operation.
+   * If a discovery operation is running, this will result in the callback
+   * being run.
+   */
+  void Abort();
+
+  /**
+   * @brief Initiate a full discovery operation.
+   * @param on_complete the callback to run once discovery completes.
+   */
+  void StartFullDiscovery(DiscoveryCompleteCallback *on_complete);
+
+  /**
+   * @brief Initiate an incremental discovery operation.
+   * @param on_complete the callback to run once discovery completes.
+   */
+  void StartIncrementalDiscovery(DiscoveryCompleteCallback *on_complete);
 
  private:
-    /**
-     * Represents a range of UIDs (a branch of the UID tree)
-     */
-    struct UIDRange {
-      UIDRange(const UID &lower, const UID &upper, UIDRange *parent)
-          : lower(lower),
-            upper(upper),
-            parent(parent),
-            attempt(0),
-            failures(0),
-            uids_discovered(0),
-            branch_corrupt(false) {
-      }
-      UID lower;
-      UID upper;
-      UIDRange *parent;  // the parent Range
-      unsigned int attempt;  // the # of attempts for this branch
-      unsigned int failures;
-      unsigned int uids_discovered;
-      bool branch_corrupt;  // true if this branch contains a bad device
-    };
+  /**
+   * Represents a range of UIDs (a branch of the UID tree)
+   */
+  struct UIDRange {
+    UIDRange(const UID &lower, const UID &upper, UIDRange *parent)
+        : lower(lower),
+          upper(upper),
+          parent(parent),
+          attempt(0),
+          failures(0),
+          uids_discovered(0),
+          branch_corrupt(false) {
+    }
+    UID lower;
+    UID upper;
+    UIDRange *parent;  // the parent Range
+    unsigned int attempt;  // the # of attempts for this branch
+    unsigned int failures;
+    unsigned int uids_discovered;
+    bool branch_corrupt;  // true if this branch contains a bad device
+  };
 
-    typedef std::stack<UIDRange*> UIDRanges;
+  typedef std::stack<UIDRange*> UIDRanges;
 
-    DiscoveryTargetInterface *m_target;
-    UIDSet m_uids;
-    // uids that are misbehaved in some way
-    UIDSet m_bad_uids;
-    DiscoveryCompleteCallback *m_on_complete;
-    // uids to mute during incremental discovery
-    std::queue<UID> m_uids_to_mute;
-    // Callbacks used by the DiscoveryTarget
-    DiscoveryTargetInterface::UnMuteDeviceCallback *m_unmute_callback;
-    DiscoveryTargetInterface::MuteDeviceCallback *m_incremental_mute_callback;
-    DiscoveryTargetInterface::MuteDeviceCallback *m_branch_mute_callback;
-    DiscoveryTargetInterface::BranchCallback *m_branch_callback;
-    // The stack of UIDRanges
-    UIDRanges m_uid_ranges;
-    UID m_muting_uid;  // the uid we're currently trying to mute
-    unsigned int m_mute_attempts;
-    bool m_tree_corrupt;  // true if there was a problem with discovery
+  DiscoveryTargetInterface *m_target;
+  UIDSet m_uids;
+  // uids that are misbehaved in some way
+  UIDSet m_bad_uids;
+  DiscoveryCompleteCallback *m_on_complete;
+  // uids to mute during incremental discovery
+  std::queue<UID> m_uids_to_mute;
+  // Callbacks used by the DiscoveryTarget
+  std::auto_ptr<DiscoveryTargetInterface::UnMuteDeviceCallback>
+      m_unmute_callback;
+  std::auto_ptr<DiscoveryTargetInterface::MuteDeviceCallback>
+      m_incremental_mute_callback;
+  std::auto_ptr<DiscoveryTargetInterface::MuteDeviceCallback>
+      m_branch_mute_callback;
+  std::auto_ptr<DiscoveryTargetInterface::BranchCallback> m_branch_callback;
 
-    void InitDiscovery(DiscoveryCompleteCallback *on_complete,
-                       bool incremental);
+  // The stack of UIDRanges
+  UIDRanges m_uid_ranges;
+  UID m_muting_uid;  // the uid we're currently trying to mute
+  unsigned int m_unmute_count;
+  unsigned int m_mute_attempts;
+  bool m_tree_corrupt;  // true if there was a problem with discovery
 
-    void UnMuteComplete();
-    void MaybeMuteNextDevice();
-    void IncrementalMuteComplete(bool status);
-    void SendDiscovery();
+  void InitDiscovery(DiscoveryCompleteCallback *on_complete,
+                     bool incremental);
 
-    void BranchComplete(const uint8_t *data, unsigned int length);
-    void BranchMuteComplete(bool status);
-    void HandleCollision();
-    void FreeCurrentRange();
+  void UnMuteComplete();
+  void MaybeMuteNextDevice();
+  void IncrementalMuteComplete(bool status);
+  void SendDiscovery();
 
-    static const unsigned int MAX_DUB_RESPONSE_SIZE = 24;
-    static const unsigned int MIN_DUB_RESPONSE_SIZE = 17;
-    /*
-     * The maximum numbers of times we'll retry discovery if we get a
-     * collision, but after splitting the range in two no nodes can be found.
-     */
-    static const unsigned int MAX_EMPTY_BRANCH_ATTEMPTS = 5;
-    /*
-     * The maximum number of times we'll perform discovery on a branch when we
-     * get an inconsistent result (responder not muting, etc.)
-     */
-    static const unsigned int MAX_BRANCH_FAILURES = 5;
-    // The number of times we'll attempt to mute a UID
-    static const unsigned int MAX_MUTE_ATTEMPTS = 5;
+  void BranchComplete(const uint8_t *data, unsigned int length);
+  void BranchMuteComplete(bool status);
+  void HandleCollision();
+  void FreeCurrentRange();
+
+  static const unsigned int PREAMBLE_SIZE = 8;
+  static const unsigned int EUID_SIZE = 12;
+  static const unsigned int CHECKSUM_SIZE = 4;
+
+  /*
+   * The maximum numbers of times we'll retry discovery if we get a
+   * collision, but after splitting the range in two no nodes can be found.
+   */
+  static const unsigned int MAX_EMPTY_BRANCH_ATTEMPTS = 5;
+  /*
+   * The maximum number of times we'll perform discovery on a branch when we
+   * get an inconsistent result (responder not muting, etc.)
+   */
+  static const unsigned int MAX_BRANCH_FAILURES = 5;
+
+  // The number of times we'll attempt to mute a UID
+  static const unsigned int MAX_MUTE_ATTEMPTS = 5;
+  // The number of times we'll send a broadcast unmute command
+  // This should be more than 1 to ensure that all devices are unmuted.
+  static const unsigned int BROADCAST_UNMUTE_REPEATS = 3;
 };
 }  // namespace rdm
 }  // namespace ola


### PR DESCRIPTION
- Send a broadcast unmute 3 times in case a device misses it.
- Support trailing data for DUB responses.
- Clean up the documentation.