### PR TITLE
Bump protobuf java dependency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.4.1</version>
+      <version>2.6.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
The current code does not work with 2.4.1. The latest stable version is
2.6.1, and it seems to work with that.