### PR TITLE
Fix some tests for Python 3

### DIFF
--- a/python/ola/MACAddress.py
+++ b/python/ola/MACAddress.py
@@ -56,6 +56,15 @@ class MACAddress(object):
       return 1
     return cmp(self.mac_address, other.mac_address)
 
+  def __lt__(self, other):
+    return self.mac_address < other.mac_address
+
+  def __eq__(self, other):
+    if other is None:
+      return False
+
+    return self.mac_address == other.mac_address
+
   @staticmethod
   def FromString(mac_address_str):
     """Create a new MAC Address from a string.

--- a/python/ola/MACAddressTest.py
+++ b/python/ola/MACAddressTest.py
@@ -20,6 +20,7 @@
 
 __author__ = 'nomis52@gmail.com (Simon Newton)'
 
+import sys
 import unittest
 from ola.MACAddress import MACAddress
 
@@ -31,7 +32,10 @@ class MACAddressTest(unittest.TestCase):
     self.assertEqual(b'\x01\x23\x45\x67\x89\xab', bytes(mac.mac_address))
     self.assertEqual('01:23:45:67:89:ab', str(mac))
 
-    self.assertTrue(mac > None)
+    # Python 3 does not allow sorting of incompatible types.
+    if sys.version_info.major == 2:
+        self.assertTrue(mac > None)
+
     mac2 = MACAddress(bytearray([0x01, 0x23, 0x45, 0x67, 0x89, 0xcd]))
     self.assertTrue(mac2 > mac)
     mac3 = MACAddress(bytearray([0x01, 0x23, 0x45, 0x67, 0x88, 0xab]))
@@ -63,6 +67,11 @@ class MACAddressTest(unittest.TestCase):
     m4 = MACAddress(bytearray([0x48, 0x46, 0x00, 0x00, 0x02, 0x2e]))
     macs = sorted([m1, m2, m3, m4])
     self.assertEqual([m3, m2, m1, m4], macs)
+
+  def testEquals(self):
+    m1 = MACAddress(bytearray([0x48, 0x45, 0xff, 0xff, 0xff, 0xfe]))
+    m2 = MACAddress(bytearray([0x48, 0x45, 0xff, 0xff, 0xff, 0xfe]))
+    self.assertEqual(m1, m2)
 
 if __name__ == '__main__':
   unittest.main()

--- a/python/ola/UID.py
+++ b/python/ola/UID.py
@@ -61,6 +61,19 @@ class UID(object):
       return cmp(self._device_id, other._device_id)
     return cmp(self.manufacturer_id, other.manufacturer_id)
 
+  def __lt__(self, other):
+    if self.manufacturer_id != other.manufacturer_id:
+      return self.manufacturer_id < other.manufacturer_id
+    else:
+      return self.device_id < other.device_id
+
+  def __eq__(self, other):
+    if other is None:
+      return False
+
+    return self.manufacturer_id == other.manufacturer_id and \
+           self.device_id == other.device_id
+
   @staticmethod
   def AllDevices():
     return UID(0xffff, 0xffffffff)

--- a/python/ola/UIDTest.py
+++ b/python/ola/UIDTest.py
@@ -20,6 +20,7 @@
 
 __author__ = 'nomis52@gmail.com (Simon Newton)'
 
+import sys
 import unittest
 from ola.UID import UID, UIDOutOfRangeException
 
@@ -32,7 +33,10 @@ class UIDTest(unittest.TestCase):
     self.assertEqual(0x12345678, uid.device_id)
     self.assertEqual('707a:12345678', str(uid))
 
-    self.assertTrue(uid > None)
+    # Python 3 does not allow sorting of incompatible types.
+    if sys.version_info.major == 2:
+        self.assertTrue(uid > None)
+
     uid2 = UID(0x707a, 0x12345679)
     self.assertTrue(uid2 > uid)
     uid3 = UID(0x7079, 0x12345678)


### PR DESCRIPTION
Python 3 complains that our types are unorderable if they don't define
at least __lt__. That's the only one needed for sorting only (as well as
__eq__ for equality).

These tests now pass:

  $ python -V
  Python 3.4.3
  $ PYTHONPATH=$PWD nosetests ola/DUBDecoderTest.py ola/MACAddressTest.py ola/UIDTest.py
  ..........
  ----------------------------------------------------------------------
  Ran 10 tests in 0.003s

  OK

Nothing seemed to test equality of MACAddresses, so I added a test for
that.