### PR TITLE
configure.ac: Ja Rule dependency management, auto support for plugins, various small improvements

### DIFF
--- a/config/ola.m4
+++ b/config/ola.m4
@@ -104,22 +104,23 @@ AM_CONDITIONAL(BUILD_OLA_PROTOC_PLUGIN, test "${with_ola_protoc_plugin}" == "no"
 #
 # Build the specified plugin if requested and its dependencies are met.
 #
-# Each plugin specified with PLUGIN_SUPPORT gets its own configure switch named
-# --enable_${plugin_key}. The three acceptable values the user can give are:
+# Each plugin specified with PLUGIN_SUPPORT gets its own configure switches
+# --enable-X/--disable-X, which translate to the enable_X variable. The three
+# acceptable states for this variable are:
 #
-#  - auto (default): Build the plugin if its dependencies are met, otherwise
-#    don't.
+#  - auto: Build the plugin if its dependencies are met, otherwise
+#    don't. This is the default state used when the user does not specify
+#    anything regarding this plugin.
 #  - yes: Build the plugin and error out if its dependencies are not met.
 #  - no: Never build the plugin.
 #
-# If the input value of enable_${plugin_key} is "auto" and EITHER of the
-# following is true:
+# If the input value of enable_X is "auto" and EITHER of the following is true:
 #
 #  - --disable-all-plugins is specified
 #  - the plugin's dependencies are not met
 #
-# then PLUGIN_SUPPORT will overwrite the value of enable_${plugin_key} to "no".
-# In all other cases, its original value is preserved.
+# then PLUGIN_SUPPORT will overwrite the value of enable_X to "no". In all
+# other cases, the original value is preserved.
 #
 # This means that after PLUGIN_SUPPORT has "ran" for a particular plugin, a value
 # of "auto" or "yes" means that the plugin will get built, while a value of "no"

--- a/config/ola.m4
+++ b/config/ola.m4
@@ -148,13 +148,13 @@ AC_DEFUN([PLUGIN_SUPPORT],
 
   # If dependencies are not met...
   if test "$3" == "no"; then
-    # ...and the user has explicitely requested this plugin to be enabled,
+    # ...and the user has explicitly requested this plugin to be enabled,
     # error out.
     if test "${enable_plugin}" = "yes"; then
       AC_MSG_ERROR([Dependencies for plugin ${plugin_key} are not met.])
     fi
 
-    # Otherwise, force the plugin disabled silently.
+    # Otherwise, silently force disable the plugin.
     enable_plugin="no";
   fi
 

--- a/config/ola.m4
+++ b/config/ola.m4
@@ -160,7 +160,7 @@ AC_DEFUN([PLUGIN_SUPPORT],
 
   # If we've disabled all plugins, disable this one unless it has been
   # explicitly enabled.
-  if test "${enable_all_plugins}" = "no" -a "${enable_plugin}" != "yes"; then
+  if test "${enable_all_plugins}" = "no" -a "${enable_plugin}" = "auto"; then
     enable_plugin="no";
   fi
 

--- a/config/ola.m4
+++ b/config/ola.m4
@@ -100,9 +100,30 @@ AM_CONDITIONAL(BUILD_OLA_PROTOC_PLUGIN, test "${with_ola_protoc_plugin}" == "no"
 ])
 
 
-# PLUGIN_SUPPORT(plugin, conditional, prerequisites_found)
-# Build the specified plugin, unless it was disabled at configure time.
-# -----------------------------------------------------------------------------
+# PLUGIN_SUPPORT(plugin_key, conditional, prerequisites_found)
+#
+# Build the specified plugin if requested and its dependencies are met.
+#
+# Each plugin specified with PLUGIN_SUPPORT gets its own configure switch named
+# --enable_${plugin_key}. The three acceptable values the user can give are:
+#
+#  - auto (default): Build the plugin if its dependencies are met, otherwise
+#    don't.
+#  - yes: Build the plugin and error out if its dependencies are not met.
+#  - no: Never build the plugin.
+#
+# If the input value of enable_${plugin_key} is "auto" and EITHER of the
+# following is true:
+#
+#  - --disable-all-plugins is specified
+#  - the plugin's dependencies are not met
+#
+# then PLUGIN_SUPPORT will overwrite the value of enable_${plugin_key} to "no".
+# In all other cases, its original value is preserved.
+#
+# This means that after PLUGIN_SUPPORT has "ran" for a particular plugin, a value
+# of "auto" or "yes" means that the plugin will get built, while a value of "no"
+# means that it won't.
 AC_DEFUN([PLUGIN_SUPPORT],
 [
   plugin_key=$1
@@ -110,19 +131,36 @@ AC_DEFUN([PLUGIN_SUPPORT],
 
   AC_ARG_ENABLE(
     [$1],
-    AS_HELP_STRING([--disable-$1], [Disable the $1 plugin]))
+    AS_HELP_STRING([--disable-$1], [Disable the $1 plugin]),
+    [],
+    [eval $enable_arg=auto])
 
   eval enable_plugin=\$$enable_arg;
+
+  # Input validation.
+  if test "${enable_plugin}" != "yes" -a \
+          "${enable_plugin}" != "no" -a \
+          "${enable_plugin}" != "auto"; then
+    AC_MSG_ERROR([Invalid value for --enable-${plugin_key}/\
+--disable-${plugin_key}. Valid values are yes, no and auto.])
+  fi
+
+  # If dependencies are not met...
   if test "$3" == "no"; then
+    # ...and the user has explicitely requested this plugin to be enabled,
+    # error out.
+    if test "${enable_plugin}" = "yes"; then
+      AC_MSG_ERROR([Dependencies for plugin ${plugin_key} are not met.])
+    fi
+
+    # Otherwise, force the plugin disabled silently.
     enable_plugin="no";
   fi
 
   # If we've disabled all plugins, disable this one unless it has been
-  # explicitly enabled
-  if test "${enable_all_plugins}" == "no"; then
-    if test "${enable_plugin}" != "yes"; then
-      enable_plugin="no";
-    fi
+  # explicitly enabled.
+  if test "${enable_all_plugins}" = "no" -a "${enable_plugin}" != "yes"; then
+    enable_plugin="no";
   fi
 
   if test "${enable_plugin}" != "no"; then

--- a/config/ola.m4
+++ b/config/ola.m4
@@ -122,7 +122,7 @@ AM_CONDITIONAL(BUILD_OLA_PROTOC_PLUGIN, test "${with_ola_protoc_plugin}" == "no"
 # then PLUGIN_SUPPORT will overwrite the value of enable_X to "no". In all
 # other cases, the original value is preserved.
 #
-# This means that after PLUGIN_SUPPORT has "ran" for a particular plugin, a value
+# This means that after PLUGIN_SUPPORT has "run" for a particular plugin, a value
 # of "auto" or "yes" means that the plugin will get built, while a value of "no"
 # means that it won't.
 AC_DEFUN([PLUGIN_SUPPORT],

--- a/configure.ac
+++ b/configure.ac
@@ -663,6 +663,11 @@ AC_ARG_ENABLE(
 # knows what to link against.
 PLUGINS=""
 
+# Force enable_usbdmx to yes when Ja Rule is explicitly requested.
+AS_IF([test "x$enable_ja_rule" = xyes],
+      [AS_ECHO(["Ja Rule is enable, enabling the usbdmx plugin."])]
+      [enable_usbdmx="yes"])
+
 PLUGIN_SUPPORT(artnet, USE_ARTNET)
 PLUGIN_SUPPORT(dmx4linux, USE_DMX4LINUX, [$have_dmx4linux])
 PLUGIN_SUPPORT(dummy, USE_DUMMY)
@@ -717,13 +722,20 @@ AC_SUBST(OLA_CLIENT_LIBS)
 
 # Extra tools
 #####################################################
-AM_CONDITIONAL([BUILD_JA_RULE],
-               [test "x$enable_ja_rule" = xyes && test "x$have_libusb" = xyes \
-                && test "x$have_libusb_hotplug_api" = xyes])
+AS_IF([test "x$enable_ja_rule" = xyes && test "x$enable_usbdmx" != xyes],
+      AC_MSG_ERROR([Ja Rule requires the usbdmx plugin, but it could not be enabled.]))
+AS_IF([test "x$enable_ja_rule" = xyes && test "x$have_libusb" != xyes],
+      AC_MSG_ERROR([Ja Rule requires libusb, but it was not found on your system.]))
+AS_IF([test "x$enable_ja_rule" = xyes && test "x$have_libusb_hotplug_api" != xyes],
+      AC_MSG_ERROR([Ja Rule requires libusb to have the hotplug capability \
+(versions 1.0.16 and above), but the version found on your system doesn't \
+appear to have it.]))
+
+AM_CONDITIONAL([BUILD_JA_RULE], [test "x$enable_ja_rule" = xyes])
 
 # Status just for configure
 BUILDING_JA_RULE='no'
-if test -z "${BUILD_JA_RULE_TRUE}"; then
+if test "x$enable_ja_rule" = xyes; then
   BUILDING_JA_RULE='yes'
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -726,11 +726,11 @@ AC_SUBST(OLA_CLIENT_LIBS)
 
 # Extra tools
 #####################################################
-AS_IF([test "x$enable_ja_rule" = xyes && test "x$enable_usbdmx" != xyes],
+AS_IF([test "x$enable_ja_rule" = xyes && test "x$enable_usbdmx" = xno],
       [AC_MSG_ERROR([Ja Rule requires the usbdmx plugin, but it could not be enabled.])])
-AS_IF([test "x$enable_ja_rule" = xyes && test "x$have_libusb" != xyes],
+AS_IF([test "x$enable_ja_rule" = xyes && test "x$have_libusb" = xno],
       [AC_MSG_ERROR([Ja Rule requires libusb, but, it was not found on your system.])])
-AS_IF([test "x$enable_ja_rule" = xyes && test "x$have_libusb_hotplug_api" != xyes],
+AS_IF([test "x$enable_ja_rule" = xyes && test "x$have_libusb_hotplug_api" = xno],
       [AC_MSG_ERROR([Ja Rule requires libusb to have the hotplug capability (versions 1.0.16 and above) but, the version found on your system doesn't appear to have it.])])
 
 AM_CONDITIONAL([BUILD_JA_RULE], [test "x$enable_ja_rule" = xyes])

--- a/configure.ac
+++ b/configure.ac
@@ -669,7 +669,7 @@ PLUGINS=""
 
 # Force enable_usbdmx to yes when Ja Rule is explicitly requested.
 AS_IF([test "x$enable_ja_rule" = xyes],
-      [AS_ECHO(["Ja Rule is enable, enabling the usbdmx plugin."])]
+      [AS_ECHO(["Ja Rule is enabled, enabling the usbdmx plugin."])]
       [enable_usbdmx="yes"])
 
 PLUGIN_SUPPORT(artnet, USE_ARTNET)

--- a/configure.ac
+++ b/configure.ac
@@ -729,9 +729,10 @@ AC_SUBST(OLA_CLIENT_LIBS)
 AS_IF([test "x$enable_ja_rule" = xyes && test "x$enable_usbdmx" = xno],
       [AC_MSG_ERROR([Ja Rule requires the usbdmx plugin, but it could not be enabled.])])
 AS_IF([test "x$enable_ja_rule" = xyes && test "x$have_libusb" = xno],
-      [AC_MSG_ERROR([Ja Rule requires libusb, but, it was not found on your system.])])
+      [AC_MSG_ERROR([Ja Rule requires libusb, but it was not found on your system.])])
 AS_IF([test "x$enable_ja_rule" = xyes && test "x$have_libusb_hotplug_api" = xno],
-      [AC_MSG_ERROR([Ja Rule requires libusb to have the hotplug capability (versions 1.0.16 and above) but, the version found on your system doesn't appear to have it.])])
+      [AC_MSG_ERROR([Ja Rule requires libusb to have the hotplug capability (versions 1.0.16 \
+and above), but the version found on your system doesn't appear to have it.])])
 
 AM_CONDITIONAL([BUILD_JA_RULE], [test "x$enable_ja_rule" = xyes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -727,13 +727,11 @@ AC_SUBST(OLA_CLIENT_LIBS)
 # Extra tools
 #####################################################
 AS_IF([test "x$enable_ja_rule" = xyes && test "x$enable_usbdmx" != xyes],
-      AC_MSG_ERROR([Ja Rule requires the usbdmx plugin, but it could not be enabled.]))
+      [AC_MSG_ERROR([Ja Rule requires the usbdmx plugin, but it could not be enabled.])])
 AS_IF([test "x$enable_ja_rule" = xyes && test "x$have_libusb" != xyes],
-      AC_MSG_ERROR([Ja Rule requires libusb, but it was not found on your system.]))
+      [AC_MSG_ERROR([Ja Rule requires libusb, but, it was not found on your system.])])
 AS_IF([test "x$enable_ja_rule" = xyes && test "x$have_libusb_hotplug_api" != xyes],
-      AC_MSG_ERROR([Ja Rule requires libusb to have the hotplug capability \
-(versions 1.0.16 and above), but the version found on your system doesn't \
-appear to have it.]))
+      [AC_MSG_ERROR([Ja Rule requires libusb to have the hotplug capability (versions 1.0.16 and above) but, the version found on your system doesn't appear to have it.])])
 
 AM_CONDITIONAL([BUILD_JA_RULE], [test "x$enable_ja_rule" = xyes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -480,6 +480,10 @@ have_microhttpd="no"
 AS_IF([test "x$enable_http" != xno],
       [PKG_CHECK_MODULES([libmicrohttpd], [libmicrohttpd],
                          [have_microhttpd="yes"], [true])])
+
+AS_IF([test "x$enable_http" = xyes && test "x$have_microhttpd" != xyes],
+      AC_MSG_ERROR([--enable-http was given but libmicrohttpd was not found.]))
+
 AM_CONDITIONAL([HAVE_LIBMICROHTTPD], [test "x$have_microhttpd" = xyes])
 AS_IF([test "x$have_microhttpd" = xyes],
       [AC_DEFINE([HAVE_LIBMICROHTTPD], [1],


### PR DESCRIPTION
… met

Configure now fails if Ja Rule is enabled, but either of:

 - the usbdmx plugin is not enabled
 - libusb doesn't support hotplug

is true.