### PR TITLE
Avoid using sys.version_info.major to keep Python 2.6 support

### DIFF
--- a/python/ola/MACAddressTest.py
+++ b/python/ola/MACAddressTest.py
@@ -33,7 +33,8 @@ class MACAddressTest(unittest.TestCase):
     self.assertEqual('01:23:45:67:89:ab', str(mac))
 
     # Python 3 does not allow sorting of incompatible types.
-    if sys.version_info.major == 2:
+    # We don't use sys.version_info.major to support Python 2.6.
+    if sys.version_info[0] == 2:
         self.assertTrue(mac > None)
 
     mac2 = MACAddress(bytearray([0x01, 0x23, 0x45, 0x67, 0x89, 0xcd]))

--- a/python/ola/UIDTest.py
+++ b/python/ola/UIDTest.py
@@ -34,7 +34,8 @@ class UIDTest(unittest.TestCase):
     self.assertEqual('707a:12345678', str(uid))
 
     # Python 3 does not allow sorting of incompatible types.
-    if sys.version_info.major == 2:
+    # We don't use sys.version_info.major to support Python 2.6.
+    if sys.version_info[0] == 2:
         self.assertTrue(uid > None)
 
     uid2 = UID(0x707a, 0x12345679)


### PR DESCRIPTION
Refs #774