### PR TITLE
Disable the use of kqueue.

### DIFF
--- a/common/io/SelectServer.cpp
+++ b/common/io/SelectServer.cpp
@@ -61,7 +61,7 @@ DEFINE_default_bool(use_epoll, true,
 #ifdef HAVE_KQUEUE
 #include "common/io/KQueuePoller.h"
 DEFINE_default_bool(use_kqueue, false,
-                    "Use of kqueue() rather than select()");
+                    "Use kqueue() rather than select()");
 #endif
 
 namespace ola {

--- a/common/io/SelectServer.cpp
+++ b/common/io/SelectServer.cpp
@@ -60,8 +60,8 @@ DEFINE_default_bool(use_epoll, true,
 
 #ifdef HAVE_KQUEUE
 #include "common/io/KQueuePoller.h"
-DEFINE_default_bool(use_kqueue, true,
-                    "Disable the use of kqueue(), revert to select()");
+DEFINE_default_bool(use_kqueue, false,
+                    "Use of kqueue() rather than select()");
 #endif
 
 namespace ola {


### PR DESCRIPTION
Use of kqueue causes an infinite loop if a USB serial device is removed.
See #799 for details.