### PR TITLE
Correcting Xcode build errors

### DIFF
--- a/include/ola/client/ClientArgs.h
+++ b/include/ola/client/ClientArgs.h
@@ -90,9 +90,9 @@ struct SendDMXArgs {
   /**
    * @brief Create a new SendDMXArgs object
    */
-  explicit SendDMXArgs(GeneralSetCallback *callback)
+  explicit SendDMXArgs(GeneralSetCallback *_callback)
       : priority(ola::dmx::SOURCE_PRIORITY_DEFAULT),
-        callback(callback) {
+        callback(_callback) {
   }
 };
 
@@ -111,8 +111,8 @@ struct SendRDMArgs {
    */
   bool include_raw_frames;
 
-  explicit SendRDMArgs(RDMCallback *callback)
-    : callback(callback),
+  explicit SendRDMArgs(RDMCallback *_callback)
+    : callback(_callback),
       include_raw_frames(false) {
   }
 };

--- a/include/ola/client/ClientTypes.h
+++ b/include/ola/client/ClientTypes.h
@@ -318,10 +318,10 @@ struct DMXMetadata {
    */
   uint8_t priority;
 
-  explicit DMXMetadata(unsigned int universe,
-                       uint8_t priority = ola::dmx::SOURCE_PRIORITY_DEFAULT)
-      : universe(universe),
-        priority(priority) {
+  explicit DMXMetadata(unsigned int _universe,
+                       uint8_t _priority = ola::dmx::SOURCE_PRIORITY_DEFAULT)
+      : universe(_universe),
+        priority(_priority) {
   }
 };
 
@@ -346,8 +346,8 @@ struct RDMMetadata {
    */
   RDMMetadata() : response_code(ola::rdm::RDM_FAILED_TO_SEND) {}
 
-  explicit RDMMetadata(ola::rdm::rdm_response_code response_code)
-      : response_code(response_code) {
+  explicit RDMMetadata(ola::rdm::rdm_response_code _response_code)
+      : response_code(_response_code) {
   }
 };
 }  // namespace client

--- a/include/ola/http/HTTPServer.h
+++ b/include/ola/http/HTTPServer.h
@@ -218,8 +218,8 @@ class HTTPServer: public ola::thread::Thread {
 
   struct DescriptorState {
    public:
-    explicit DescriptorState(ola::io::UnmanagedFileDescriptor *descriptor)
-        : descriptor(descriptor), read(0), write(0) {}
+    explicit DescriptorState(ola::io::UnmanagedFileDescriptor *_descriptor)
+        : descriptor(_descriptor), read(0), write(0) {}
 
     ola::io::UnmanagedFileDescriptor *descriptor;
     uint8_t read    : 1;

--- a/include/ola/messaging/StringMessageBuilder.h
+++ b/include/ola/messaging/StringMessageBuilder.h
@@ -38,7 +38,7 @@ class StringMessageBuilder: public FieldDescriptorVisitor {
     explicit StringMessageBuilder(const std::vector<std::string> &input)
         : m_input(input) {
     }
-    ~StringMessageBuilderVisitor() {}
+    ~StringMessageBuilder() {}
 
     void Visit(const BoolFieldDescriptor*);
     void Visit(const IPV4FieldDescriptor*);

--- a/include/ola/rdm/DiscoveryAgent.h
+++ b/include/ola/rdm/DiscoveryAgent.h
@@ -172,10 +172,10 @@ class DiscoveryAgent {
    * @brief Represents a range of UIDs (a branch of the UID tree)
    */
   struct UIDRange {
-    UIDRange(const UID &lower, const UID &upper, UIDRange *parent)
-        : lower(lower),
-          upper(upper),
-          parent(parent),
+    UIDRange(const UID &_lower, const UID &_upper, UIDRange *_parent)
+        : lower(_lower),
+          upper(_upper),
+          parent(_parent),
           attempt(0),
           failures(0),
           uids_discovered(0),

--- a/include/ola/rdm/RDMFrame.h
+++ b/include/ola/rdm/RDMFrame.h
@@ -43,8 +43,8 @@ class RDMFrame {
    public:
     Options() : prepend_start_code(false) {}
 
-    explicit Options(bool prepend_start_code)
-        : prepend_start_code(prepend_start_code) {
+    explicit Options(bool _prepend_start_code)
+        : prepend_start_code(_prepend_start_code) {
     }
 
     /**

--- a/include/ola/rdm/ResponderSensor.h
+++ b/include/ola/rdm/ResponderSensor.h
@@ -56,20 +56,20 @@ class Sensor {
     // SensorOptions constructor to set all options, for use in
     // initialisation lists. This also sets the defaults if called with no
     // args
-    SensorOptions(bool recorded_value_support = true,
-                  bool recorded_range_support = true,
-                  int16_t range_min = SENSOR_DEFINITION_RANGE_MIN_UNDEFINED,
-                  int16_t range_max = SENSOR_DEFINITION_RANGE_MAX_UNDEFINED,
-                  int16_t normal_min =
+    SensorOptions(bool _recorded_value_support = true,
+                  bool _recorded_range_support = true,
+                  int16_t _range_min = SENSOR_DEFINITION_RANGE_MIN_UNDEFINED,
+                  int16_t _range_max = SENSOR_DEFINITION_RANGE_MAX_UNDEFINED,
+                  int16_t _normal_min =
                       SENSOR_DEFINITION_NORMAL_MIN_UNDEFINED,
-                  int16_t normal_max =
+                  int16_t _normal_max =
                       SENSOR_DEFINITION_NORMAL_MAX_UNDEFINED)
-        : recorded_value_support(recorded_value_support),
-          recorded_range_support(recorded_range_support),
-          range_min(range_min),
-          range_max(range_max),
-          normal_min(normal_min),
-          normal_max(normal_max) {
+        : recorded_value_support(_recorded_value_support),
+          recorded_range_support(_recorded_range_support),
+          range_min(_range_min),
+          range_max(_range_max),
+          normal_min(_normal_min),
+          normal_max(_normal_max) {
     }
   };
 

--- a/include/ola/strings/FormatPrivate.h
+++ b/include/ola/strings/FormatPrivate.h
@@ -45,10 +45,10 @@ enum { HEX_BIT_WIDTH = 4 };
 template<typename T>
 struct _ToHex {
  public:
-  _ToHex(T v, int width, bool prefix)
-      : width(width),
+  _ToHex(T v, int _width, bool _prefix)
+      : width(_width),
         value(v),
-        prefix(prefix) {
+        prefix(_prefix) {
   }
 
   int width;  // setw takes an int


### PR DESCRIPTION
Fixes to constructor arguments shadowing member variables.  Correcting name of StringMessageBuilder destructor.