### PR TITLE
fix the use of DISTCHECK_CONFIGURE_FLAGS

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -74,10 +74,10 @@ elif [[ $TASK = 'jshint' ]]; then
   npm install;
   grunt test
 else
-  # Otherwise compile and check as normal
+  export DISTCHECK_CONFIGURE_FLAGS='--enable-rdm-tests --enable-ja-rule'
   autoreconf -i;
-  ./configure --enable-rdm-tests --enable-ja-rule;
-  make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-rdm-tests --enable-ja-rule';
+  ./configure $DISTCHECK_CONFIGURE_FLAGS;
+  make distcheck;
   make dist;
   tarball=$(ls -Ut ola*.tar.gz | head -1)
   tar -zxf $tarball;

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -74,6 +74,7 @@ elif [[ $TASK = 'jshint' ]]; then
   npm install;
   grunt test
 else
+  # Otherwise compile and check as normal
   export DISTCHECK_CONFIGURE_FLAGS='--enable-rdm-tests --enable-ja-rule'
   autoreconf -i;
   ./configure $DISTCHECK_CONFIGURE_FLAGS;


### PR DESCRIPTION
now both ```./configure``` and ```make distcheck``` use the same flags