### PR TITLE
drop AC_PROG_LIBTOOL in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,6 @@ AC_CHECK_FUNCS([bzero gettimeofday memmove memset mkdir strdup strrchr \
                 getgrnam_r getgrgid_r secure_getenv])
 
 LT_INIT
-AC_PROG_LIBTOOL
 
 # Decide if we're building on Windows early on.
 AM_CONDITIONAL([USING_WIN32], [test "x$host_os" = xmingw32])


### PR DESCRIPTION
since AC_PROG_LIBTOOL is obsolete in newer versions op autotools (according to redhat epel6+) they now use LT_INIT instead.

fixes #931