### PR TITLE
Fix invalid shebangs

### DIFF
--- a/python/ola/ClientWrapper.py
+++ b/python/ola/ClientWrapper.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/python/ola/DMXConstants.py
+++ b/python/ola/DMXConstants.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either


### PR DESCRIPTION
There should not be any shebangs in python-modules.
Encountered this issue when packaging for openSUSE.
Will fix a part of issue #904