### PR TITLE
Fixed wrong shebangs in tools/rdm.

### DIFF
--- a/tools/rdm/DMXSender.py
+++ b/tools/rdm/DMXSender.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/ExpectedResults.py
+++ b/tools/rdm/ExpectedResults.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/ModelCollector.py
+++ b/tools/rdm/ModelCollector.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/ResponderTest.py
+++ b/tools/rdm/ResponderTest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/TestCategory.py
+++ b/tools/rdm/TestCategory.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/TestDefinitions.py
+++ b/tools/rdm/TestDefinitions.py
@@ -1,4 +1,3 @@
-# !/usr/bin/python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/TestHelpers.py
+++ b/tools/rdm/TestHelpers.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/TestLogger.py
+++ b/tools/rdm/TestLogger.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/TestRunner.py
+++ b/tools/rdm/TestRunner.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/TestState.py
+++ b/tools/rdm/TestState.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/launch_tests.py
+++ b/tools/rdm/launch_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/rdm_model_collector.py
+++ b/tools/rdm/rdm_model_collector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/rdm_responder_test.py
+++ b/tools/rdm/rdm_responder_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/rdm_test_server.py
+++ b/tools/rdm/rdm_test_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or

--- a/tools/rdm/setup_patch.py
+++ b/tools/rdm/setup_patch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or


### PR DESCRIPTION
Shebangs only in executable scripts not in modules.
Use "/usr/bin/env python", so the system will figure out the correct position of python itself.
See @peternewman s request in #961 