### PR TITLE
Move serial number of Nodle U1 from ports to device name

### DIFF
--- a/plugins/usbdmx/AsyncPluginImpl.cpp
+++ b/plugins/usbdmx/AsyncPluginImpl.cpp
@@ -172,10 +172,11 @@ bool AsyncPluginImpl::NewWidget(AnymauDMX *widget) {
 bool AsyncPluginImpl::NewWidget(DMXCProjectsNodleU1 *widget) {
   return StartAndRegisterDevice(
       widget,
-      new DMXCProjectsNodleU1Device(m_plugin, widget,
-                                    "DMXControl Projects e.V. Nodle U1",
-                                    "nodleu1-" + widget->SerialNumber(),
-                                    m_plugin_adaptor));
+      new DMXCProjectsNodleU1Device(
+          m_plugin, widget,
+          "DMXControl Projects e.V. Nodle U1 (" + widget->SerialNumber() + ")",
+          "nodleu1-" + widget->SerialNumber(),
+          m_plugin_adaptor));
 }
 
 bool AsyncPluginImpl::NewWidget(EurolitePro *widget) {

--- a/plugins/usbdmx/DMXCProjectsNodleU1Device.cpp
+++ b/plugins/usbdmx/DMXCProjectsNodleU1Device.cpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include "plugins/usbdmx/DMXCProjectsNodleU1Port.h"
+#include "plugins/usbdmx/GenericOutputPort.h"
 
 namespace ola {
 namespace plugin {
@@ -40,7 +41,7 @@ DMXCProjectsNodleU1Device::DMXCProjectsNodleU1Device(
   unsigned int mode = widget->Mode();
 
   if (mode & DMXCProjectsNodleU1::OUTPUT_ENABLE_MASK) {  // output port active
-    m_out_port.reset(new DMXCProjectsNodleU1OutputPort(this, 0, widget));
+    m_out_port.reset(new GenericOutputPort(this, 0, widget));
   }
 
   if (mode & DMXCProjectsNodleU1::INPUT_ENABLE_MASK) {  // input port active

--- a/plugins/usbdmx/DMXCProjectsNodleU1Device.h
+++ b/plugins/usbdmx/DMXCProjectsNodleU1Device.h
@@ -61,7 +61,7 @@ class DMXCProjectsNodleU1Device: public Device {
 
  private:
   const std::string m_device_id;
-  std::auto_ptr<class DMXCProjectsNodleU1OutputPort> m_out_port;
+  std::auto_ptr<class GenericOutputPort> m_out_port;
   std::auto_ptr<class DMXCProjectsNodleU1InputPort> m_in_port;
 
   DISALLOW_COPY_AND_ASSIGN(DMXCProjectsNodleU1Device);

--- a/plugins/usbdmx/DMXCProjectsNodleU1Port.cpp
+++ b/plugins/usbdmx/DMXCProjectsNodleU1Port.cpp
@@ -27,20 +27,6 @@ namespace ola {
 namespace plugin {
 namespace usbdmx {
 
-DMXCProjectsNodleU1OutputPort::DMXCProjectsNodleU1OutputPort(
-    Device *parent,
-    unsigned int id,
-    DMXCProjectsNodleU1 *widget)
-    : BasicOutputPort(parent, id),
-      m_widget(widget) {
-}
-
-bool DMXCProjectsNodleU1OutputPort::WriteDMX(const DmxBuffer &buffer,
-                                             OLA_UNUSED uint8_t priority) {
-  m_widget->SendDMX(buffer);
-  return true;
-}
-
 DMXCProjectsNodleU1InputPort::DMXCProjectsNodleU1InputPort(
     Device *parent,
     unsigned int id,

--- a/plugins/usbdmx/DMXCProjectsNodleU1Port.h
+++ b/plugins/usbdmx/DMXCProjectsNodleU1Port.h
@@ -37,35 +37,6 @@ namespace usbdmx {
 /**
  * @brief A thin wrapper around a Widget so that it can operate as a Port.
  */
-class DMXCProjectsNodleU1OutputPort: public BasicOutputPort {
- public:
-  /**
-   * @brief Create a new DMXCProjectsNodleU1OutputPort.
-   * @param parent The parent device for this port.
-   * @param id The port id.
-   * @param widget The widget to use to send DMX frames.
-   */
-  DMXCProjectsNodleU1OutputPort(Device *parent,
-                                unsigned int id,
-                                class DMXCProjectsNodleU1 *widget);
-
-  bool WriteDMX(const DmxBuffer &buffer, uint8_t priority);
-
-  std::string Description() const {
-    std::ostringstream str;
-    str << "Serial #: " << m_widget->SerialNumber();
-    return str.str();
-  }
-
- private:
-  class DMXCProjectsNodleU1* const m_widget;
-
-  DISALLOW_COPY_AND_ASSIGN(DMXCProjectsNodleU1OutputPort);
-};
-
-/**
- * @brief A thin wrapper around a Widget so that it can operate as a Port.
- */
 class DMXCProjectsNodleU1InputPort: public BasicInputPort {
  public:
   /**
@@ -85,13 +56,10 @@ class DMXCProjectsNodleU1InputPort: public BasicInputPort {
   }
 
   std::string Description() const {
-    std::ostringstream str;
-    str << "Serial #: " << m_widget->SerialNumber();
-    return str.str();
+    return "";
   }
 
  private:
-  DmxBuffer m_buffer;
   class DMXCProjectsNodleU1* const m_widget;
 
   DISALLOW_COPY_AND_ASSIGN(DMXCProjectsNodleU1InputPort);

--- a/plugins/usbdmx/SyncPluginImpl.cpp
+++ b/plugins/usbdmx/SyncPluginImpl.cpp
@@ -126,10 +126,11 @@ bool SyncPluginImpl::NewWidget(AnymauDMX *widget) {
 bool SyncPluginImpl::NewWidget(DMXCProjectsNodleU1 *widget) {
   return StartAndRegisterDevice(
       widget,
-      new DMXCProjectsNodleU1Device(m_plugin, widget,
-                                    "DMXControl Projects e.V. Nodle U1",
-                                    "nodleu1-" + widget->SerialNumber(),
-                                    m_plugin_adaptor));
+      new DMXCProjectsNodleU1Device(
+          m_plugin, widget,
+          "DMXControl Projects e.V. Nodle U1 (" + widget->SerialNumber() + ")",
+          "nodleu1-" + widget->SerialNumber(),
+          m_plugin_adaptor));
 }
 
 bool SyncPluginImpl::NewWidget(EurolitePro *widget) {


### PR DESCRIPTION
If you want to do the change as proposed in #975, here are the changes necessary for the DMXControl Projects e.V. Nodle U1.