### PR TITLE
spec-file: add numpy to require and cleanup

### DIFF
--- a/ola.spec.in
+++ b/ola.spec.in
@@ -2,8 +2,6 @@
 %{!?python2_sitelib:%global python2_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 #udev macro shim
 %{!?_udevrulesdir:%global _udevrulesdir %{_sysconfdir}/udev/rules.d/ }
-#license shim
-%{!?_licensedir:%global license %doc}
 
 Name:		ola
 Version:	@VERSION@
@@ -101,6 +99,8 @@ cp debian/ola.udev %buildroot/%{_udevrulesdir}
 %postun -p /sbin/ldconfig
 
 %files
+#license shim
+%{!?_licensedir:%global license %doc}
 %doc AUTHORS NEWS README
 %{_bindir}/ola*
 %{_bindir}/rdmpro_sniffer

--- a/ola.spec.in
+++ b/ola.spec.in
@@ -1,10 +1,9 @@
-#missing el6 macros
-%if 0%{?el6}
-#python2_sitelib macro
+#python2_sitelib macro shim
 %{!?python2_sitelib:%global python2_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
-#udev macro
+#udev macro shim
 %{!?_udevrulesdir:%global _udevrulesdir %{_sysconfdir}/udev/rules.d/ }
-%endif
+#license shim
+%{!?license:%global license %%doc}
 
 Name:		ola
 Version:	@VERSION@
@@ -16,14 +15,13 @@ URL:		https://github.com/OpenLightingProject/ola
 Source:		https://github.com/OpenLightingProject/ola/releases/download/%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:	pkgconfig,pkgconfig(cppunit),pkgconfig(uuid),pkgconfig(avahi-client)
-BuildRequires:	pkgconfig(libusb-1.0) >= 1.0.2,pkgconfig(libmicrohttpd) >= 0.4.0
+BuildRequires:	pkgconfig(libusb-1.0) >= 1.0.2,pkgconfig(libmicrohttpd) >= 0.4.0%{!?el6:,pkgconfig(systemd)}
 BuildRequires:	libtool,bison,flex,python2-devel,openslp-devel,pkgconfig(libftdi%{!?el6:1}) >= 0.18
-BuildRequires:	protobuf-devel >= 0.2,protobuf-compiler,protobuf-python
+BuildRequires:	protobuf-devel >= 0.2,protobuf-compiler,protobuf-python,numpy
 %if 0%{?fedora} >= 21
 BuildRequires:	liblo-devel
 %endif
-Provides:	bundled(bootstrap) = 3.3.2, bundled(jquery) = 2.1.3
-Provides:	bundled(angularjs) = 1.3.14, bundled(angular-route) = 1.3.14
+Requires:	%{name}-data = %{version}-%{release}
 
 %description
 The Open Lighting Architecture is a framework for lighting control information.
@@ -52,7 +50,7 @@ BuildArch:	noarch
 The OLA python library
 
 %package rdm-tests
-Requires:	%{name} = %{version}-%{release}, python2-%{name}
+Requires:	%{name} = %{version}-%{release}, python2-%{name}, numpy
 Group:		Development/Libraries
 BuildArch:	noarch
 Summary:	RDM test suite using OLA and python
@@ -61,44 +59,56 @@ Provides:	bundled(jquery) = 1.7.2, bundled(jquery-ui) = 1.8.21
 %description rdm-tests
 The rdm test suite for OLA
 
+%package data
+Group:		Development/Libraries
+BuildArch:	noarch
+Summary:	data for OLA
+Provides:	bundled(bootstrap) = 3.3.2, bundled(jquery) = 2.1.3
+Provides:	bundled(angularjs) = 1.3.14, bundled(angular-route) = 1.3.14
+
+%description data
+HTML, CSS, JS and RDM PIDs files for OLA
+
 %prep
 %setup -q -n %{name}-%{version}
 
 %build
+export LD_LIBRARY_PATH="%buildroot%{_libdir}"
 autoreconf -i
 %configure --enable-rdm-tests --enable-shared --disable-static
-#begin rpath removal
+#only link as needed
+sed -i -e 's! -shared ! -Wl,--as-needed\0!g' libtool
+#rpath, please die
 sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
 sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+#we can't fix this upstream (I think)
 sed -i "s|\$(LN_S) -f \$(bindir)\/|\$(LN_S) -f |g" Makefile
-#end rpath removal
 make %{!?el6:%{?_smp_mflags}} #el6 has problems with parralel building
 
 %check
-export LD_LIBRARY_PATH="%buildroot/usr/lib:%buildroot/usr/lib64"
+export LD_LIBRARY_PATH="%buildroot%{_libdir}"
 make check %{!?el6:%{?_smp_mflags}} #el6 has problems with parralel building
 find %buildroot -name "*\.la" -delete
 find %buildroot -name "*\.a" -delete
 
 %install
-rm -rf %buildroot
+export LD_LIBRARY_PATH="%buildroot%{_libdir}"
 %make_install
 mkdir -p %buildroot/%{_udevrulesdir}
 cp debian/ola.udev %buildroot/%{_udevrulesdir}
 
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
 %files
-%doc AUTHORS ChangeLog NEWS README TODO
+%doc AUTHORS NEWS README
 %{_bindir}/ola*
 %{_bindir}/rdmpro_sniffer
 %{_bindir}/usbpro_firmware
-%{_datadir}/olad
-%{_datadir}/olad/**
-%{_datadir}/ola
-%{_datadir}/ola/pids
-%{_datadir}/ola/pids/**
 %{_libdir}/libola*\.so\.*
 %{_mandir}/man1/**
 %{_udevrulesdir}/ola.udev
+%license LICENCE tools/rdm/static/MIT-LICENSE.txt javascript/new-src/README.md COPYING
 
 %files devel
 %doc README.developer
@@ -107,36 +117,30 @@ cp debian/ola.udev %buildroot/%{_udevrulesdir}
 %{_libdir}/pkgconfig/*
 
 %files -n python2-%{name}
-%{python2_sitelib}/ola
+%dir %{python2_sitelib}/ola
 %{python2_sitelib}/ola/*\.py*
 %{python2_sitelib}/ola/rpc
-%{python2_sitelib}/ola/rpc/*\.py*
 
 %files rdm-tests
 %{_bindir}/rdm_model_collector.py*
 %{_bindir}/rdm_responder_test.py*
 %{_bindir}/rdm_test_server.py*
 %{_datadir}/ola/rdm-server
-%{_datadir}/ola/rdm-server/**
 %{python2_sitelib}/ola/testing
-%{python2_sitelib}/ola/testing/*\.py*
-%{python2_sitelib}/ola/testing/rdm
-%{python2_sitelib}/ola/testing/rdm/*\.py*
 
-%post -p /sbin/ldconfig
-
-%postun -p /sbin/ldconfig
-
-%post devel -p /sbin/ldconfig
-
-%postun devel -p /sbin/ldconfig
-
-%licence LICENCE
+%files data
+%{_datadir}/olad
+%dir %{_datadir}/ola
+%{_datadir}/ola/pids
 
 %changelog
-* Sat Sep 19 2015 Dave Olsthoorn - 0.9.7-1
+* Thu Nov 12 2015 Dave Olsthoorn <dave.olsthoorn@gmail.com> - 0.9.8-1
+- update to 0.9.8 full changelog here: https://github.com/OpenLightingProject/ola/releases/tag/0.9.8
+
+* Sat Sep 19 2015 Dave Olsthoorn <dave.olsthoorn@gmail.com> - 0.9.7-1
 - update to 0.9.7
 - OLA now requires libusb
+
 * Thu Aug 27 2009 Kevin Deldycke <kevin@deldycke.com> 0.3.1.trunk.20090827-1mdv2009.1
 - Rename all project from lla to OLA
 - Upgrade to the latest OLA 0.3.1 from the master branch of the git repository
@@ -144,7 +148,9 @@ cp debian/ola.udev %buildroot/%{_udevrulesdir}
 - Disable the --no-undefined option and make all undefined symbols weakly bound
 - Add check step
 - Rebuild RPM for Mandriva 2009.1
+
 * Mon May 12 2008 Kevin Deldycke <kev@coolcavemen.com> 0.2.3.200710210908-1mdv2008.1
 - Ported from Fedora Core 8 ( http://rpms.netmindz.net/FC8/SRPMS.netmindz/lla-0.2.3.200710210908-1.fc8.src.rpm ) to Mandriva 2008.1
+
 * Sun Apr 29 2007 Will Tatam <will@netmindz.net> 0.1.3-1
 - First Build

--- a/ola.spec.in
+++ b/ola.spec.in
@@ -3,7 +3,7 @@
 #udev macro shim
 %{!?_udevrulesdir:%global _udevrulesdir %{_sysconfdir}/udev/rules.d/ }
 #license shim
-%{!?license:%global license %%doc}
+%{!?_licensedir:%global license %doc}
 
 Name:		ola
 Version:	@VERSION@


### PR DESCRIPTION
Add numpy as a dependency for the python package since the rdm-tests now use numpy.
The rest of this commit is to solve rpmlint errors and warnings like:
 - unused-direct-shlib-dependency
 - postun-without-ldconfig
 - non-empty-%postun
 - and more