### PR TITLE
Feature/Bugfix: add setgroups and getgroups to Credential functions

### DIFF
--- a/common/base/Credentials.cpp
+++ b/common/base/Credentials.cpp
@@ -135,7 +135,6 @@ bool SetUID(uid_t new_uid) {
 bool SetGID(gid_t new_gid) {
 #ifdef _WIN32
   (void) new_gid;
-  (void_
   return false;
 #else
   if (setgid(new_gid)) {

--- a/common/base/Credentials.cpp
+++ b/common/base/Credentials.cpp
@@ -135,10 +135,34 @@ bool SetUID(uid_t new_uid) {
 bool SetGID(gid_t new_gid) {
 #ifdef _WIN32
   (void) new_gid;
+  (void_
   return false;
 #else
   if (setgid(new_gid)) {
     OLA_WARN << "setgid(" << new_gid << "): " << strerror(errno);
+    return false;
+  }
+  return true;
+#endif
+}
+
+int GetGroups(int size, gid_t list[]) {
+#ifdef _WIN32
+  (void) size;
+  (void) list;
+  return -1;
+#else
+  return getgroups(size, list);
+#endif
+}
+
+bool SetGroups(size_t size, const gid_t *list) {
+#ifdef _WIN32
+  (void) size;
+  return false;
+#else
+  if (setgroups(size, list)) {
+    OLA_WARN << "setgroups(): " << strerror(errno);
     return false;
   }
   return true;

--- a/include/ola/base/Credentials.h
+++ b/include/ola/base/Credentials.h
@@ -129,7 +129,7 @@ bool SetGID(gid_t new_gid);
 /**
  * @brief Get the supplementary group ID's of the process
  * @param size the size of the list to place group ID's in
- * @param list the list to place group ID's
+ * @param[out] list the list to place group ID's
  * @note when size 0 is given, the list remain's untouched and only the
  * number of group ID's is returned
  * @return on error -1, otherwise the number of group ID's

--- a/include/ola/base/Credentials.h
+++ b/include/ola/base/Credentials.h
@@ -120,6 +120,32 @@ bool SetGID(gid_t new_gid);
 
 /**
  * @}
+ *
+ * @name Get / Set supplementary group IDs
+ * @{
+ */
+
+
+/**
+ * @brief Get the supplementary group ID's of the process
+ * @param size the size of the list to place group ID's in
+ * @param list the list to place group ID's
+ * @note when size 0 is given, the list remain's untouched and only the
+ * number of group ID's is returned
+ * @return on error -1, otherwise the number of group ID's
+ */
+int GetGroups(int size, gid_t list[]);
+
+/**
+ * @brief Set the supplementary group ID's of the process
+ * @param size the size of the list of ID's
+ * @param list pointer to the list of ID's
+ * @return true on success, false otherwise
+ */
+bool SetGroups(size_t size, const gid_t *list);
+
+/**
+ * @}
  */
 
 /**

--- a/include/ola/base/Credentials.h
+++ b/include/ola/base/Credentials.h
@@ -67,14 +67,14 @@ bool SupportsUIDs();
 
 /**
  * @brief Get the real UID of the process.
- * @param uid is the variable to receive the real UID
+ * @param[out] uid is the variable to receive the real UID
  * @return true on success, false otherwise
  */
 bool GetUID(uid_t* uid);
 
 /**
  * @brief Get the effective UID of the process.
- * @param euid is the variable to receive the effective UID
+ * @param[out] euid is the variable to receive the effective UID
  * @return true on success, false otherwise
  */
 bool GetEUID(uid_t* euid);
@@ -97,14 +97,14 @@ bool SetUID(uid_t new_uid);
 
 /**
  * @brief Get the real Group ID
- * @param gid is the variable to receive the real Group ID
+ * @param[out] gid is the variable to receive the real Group ID
  * @return true on success, false otherwise
  */
 bool GetGID(gid_t* gid);
 
 /**
  * @brief Get the effective group ID
- * @param egid is the variable to receive the effective Group ID
+ * @param[out] egid is the variable to receive the effective Group ID
  * @return true on success, false otherwise
  */
 bool GetEGID(gid_t* egid);


### PR DESCRIPTION
This commit removes the complaints of rpmlint while pacakging ola for fedora,
but also makes the api more complete.