### PR TITLE
Change the universes limits to 512 for e.131 sACN

### DIFF
--- a/plugins/e131/E131Plugin.cpp
+++ b/plugins/e131/E131Plugin.cpp
@@ -203,12 +203,12 @@ bool E131Plugin::SetDefaultPreferences() {
 
   save |= m_preferences->SetDefaultValue(
       INPUT_PORT_COUNT_KEY,
-      UIntValidator(0, 128),
+      UIntValidator(0, 512),
       DEFAULT_PORT_COUNT);
 
   save |= m_preferences->SetDefaultValue(
       OUTPUT_PORT_COUNT_KEY,
-      UIntValidator(0, 128),
+      UIntValidator(0, 512),
       DEFAULT_PORT_COUNT);
 
   save |= m_preferences->SetDefaultValue(IP_KEY, StringValidator(true), "");


### PR DESCRIPTION
We talked about the output universe limits on google groups:
https://groups.google.com/forum/m/#!topic/open-lighting/eABrg9dMfSU

Turns out the 128 limits in/out e.131 sACN universes were empiric. After some testing I am able to run more than 200 full universes with 60fps outputs.

So I think it could be good to have a higher limit.