### PR TITLE
Python RpcChannel incorrectly decodes message header on big-endian architectures

### DIFF
--- a/python/ola/rpc/StreamRpcChannel.py
+++ b/python/ola/rpc/StreamRpcChannel.py
@@ -240,7 +240,7 @@ class StreamRpcChannel(service.RpcChannel):
         if not raw_header:
           # not enough data yet
           return
-        header = struct.unpack('<L', raw_header)[0]
+        header = struct.unpack('=L', raw_header)[0]
         version, size = self._DecodeHeader(header)
 
         if version != self.PROTOCOL_VERSION:


### PR DESCRIPTION
On the C++ server side, RpcChannel::SendMsg in common/rpc/RpcChannel.cpp does

```
   RpcHeader::EncodeHeader(&header, PROTOCOL_VERSION,
                                length - sizeof(header));
```

to produce the header, and then sends it by doing

```
  output.replace(
      0, sizeof(header),
      reinterpret_cast<const char*>(&header), sizeof(header));

  ssize_t ret = m_descriptor->Send(
      reinterpret_cast<const uint8_t*>(output.data()), length);
```

On the OLA client program's Python API side, `StreamRpcChannel::_ProcessIncomingData` in `ola/rpc/StreamRpcChannel.py` does

        header = struct.unpack('<L', raw_header)[0]
        version, size = self._DecodeHeader(header)

to receive the header. The problem is that the format string passed to `struct.unpack` instructs to use little-endian decoding instead of the native byte order.

Consequently, on big-endian architectures

> Protocol mismatch: 0 != 1

is printed and the value of `expected_size` becomes `100663312`, which results in the OLA client program never receiving a message, since `_ProcessIncomingData` will always return at `# not enough data yet`). The program will use more and more CPU as `self._buffer` grows larger since `data_size = sum([len(s) for s in self._buffer])` will take increasingly longer to execute.

Tested on powerpc.