### PR TITLE
Add warning if JavaScript is off, #1046

### DIFF
--- a/olad/www/mobile.html
+++ b/olad/www/mobile.html
@@ -447,6 +447,15 @@
       <div id="plugin_frame"><div id="plugin_list"></div></div>
       <div id="plugin_info_frame"></div>
     </div>
+    <noscript>
+      <br>
+      <p align="center">
+        <strong>This interface requires JavaScript to function. If you
+        would like to use it, enable JavaScript and reload the
+        page.</strong>
+      </p>
+      <br>
+    </noscript>
 
 
     <div id='footer'>

--- a/olad/www/new/index.html
+++ b/olad/www/new/index.html
@@ -89,6 +89,15 @@
  </div>
  <!-- /.container-fluid -->
 </nav>
+<noscript>
+  <br>
+  <p align="center">
+    <strong>This interface requires JavaScript to function. If you
+      would like to use it, enable JavaScript and reload the
+      page.</strong>
+  </p>
+  <br>
+</noscript>
 <div id="errorAlerts"></div>
 <div id="ngView" class="container-fluid" ng-view></div>
 <div class="modal fade" id="errorModal" tabindex="-1" role="dialog"

--- a/olad/www/ola.html
+++ b/olad/www/ola.html
@@ -1015,6 +1015,15 @@
         </div>
       </div>
     </div>
+    <noscript>
+      <br>
+      <p align="center">
+        <strong>This interface requires JavaScript to function. If you
+        would like to use it, enable JavaScript and reload the
+        page.</strong>
+      </p>
+      <br>
+    </noscript>
 
     <div id='footer'>
       OLA &copy; 2005-2015 Open Lighting Project<br>


### PR DESCRIPTION
Now a simple `noscript` tag will inform the user why the `olad` web
interface is not working, and how to remedy the situation.