### PR TITLE
Final NEWS update and release 0.10.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-x/5/2016 ola-0.10.2
+21/5/2016 ola-0.10.2
  Features:
  * Add support for Enttec USB Pro Mk 2 B
  * Make DNS-SD functionality optional at build time

--- a/NEWS
+++ b/NEWS
@@ -1,26 +1,23 @@
-x/y/2016 ola-0.10.2
+x/5/2016 ola-0.10.2
  Features:
  * Add support for Enttec USB Pro Mk 2 B
  * Make DNS-SD functionality optional at build time
  * Name multi-port Enttec Pro Mk 2 ports to match the labelling on the device
-
- API:
- * 
 
  RDM Tests:
  * Correct expected NAck type in GetSettingDescriptionsMixin, as spotted by ETC
  * Fix the mute all devices test for controllers that don't support discovery
 
  Bugs:
+ * Allow one slot devices to correctly be set to any start address, including
+   512
  * Check Python numpy exists during configure if required
  * Allow the PID location to be set in the rdmpro_sniffer
  * Actually decode PID param data when requested when using the
    logic_rdm_sniffer
  * Correct the operation of the --full-rdm option in the logic_rdm_sniffer,
    this inverts how it used to behave
-
- Internal:
- *
+ * Fix a segfault with the client if auto start is off or olad fails to start
 
 29/2/2016 ola-0.10.1
  Features:

--- a/config/ola_version.m4
+++ b/config/ola_version.m4
@@ -19,7 +19,7 @@
 # -----------------------------------------------------------------------------
 m4_define([ola_major_version], [0])
 m4_define([ola_minor_version], [10])
-m4_define([ola_revision_version], [1])
+m4_define([ola_revision_version], [2])
 
 m4_define([ola_version],
       [ola_major_version.ola_minor_version.ola_revision_version])

--- a/config/ola_version.m4
+++ b/config/ola_version.m4
@@ -19,7 +19,7 @@
 # -----------------------------------------------------------------------------
 m4_define([ola_major_version], [0])
 m4_define([ola_minor_version], [10])
-m4_define([ola_revision_version], [2])
+m4_define([ola_revision_version], [1])
 
 m4_define([ola_version],
       [ola_major_version.ola_minor_version.ola_revision_version])

--- a/data/rdm/manufacturer_pids.proto
+++ b/data/rdm/manufacturer_pids.proto
@@ -5166,6 +5166,198 @@ manufacturer {
     set_sub_device_range: ROOT_DEVICE
   }
   pid {
+    name: "GOBO3_ANIMATION_START"
+    value: 33567
+    get_request {
+    }
+    get_response {
+      field {
+        type: UINT8
+        name: "gobo3_animation_start"
+        label {
+          value: 0
+          label: "Position Off"
+        }
+        label {
+          value: 1
+          label: "Position 1"
+        }
+        label {
+          value: 2
+          label: "Position 2"
+        }
+        label {
+          value: 3
+          label: "Position 3"
+        }
+        label {
+          value: 4
+          label: "Position 4"
+        }
+        label {
+          value: 5
+          label: "Position 5"
+        }
+        label {
+          value: 6
+          label: "Position 6"
+        }
+        label {
+          value: 7
+          label: "Position 7"
+        }
+        label {
+          value: 8
+          label: "Position 8"
+        }
+      }
+    }
+    get_sub_device_range: ROOT_DEVICE
+    set_request {
+      field {
+        type: UINT8
+        name: "gobo3_animation_start"
+        label {
+          value: 0
+          label: "Position Off"
+        }
+        label {
+          value: 1
+          label: "Position 1"
+        }
+        label {
+          value: 2
+          label: "Position 2"
+        }
+        label {
+          value: 3
+          label: "Position 3"
+        }
+        label {
+          value: 4
+          label: "Position 4"
+        }
+        label {
+          value: 5
+          label: "Position 5"
+        }
+        label {
+          value: 6
+          label: "Position 6"
+        }
+        label {
+          value: 7
+          label: "Position 7"
+        }
+        label {
+          value: 8
+          label: "Position 8"
+        }
+      }
+    }
+    set_response {
+    }
+    set_sub_device_range: ROOT_DEVICE
+  }
+  pid {
+    name: "GOBO3_ANIMATION_END"
+    value: 33568
+    get_request {
+    }
+    get_response {
+      field {
+        type: UINT8
+        name: "gobo3_animation_end"
+        label {
+          value: 0
+          label: "Position Off"
+        }
+        label {
+          value: 1
+          label: "Position 1"
+        }
+        label {
+          value: 2
+          label: "Position 2"
+        }
+        label {
+          value: 3
+          label: "Position 3"
+        }
+        label {
+          value: 4
+          label: "Position 4"
+        }
+        label {
+          value: 5
+          label: "Position 5"
+        }
+        label {
+          value: 6
+          label: "Position 6"
+        }
+        label {
+          value: 7
+          label: "Position 7"
+        }
+        label {
+          value: 8
+          label: "Position 8"
+        }
+        label {
+          value: 9
+          label: "Position 9"
+        }
+      }
+    }
+    get_sub_device_range: ROOT_DEVICE
+    set_request {
+      field {
+        type: UINT8
+        name: "gobo3_animation_start"
+        label {
+          value: 0
+          label: "Position Off"
+        }
+        label {
+          value: 1
+          label: "Position 1"
+        }
+        label {
+          value: 2
+          label: "Position 2"
+        }
+        label {
+          value: 3
+          label: "Position 3"
+        }
+        label {
+          value: 4
+          label: "Position 4"
+        }
+        label {
+          value: 5
+          label: "Position 5"
+        }
+        label {
+          value: 6
+          label: "Position 6"
+        }
+        label {
+          value: 7
+          label: "Position 7"
+        }
+        label {
+          value: 8
+          label: "Position 8"
+        }
+      }
+    }
+    set_response {
+    }
+    set_sub_device_range: ROOT_DEVICE
+  }
+  pid {
     name: "PAN_TILT_SPEED"
     value: 33792
     get_request {
@@ -8386,4 +8578,4 @@ manufacturer {
     set_sub_device_range: ROOT_DEVICE
   }
 }
-version: 1455773308
+version: 1458491190

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ola (0.10.2-1) unstable; urgency=low
+
+  * New upstream release
+
+ -- Simon Newton <nomis52@gmail.com>  Sat, 21 May 2016 22:27:00 +0100
+
 ola (0.10.1-1) unstable; urgency=low
 
   * New upstream release
@@ -15,7 +21,6 @@ ola (0.9.8-1) unstable; urgency=low
   * New upstream release
 
  -- Simon Newton <nomis52@gmail.com>  Wed, 30 Sep 2015 19:28:21 -0700
-
 
 ola (0.9.7-1) unstable; urgency=low
 


### PR DESCRIPTION
I suspect this may fail Travis due to the following in our ola_protoc which the latest clang 3.9.0 has brought up. I don't know your thoughts but I'd be tempted to force it through regardless, then we can work on fixing this issue for the next release.

```
common/rpc/TestServiceService.pb.cpp:137:14: error: binding dereferenced null
      pointer to reference has undefined behavior [-Werror,-Wnull-dereference]
      return *reinterpret_cast< ::google::protobuf::Message*>(NULL);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
common/rpc/TestServiceService.pb.cpp:153:14: error: binding dereferenced null
      pointer to reference has undefined behavior [-Werror,-Wnull-dereference]
      return *reinterpret_cast< ::google::protobuf::Message*>(NULL);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```