### PR TITLE
Force gnu++98 mode if compiler supports 98 and 11 modes so we keep std::auto_ptr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
      - g++-5
     packages: &core_build_clang_latest
      - *core_build
-     - clang-3.9
+     - clang-3.4
 
 matrix:
   fast_finish: true
@@ -53,7 +53,7 @@ matrix:
            - *core_build_clang_latest
           sources:
            - ubuntu-toolchain-r-test
-           - llvm-toolchain-precise
+           # - llvm-toolchain-precise
     - os: linux
       compiler: gcc
       env: TASK='compile'
@@ -167,7 +167,7 @@ before_install:
  - if [ "$TRAVIS_OS_NAME" == "linux" -a \( "$TASK" = "compile" -o "$TASK" = "coverage" -o "$TASK" = "doxygen" \) -a "$CXX" = "g++" ]; then export CXX="ccache g++-5" CC="ccache gcc-5"; fi
  - if [ "$TASK" = "coverity" -a "$CXX" = "g++" ]; then export CXX="ccache g++-4.9" CC="ccache gcc-4.9"; fi
 #Use the latest clang if we're compiling with clang
- - if [ "$TRAVIS_OS_NAME" == "linux" -a "$CXX" = "clang++" ]; then export CXX="clang++-3.9" CC="clang-3.9"; fi
+ - if [ "$TRAVIS_OS_NAME" == "linux" -a "$CXX" = "clang++" ]; then export CXX="clang++-3.4" CC="clang-3.4"; fi
 #Report the compiler version
  - $CXX --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -167,7 +167,7 @@ before_install:
  - if [ "$TRAVIS_OS_NAME" == "linux" -a \( "$TASK" = "compile" -o "$TASK" = "coverage" -o "$TASK" = "doxygen" \) -a "$CXX" = "g++" ]; then export CXX="ccache g++-5" CC="ccache gcc-5"; fi
  - if [ "$TASK" = "coverity" -a "$CXX" = "g++" ]; then export CXX="ccache g++-4.9" CC="ccache gcc-4.9"; fi
 #Use the latest clang if we're compiling with clang
- - if [ "$TRAVIS_OS_NAME" == "linux" -a "$CXX" = "clang++" ]; then export CXX="clang++-3.4" CC="clang-3.4"; fi
+# - if [ "$TRAVIS_OS_NAME" == "linux" -a "$CXX" = "clang++" ]; then export CXX="clang++-3.4" CC="clang-3.4"; fi
 #Report the compiler version
  - $CXX --version
 

--- a/common/rpc/Makefile.mk
+++ b/common/rpc/Makefile.mk
@@ -1,4 +1,3 @@
-
 built_sources += \
     common/rpc/Rpc.pb.cc \
     common/rpc/Rpc.pb.h \

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,43 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_MKDIR_P
 
+# check if the compiler supports -std=gnu++98
+AC_MSG_CHECKING(for -std=gnu++98 support)
+old_cppflags=$CPPFLAGS
+CPPFLAGS="${CPPFLAGS} -std=gnu++98 -Wall -Werror"
+AC_CACHE_VAL(ac_cv_gnu_plus_plus_98,
+  AC_COMPILE_IFELSE(
+     [AC_LANG_PROGRAM([], [])],
+     [ac_cv_gnu_plus_plus_98=yes],
+     [ac_cv_gnu_plus_plus_98=no])
+)
+CPPFLAGS=$old_cppflags
+AC_MSG_RESULT($ac_cv_gnu_plus_plus_98)
+
+AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_98], [test "x$ac_cv_gnu_plus_plus_98" = xyes])
+
+# check if the compiler supports -std=gnu++11
+AC_MSG_CHECKING(for -std=gnu++11 support)
+old_cppflags=$CPPFLAGS
+CPPFLAGS="${CPPFLAGS} -std=gnu++11 -Wall -Werror"
+AC_CACHE_VAL(ac_cv_gnu_plus_plus_11,
+  AC_COMPILE_IFELSE(
+     [AC_LANG_PROGRAM([], [])],
+     [ac_cv_gnu_plus_plus_11=yes],
+     [ac_cv_gnu_plus_plus_11=no])
+)
+CPPFLAGS=$old_cppflags
+AC_MSG_RESULT($ac_cv_gnu_plus_plus_11)
+
+AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_11], [test "x$ac_cv_gnu_plus_plus_11" = xyes])
+
+# force us into gnu++98 mode if necessary
+AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
+      [AS_IF([test "x$ac_cv_gnu_plus_plus_98" = xyes],
+             [CPPFLAGS="$CPPFLAGS -std=gnu++98"],
+             [AC_MSG_WARN([OLA requires std::auto_ptr support.])])
+      ])
+
 # Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_RESOLV
@@ -156,44 +193,6 @@ CPPFLAGS=$old_cppflags
 AC_MSG_RESULT($ac_cv_rdynamic)
 
 AM_CONDITIONAL([SUPPORTS_RDYNAMIC], [test "x$ac_cv_rdynamic" = xyes])
-
-# check if the compiler supports -std=gnu++98
-AC_MSG_CHECKING(for -std=gnu++98 support)
-old_cppflags=$CPPFLAGS
-CPPFLAGS="${CPPFLAGS} -std=gnu++98 -Wall -Werror"
-AC_CACHE_VAL(ac_cv_gnu_plus_plus_98,
-  AC_COMPILE_IFELSE(
-     [AC_LANG_PROGRAM([], [])],
-     [ac_cv_gnu_plus_plus_98=yes],
-     [ac_cv_gnu_plus_plus_98=no])
-)
-CPPFLAGS=$old_cppflags
-AC_MSG_RESULT($ac_cv_gnu_plus_plus_98)
-
-AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_98], [test "x$ac_cv_gnu_plus_plus_98" = xyes])
-
-# check if the compiler supports -std=gnu++11
-AC_MSG_CHECKING(for -std=gnu++11 support)
-old_cppflags=$CPPFLAGS
-CPPFLAGS="${CPPFLAGS} -std=gnu++11 -Wall -Werror"
-AC_CACHE_VAL(ac_cv_gnu_plus_plus_11,
-  AC_COMPILE_IFELSE(
-     [AC_LANG_PROGRAM([], [])],
-     [ac_cv_gnu_plus_plus_11=yes],
-     [ac_cv_gnu_plus_plus_11=no])
-)
-CPPFLAGS=$old_cppflags
-AC_MSG_RESULT($ac_cv_gnu_plus_plus_11)
-
-AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_11], [test "x$ac_cv_gnu_plus_plus_11" = xyes])
-
-# force us into gnu++98 mode if necessary
-AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
-      [AS_IF([test "x$ac_cv_gnu_plus_plus_98" = xyes],
-             [CFLAGS="$CFLAGS -std=gnu++98"
-              CXXFLAGS="$CXXFLAGS -std=gnu++98"],
-             [AC_MSG_WARN([OLA requires std::auto_ptr support.])])
-      ])
 
 # check for ipv6 support - taken from unp
 AC_MSG_CHECKING(for IPv6 support)

--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,44 @@ AC_MSG_RESULT($ac_cv_rdynamic)
 
 AM_CONDITIONAL([SUPPORTS_RDYNAMIC], [test "x$ac_cv_rdynamic" = xyes])
 
+# check if the compiler supports -std=gnu++98
+AC_MSG_CHECKING(for -std=gnu++98 support)
+old_cppflags=$CPPFLAGS
+CPPFLAGS="${CPPFLAGS} -std=gnu++98 -Wall -Werror"
+AC_CACHE_VAL(ac_cv_gnu_plus_plus_98,
+  AC_COMPILE_IFELSE(
+     [AC_LANG_PROGRAM([], [])],
+     [ac_cv_gnu_plus_plus_98=yes],
+     [ac_cv_gnu_plus_plus_98=no])
+)
+CPPFLAGS=$old_cppflags
+AC_MSG_RESULT($ac_cv_gnu_plus_plus_98)
+
+AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_98], [test "x$ac_cv_gnu_plus_plus_98" = xyes])
+
+# check if the compiler supports -std=gnu++11
+AC_MSG_CHECKING(for -std=gnu++11 support)
+old_cppflags=$CPPFLAGS
+CPPFLAGS="${CPPFLAGS} -std=gnu++11 -Wall -Werror"
+AC_CACHE_VAL(ac_cv_gnu_plus_plus_11,
+  AC_COMPILE_IFELSE(
+     [AC_LANG_PROGRAM([], [])],
+     [ac_cv_gnu_plus_plus_11=yes],
+     [ac_cv_gnu_plus_plus_11=no])
+)
+CPPFLAGS=$old_cppflags
+AC_MSG_RESULT($ac_cv_gnu_plus_plus_11)
+
+AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_11], [test "x$ac_cv_gnu_plus_plus_11" = xyes])
+
+# force us into gnu++98 mode if necessary
+AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
+      [AS_IF([test "x$ac_cv_gnu_plus_plus_98" = xyes],
+             [CFLAGS="$CFLAGS -std=gnu++98"
+              CXXFLAGS="$CXXFLAGS -std=gnu++98"],
+             [AC_MSG_WARN([OLA requires std::auto_ptr support.])])
+      ])
+
 # check for ipv6 support - taken from unp
 AC_MSG_CHECKING(for IPv6 support)
 AC_CACHE_VAL(ac_cv_ipv6,

--- a/configure.ac
+++ b/configure.ac
@@ -36,30 +36,30 @@ AC_PROG_MKDIR_P
 
 # check if the compiler supports -std=gnu++98
 AC_MSG_CHECKING(for -std=gnu++98 support)
-old_cppflags=$CPPFLAGS
-CPPFLAGS="${CPPFLAGS} -std=gnu++98 -Wall -Werror"
+old_cxxflags=$CXXFLAGS
+CXXFLAGS="${CXXFLAGS} -std=gnu++98 -Wall -Werror"
 AC_CACHE_VAL(ac_cv_gnu_plus_plus_98,
   AC_COMPILE_IFELSE(
      [AC_LANG_PROGRAM([], [])],
      [ac_cv_gnu_plus_plus_98=yes],
      [ac_cv_gnu_plus_plus_98=no])
 )
-CPPFLAGS=$old_cppflags
+CXXFLAGS=$old_cxxflags
 AC_MSG_RESULT($ac_cv_gnu_plus_plus_98)
 
 AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_98], [test "x$ac_cv_gnu_plus_plus_98" = xyes])
 
 # check if the compiler supports -std=gnu++11
 AC_MSG_CHECKING(for -std=gnu++11 support)
-old_cppflags=$CPPFLAGS
-CPPFLAGS="${CPPFLAGS} -std=gnu++11 -Wall -Werror"
+old_cxxflags=$CXXFLAGS
+CXXFLAGS="${CXXFLAGS} -std=gnu++11 -Wall -Werror"
 AC_CACHE_VAL(ac_cv_gnu_plus_plus_11,
   AC_COMPILE_IFELSE(
      [AC_LANG_PROGRAM([], [])],
      [ac_cv_gnu_plus_plus_11=yes],
      [ac_cv_gnu_plus_plus_11=no])
 )
-CPPFLAGS=$old_cppflags
+CXXFLAGS=$old_cxxflags
 AC_MSG_RESULT($ac_cv_gnu_plus_plus_11)
 
 AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_11], [test "x$ac_cv_gnu_plus_plus_11" = xyes])
@@ -67,7 +67,7 @@ AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_11], [test "x$ac_cv_gnu_plus_plus_11" = x
 # force us into gnu++98 mode if necessary
 AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
       [AS_IF([test "x$ac_cv_gnu_plus_plus_98" = xyes],
-             [CPPFLAGS="$CPPFLAGS -std=gnu++98"],
+             [CXXFLAGS="$CXXFLAGS -std=gnu++98"],
              [AC_MSG_WARN([OLA requires std::auto_ptr support.])])
       ])
 


### PR DESCRIPTION
Closes #1028 .