### PR TITLE
Work around <ernno.h> include failure on mips.

### DIFF
--- a/common/io/ExtendedSerial.cpp
+++ b/common/io/ExtendedSerial.cpp
@@ -42,7 +42,7 @@
 // ERANGE, EDOM, or EILSEQ, causing a spectacular compile failure there.
 //
 // Explicitly include <cerrno> now to avoid the issue.
-#include <cerrno>
+#include <errno.h>
 #include <asm/termios.h>
 #endif
 

--- a/common/io/ExtendedSerial.cpp
+++ b/common/io/ExtendedSerial.cpp
@@ -42,7 +42,9 @@
 // ERANGE, EDOM, or EILSEQ, causing a spectacular compile failure there.
 //
 // Explicitly include <cerrno> now to avoid the issue.
+#if HAVE_ERRNO_H
 #include <errno.h>
+#endif
 #include <asm/termios.h>
 #endif
 

--- a/common/io/ExtendedSerial.cpp
+++ b/common/io/ExtendedSerial.cpp
@@ -42,9 +42,7 @@
 // ERANGE, EDOM, or EILSEQ, causing a spectacular compile failure there.
 //
 // Explicitly include <cerrno> now to avoid the issue.
-#if HAVE_ERRNO_H
 #include <errno.h>
-#endif
 #include <asm/termios.h>
 #endif
 

--- a/common/io/ExtendedSerial.cpp
+++ b/common/io/ExtendedSerial.cpp
@@ -36,6 +36,13 @@
 
 #ifdef HAVE_ASM_TERMIOS_H
 // use this not standard termios for custom baud rates
+//
+// On mips architectures, <asm/termios.h> sets some cpp macros which cause
+// <cerrno> (included by <ostream>, used by <ola/Logging.h>) to not define
+// ERANGE, EDOM, or EILSEQ, causing a spectacular compile failure there.
+//
+// Explicitly include <cerrno> now to avoid the issue.
+#include <cerrno>
 #include <asm/termios.h>
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -75,8 +75,11 @@ AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
 AC_HEADER_DIRENT
 AC_HEADER_RESOLV
 AC_HEADER_STDC
+# Required headers (we cannot work without these)
+AC_CHECK_HEADERS([errno.h],[],[AC_MSG_ERROR([Missing a required header])])
+# Other headers (we can work without these, but may need to modify things slightly)
 AC_CHECK_HEADERS([arpa/inet.h bits/sockaddr.h fcntl.h float.h limits.h malloc.h netinet/in.h stdint.h stdlib.h string.h strings.h sys/file.h sys/ioctl.h sys/socket.h sys/time.h sys/timeb.h syslog.h termios.h unistd.h])
-AC_CHECK_HEADERS([asm/termios.h assert.h dlfcn.h endian.h errno.h execinfo.h \
+AC_CHECK_HEADERS([asm/termios.h assert.h dlfcn.h endian.h execinfo.h \
                   linux/if_packet.h math.h net/ethernet.h stropts.h \
                   sys/param.h sys/types.h sys/uio.h sysexits.h])
 AC_CHECK_HEADERS([winsock2.h])


### PR DESCRIPTION
On mips architectures, `<asm/termios.h>` sets some cpp macros which cause
`<cerrno>` (included by `<ostream>`, used by `<ola/Logging.h>`) to not define
ERANGE, EDOM, or EILSEQ, causing a spectacular [compile failure](https://buildd.debian.org/status/fetch.php?pkg=ola&arch=mips&ver=0.10.2-2&stamp=1472208742) there.

Explicitly include `<cerrno>` at the right location to avoid the issue.