### PR TITLE
Update GPIO and SPI pin limits for CHIP

### DIFF
--- a/plugins/gpio/GPIODriver.cpp
+++ b/plugins/gpio/GPIODriver.cpp
@@ -123,7 +123,7 @@ bool GPIODriver::SetupGPIO() {
    */
   const string direction("out");
   bool failed = false;
-  vector<uint8_t>::const_iterator iter = m_options.gpio_pins.begin();
+  vector<uint16_t>::const_iterator iter = m_options.gpio_pins.begin();
   for (; iter != m_options.gpio_pins.end(); ++iter) {
     std::ostringstream str;
     str << GPIO_BASE_DIR << static_cast<int>(*iter) << "/value";

--- a/plugins/gpio/GPIODriver.h
+++ b/plugins/gpio/GPIODriver.h
@@ -47,7 +47,7 @@ class GPIODriver : private ola::thread::Thread {
     /**
      * @brief A list of I/O pins to map to slots.
      */
-    std::vector<uint8_t> gpio_pins;
+    std::vector<uint16_t> gpio_pins;
 
     /**
      * @brief The DMX512 start address of the first pin

--- a/plugins/gpio/GPIODriver.h
+++ b/plugins/gpio/GPIODriver.h
@@ -86,7 +86,7 @@ class GPIODriver : private ola::thread::Thread {
    * @brief Get a list of the GPIO pins controlled by this driver.
    * @returns A list of GPIO pin numbers.
    */
-  std::vector<uint8_t> PinList() const { return m_options.gpio_pins; }
+  std::vector<uint16_t> PinList() const { return m_options.gpio_pins; }
 
   /**
    * @brief Set the values of the GPIO pins from the data in the DMXBuffer.

--- a/plugins/gpio/GPIOPlugin.cpp
+++ b/plugins/gpio/GPIOPlugin.cpp
@@ -78,7 +78,7 @@ bool GPIOPlugin::StartHook() {
       continue;
     }
 
-    uint8_t pin;
+    uint16_t pin;
     if (!StringToInt(*iter, &pin)) {
       OLA_WARN << "Invalid value for GPIO pin: " << *iter;
       return false;

--- a/plugins/gpio/GPIOPort.cpp
+++ b/plugins/gpio/GPIOPort.cpp
@@ -44,11 +44,11 @@ bool GPIOOutputPort::Init() {
 }
 
 string GPIOOutputPort::Description() const {
-  vector<uint8_t> pins = m_driver->PinList();
+  vector<uint16_t> pins = m_driver->PinList();
   std::ostringstream str;
   str << "Pins ";
 
-  vector<uint8_t>::const_iterator iter = pins.begin();
+  vector<uint16t>::const_iterator iter = pins.begin();
   while (iter != pins.end()) {
     str << static_cast<unsigned int>(*iter++);
     if (iter != pins.end())

--- a/plugins/gpio/GPIOPort.cpp
+++ b/plugins/gpio/GPIOPort.cpp
@@ -19,12 +19,12 @@
  */
 
 #include "plugins/gpio/GPIOPort.h"
-#include "ola/StringUtils.h"
 
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include "ola/StringUtils.h"
 #include "plugins/gpio/GPIODriver.h"
 
 namespace ola {
@@ -49,7 +49,6 @@ string GPIOOutputPort::Description() const {
   std::ostringstream str;
   str << "Pins ";
   str << ola::StringJoin(", ", pins);
-  }
   return str.str();
 }
 

--- a/plugins/gpio/GPIOPort.cpp
+++ b/plugins/gpio/GPIOPort.cpp
@@ -46,10 +46,7 @@ bool GPIOOutputPort::Init() {
 
 string GPIOOutputPort::Description() const {
   vector<uint16_t> pins = m_driver->PinList();
-  std::ostringstream str;
-  str << "Pins ";
-  str << ola::StringJoin(", ", pins);
-  return str.str();
+  return "Pins " + ola::StringJoin(", ", pins);
 }
 
 bool GPIOOutputPort::WriteDMX(const DmxBuffer &buffer,

--- a/plugins/gpio/GPIOPort.cpp
+++ b/plugins/gpio/GPIOPort.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "plugins/gpio/GPIOPort.h"
+#include "ola/StringUtils.h"
 
 #include <sstream>
 #include <string>
@@ -47,12 +48,7 @@ string GPIOOutputPort::Description() const {
   vector<uint16_t> pins = m_driver->PinList();
   std::ostringstream str;
   str << "Pins ";
-
-  vector<uint16_t>::const_iterator iter = pins.begin();
-  while (iter != pins.end()) {
-    str << static_cast<unsigned int>(*iter++);
-    if (iter != pins.end())
-      str << ", ";
+  str << ola::StringJoin(", ", pins);
   }
   return str.str();
 }

--- a/plugins/gpio/GPIOPort.cpp
+++ b/plugins/gpio/GPIOPort.cpp
@@ -48,7 +48,7 @@ string GPIOOutputPort::Description() const {
   std::ostringstream str;
   str << "Pins ";
 
-  vector<uint16t>::const_iterator iter = pins.begin();
+  vector<uint16_t>::const_iterator iter = pins.begin();
   while (iter != pins.end()) {
     str << static_cast<unsigned int>(*iter++);
     if (iter != pins.end())

--- a/plugins/spi/SPIBackend.cpp
+++ b/plugins/spi/SPIBackend.cpp
@@ -258,7 +258,7 @@ bool HardwareBackend::SetupGPIO() {
    */
   const string direction("out");
   bool failed = false;
-  vector<uint8_t>::const_iterator iter = m_gpio_pins.begin();
+  vector<uint16_t>::const_iterator iter = m_gpio_pins.begin();
   for (; iter != m_gpio_pins.end(); ++iter) {
     std::ostringstream str;
     str << "/sys/class/gpio/gpio" << static_cast<int>(*iter) << "/value";

--- a/plugins/spi/SPIBackend.h
+++ b/plugins/spi/SPIBackend.h
@@ -66,7 +66,7 @@ class HardwareBackend : public ola::thread::Thread,
   struct Options {
     // Which GPIO bits to use to select the output. The number of outputs
     // will be 2 ** gpio_pins.size();
-    std::vector<uint8_t> gpio_pins;
+    std::vector<uint16_t> gpio_pins;
   };
 
   HardwareBackend(const Options &options,

--- a/plugins/spi/SPIBackend.h
+++ b/plugins/spi/SPIBackend.h
@@ -137,7 +137,7 @@ class HardwareBackend : public ola::thread::Thread,
 
   // GPIO members
   GPIOFds m_gpio_fds;
-  const std::vector<uint8_t> m_gpio_pins;
+  const std::vector<uint16_t> m_gpio_pins;
   std::vector<bool> m_gpio_pin_state;
 
   void SetupOutputs(Outputs *outputs);

--- a/plugins/spi/SPIDevice.h
+++ b/plugins/spi/SPIDevice.h
@@ -86,7 +86,7 @@ class SPIDevice: public ola::Device {
   static const char SPI_DEVICE_NAME[];
   static const char HARDWARE_BACKEND[];
   static const char SOFTWARE_BACKEND[];
-  static const uint8_t MAX_GPIO_PIN = 1023;
+  static const uint16_t MAX_GPIO_PIN = 1023;
 };
 }  // namespace spi
 }  // namespace plugin

--- a/plugins/spi/SPIDevice.h
+++ b/plugins/spi/SPIDevice.h
@@ -86,7 +86,7 @@ class SPIDevice: public ola::Device {
   static const char SPI_DEVICE_NAME[];
   static const char HARDWARE_BACKEND[];
   static const char SOFTWARE_BACKEND[];
-  static const uint16_t MAX_GPIO_PIN = 25;
+  static const uint8_t MAX_GPIO_PIN = 1023;
 };
 }  // namespace spi
 }  // namespace plugin


### PR DESCRIPTION
New PR because I broke the old one pretty bad. 

This updates maximum pin values to use uint_16 (from uint_8) because the CHIP's GPIO starts above 255 in all cases, making GPIO and SPI assignments fail due to overflow.