### PR TITLE
Remove replacing -I with -isystem

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,10 @@ AM_DISTCHECK_CONFIGURE_FLAGS = --enable-python-libs
 # COMMON_TESTING_FLAGS_ONLY_WARNINGS
 # The common C++ flags for testing with (non-fatal) warnings enabled. Use this
 # for 3rd party code that does not build correctly with COMMON_TESTING_FLAGS.
+#
+# COMMON_TESTING_PROTOBUF_FLAGS
+# The common C++ flags for testing with some warnings protobuf code throws
+# disabled.
 COMMON_CXXFLAGS_ONLY_WARNINGS = \
     -I$(top_srcdir)/include \
     -I$(top_builddir)/include \
@@ -53,6 +57,7 @@ COMMON_TESTING_FLAGS_ONLY_WARNINGS = $(COMMON_CXXFLAGS_ONLY_WARNINGS) \
                                      -DTEST_BUILD_DIR=\"$(builddir)\"
 
 COMMON_TESTING_FLAGS = $(COMMON_TESTING_FLAGS_ONLY_WARNINGS)
+COMMON_TESTING_PROTOBUF_FLAGS = $(COMMON_TESTING_FLAGS)
 
 # The genererated protobuf files don't compile with -Werror on win32 so we
 # disable fatal warnings on WIN32.
@@ -61,6 +66,7 @@ if FATAL_WARNINGS
   COMMON_CXXFLAGS += -Werror
   COMMON_PROTOBUF_CXXFLAGS += -Werror -Wno-error=unused-parameter
   COMMON_TESTING_FLAGS += -Werror
+  COMMON_TESTING_PROTOBUF_FLAGS += -Werror -Wno-error=unused-parameter
 endif
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,9 +64,11 @@ COMMON_TESTING_PROTOBUF_FLAGS = $(COMMON_TESTING_FLAGS)
 if ! USING_WIN32
 if FATAL_WARNINGS
   COMMON_CXXFLAGS += -Werror
-  COMMON_PROTOBUF_CXXFLAGS += -Werror -Wno-error=unused-parameter
+  COMMON_PROTOBUF_CXXFLAGS += -Werror -Wno-error=unused-parameter \
+                              -Wno-error=deprecated-declarations
   COMMON_TESTING_FLAGS += -Werror
-  COMMON_TESTING_PROTOBUF_FLAGS += -Werror -Wno-error=unused-parameter
+  COMMON_TESTING_PROTOBUF_FLAGS += -Werror -Wno-error=unused-parameter \
+                                   -Wno-error=deprecated-declarations
 endif
 endif
 

--- a/common/rdm/Makefile.mk
+++ b/common/rdm/Makefile.mk
@@ -95,7 +95,8 @@ common_rdm_DiscoveryAgentTester_LDADD = $(COMMON_TESTING_LIBS)
 common_rdm_PidStoreTester_SOURCES = \
     common/rdm/DescriptorConsistencyCheckerTest.cpp \
     common/rdm/PidStoreTest.cpp
-common_rdm_PidStoreTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
+common_rdm_PidStoreTester_CXXFLAGS = $(COMMON_TESTING_FLAGS) \
+                                     $(COMMON_PROTOBUF_CXXFLAGS)
 common_rdm_PidStoreTester_LDADD = $(COMMON_TESTING_LIBS)
 
 common_rdm_RDMHelperTester_SOURCES = common/rdm/RDMHelperTest.cpp
@@ -109,7 +110,8 @@ common_rdm_RDMMessageTester_SOURCES = \
     common/rdm/RDMMessageInterationTest.cpp \
     common/rdm/StringMessageBuilderTest.cpp \
     common/rdm/VariableFieldSizeCalculatorTest.cpp
-common_rdm_RDMMessageTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
+common_rdm_RDMMessageTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)\
+                                       $(COMMON_PROTOBUF_CXXFLAGS)
 common_rdm_RDMMessageTester_LDADD = $(COMMON_TESTING_LIBS)
 
 common_rdm_RDMAPITester_SOURCES = \

--- a/common/rdm/Makefile.mk
+++ b/common/rdm/Makefile.mk
@@ -95,8 +95,7 @@ common_rdm_DiscoveryAgentTester_LDADD = $(COMMON_TESTING_LIBS)
 common_rdm_PidStoreTester_SOURCES = \
     common/rdm/DescriptorConsistencyCheckerTest.cpp \
     common/rdm/PidStoreTest.cpp
-common_rdm_PidStoreTester_CXXFLAGS = $(COMMON_TESTING_FLAGS) \
-                                     $(COMMON_PROTOBUF_CXXFLAGS)
+common_rdm_PidStoreTester_CXXFLAGS = $(COMMON_TESTING_PROTOBUF_FLAGS)
 common_rdm_PidStoreTester_LDADD = $(COMMON_TESTING_LIBS)
 
 common_rdm_RDMHelperTester_SOURCES = common/rdm/RDMHelperTest.cpp
@@ -110,8 +109,7 @@ common_rdm_RDMMessageTester_SOURCES = \
     common/rdm/RDMMessageInterationTest.cpp \
     common/rdm/StringMessageBuilderTest.cpp \
     common/rdm/VariableFieldSizeCalculatorTest.cpp
-common_rdm_RDMMessageTester_CXXFLAGS = $(COMMON_TESTING_FLAGS) \
-                                       $(COMMON_PROTOBUF_CXXFLAGS)
+common_rdm_RDMMessageTester_CXXFLAGS = $(COMMON_TESTING_PROTOBUF_FLAGS)
 common_rdm_RDMMessageTester_LDADD = $(COMMON_TESTING_LIBS)
 
 common_rdm_RDMAPITester_SOURCES = \

--- a/common/rdm/Makefile.mk
+++ b/common/rdm/Makefile.mk
@@ -110,7 +110,7 @@ common_rdm_RDMMessageTester_SOURCES = \
     common/rdm/RDMMessageInterationTest.cpp \
     common/rdm/StringMessageBuilderTest.cpp \
     common/rdm/VariableFieldSizeCalculatorTest.cpp
-common_rdm_RDMMessageTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)\
+common_rdm_RDMMessageTester_CXXFLAGS = $(COMMON_TESTING_FLAGS) \
                                        $(COMMON_PROTOBUF_CXXFLAGS)
 common_rdm_RDMMessageTester_LDADD = $(COMMON_TESTING_LIBS)
 

--- a/config/ola.m4
+++ b/config/ola.m4
@@ -24,9 +24,6 @@ AC_DEFUN([PROTOBUF_SUPPORT],
 AC_REQUIRE_CPP()
 PKG_CHECK_MODULES(libprotobuf, [protobuf >= $1])
 
-# We want to replace -I with -isystem here to disable errors in the .h files
-# See https://groups.google.com/forum/#!topic/open-lighting/39Mj0KXlCIk
-libprotobuf_CFLAGS=`echo $libprotobuf_CFLAGS | sed 's/-I/-isystem /'`
 AC_SUBST([libprotobuf_CFLAGS])
 
 AC_ARG_WITH([protoc],

--- a/examples/Makefile.mk
+++ b/examples/Makefile.mk
@@ -15,7 +15,7 @@ noinst_LTLIBRARIES += examples/libolaconfig.la
 examples_libolaconfig_la_SOURCES = \
     examples/OlaConfigurator.h \
     examples/OlaConfigurator.cpp
-
+examples_libolaconfig_la_CXXFLAGS = $(COMMON_PROTOBUF_CXXFLAGS)
 
 # PROGRAMS
 ##################################################

--- a/examples/Makefile.mk
+++ b/examples/Makefile.mk
@@ -31,6 +31,7 @@ bin_PROGRAMS += \
 if USE_E131
 bin_PROGRAMS += examples/ola_e131
 examples_ola_e131_SOURCES = examples/ola-e131.cpp
+examples_ola_e131_CXXFLAGS = $(COMMON_PROTOBUF_CXXFLAGS)
 examples_ola_e131_LDADD = examples/libolaconfig.la \
                           $(EXAMPLE_COMMON_LIBS) \
                           plugins/e131/messages/libolae131conf.la \
@@ -40,6 +41,7 @@ endif
 if USE_USBPRO
 bin_PROGRAMS += examples/ola_usbpro
 examples_ola_usbpro_SOURCES = examples/ola-usbpro.cpp
+examples_ola_usbpro_CXXFLAGS = $(COMMON_PROTOBUF_CXXFLAGS)
 examples_ola_usbpro_LDADD = examples/libolaconfig.la \
                             $(EXAMPLE_COMMON_LIBS) \
                             plugins/usbpro/messages/libolausbproconf.la \
@@ -49,6 +51,7 @@ endif
 if USE_ARTNET
 bin_PROGRAMS += examples/ola_artnet
 examples_ola_artnet_SOURCES = examples/ola-artnet.cpp
+examples_ola_artnet_CXXFLAGS = $(COMMON_PROTOBUF_CXXFLAGS)
 examples_ola_artnet_LDADD = examples/libolaconfig.la \
                             $(EXAMPLE_COMMON_LIBS) \
                             plugins/artnet/messages/libolaartnetconf.la \

--- a/ola/Makefile.mk
+++ b/ola/Makefile.mk
@@ -27,6 +27,7 @@ ola_libola_la_SOURCES = \
     ola/OlaClientCore.cpp \
     ola/OlaClientWrapper.cpp \
     ola/StreamingClient.cpp
+ola_libola_la_CXXFLAGS = $(COMMON_PROTOBUF_CXXFLAGS)
 ola_libola_la_LDFLAGS = -version-info 1:1:0
 ola_libola_la_LIBADD = common/libolacommon.la
 

--- a/olad/Makefile.mk
+++ b/olad/Makefile.mk
@@ -49,6 +49,7 @@ olad_libolaserver_la_SOURCES = $(ola_server_sources) \
                                olad/OlaServer.cpp \
                                olad/OlaDaemon.cpp
 olad_libolaserver_la_CXXFLAGS = $(COMMON_CXXFLAGS) \
+                                $(COMMON_PROTOBUF_CXXFLAGS) \
                                 -DHTTP_DATA_DIR=\"${www_datadir}\"
 olad_libolaserver_la_LIBADD = $(PLUGIN_LIBS) \
                               common/libolacommon.la \

--- a/olad/Makefile.mk
+++ b/olad/Makefile.mk
@@ -90,7 +90,8 @@ COMMON_OLAD_TEST_LDADD = $(COMMON_TESTING_LIBS) $(libprotobuf_LIBS) \
 olad_OlaTester_SOURCES = \
     olad/PluginManagerTest.cpp \
     olad/OlaServerServiceImplTest.cpp
-olad_OlaTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
+olad_OlaTester_CXXFLAGS = $(COMMON_TESTING_FLAGS) \
+                          $(COMMON_PROTOBUF_CXXFLAGS)
 olad_OlaTester_LDADD = $(COMMON_OLAD_TEST_LDADD)
 
 CLEANFILES += olad/ola-output.conf

--- a/olad/Makefile.mk
+++ b/olad/Makefile.mk
@@ -89,8 +89,7 @@ COMMON_OLAD_TEST_LDADD = $(COMMON_TESTING_LIBS) $(libprotobuf_LIBS) \
 olad_OlaTester_SOURCES = \
     olad/PluginManagerTest.cpp \
     olad/OlaServerServiceImplTest.cpp
-olad_OlaTester_CXXFLAGS = $(COMMON_TESTING_FLAGS) \
-                          $(COMMON_PROTOBUF_CXXFLAGS)
+olad_OlaTester_CXXFLAGS = $(COMMON_TESTING_PROTOBUF_FLAGS)
 olad_OlaTester_LDADD = $(COMMON_OLAD_TEST_LDADD)
 
 CLEANFILES += olad/ola-output.conf

--- a/olad/Makefile.mk
+++ b/olad/Makefile.mk
@@ -48,8 +48,7 @@ lib_LTLIBRARIES += olad/libolaserver.la
 olad_libolaserver_la_SOURCES = $(ola_server_sources) \
                                olad/OlaServer.cpp \
                                olad/OlaDaemon.cpp
-olad_libolaserver_la_CXXFLAGS = $(COMMON_CXXFLAGS) \
-                                $(COMMON_PROTOBUF_CXXFLAGS) \
+olad_libolaserver_la_CXXFLAGS = $(COMMON_PROTOBUF_CXXFLAGS) \
                                 -DHTTP_DATA_DIR=\"${www_datadir}\"
 olad_libolaserver_la_LIBADD = $(PLUGIN_LIBS) \
                               common/libolacommon.la \

--- a/olad/plugin_api/Makefile.mk
+++ b/olad/plugin_api/Makefile.mk
@@ -52,7 +52,8 @@ COMMON_OLAD_PLUGIN_API_TEST_LDADD = \
     common/libolacommon.la
 
 olad_plugin_api_ClientTester_SOURCES = olad/plugin_api/ClientTest.cpp
-olad_plugin_api_ClientTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
+olad_plugin_api_ClientTester_CXXFLAGS = $(COMMON_TESTING_FLAGS) \
+                                        $(COMMON_PROTOBUF_CXXFLAGS)
 olad_plugin_api_ClientTester_LDADD = $(COMMON_OLAD_PLUGIN_API_TEST_LDADD)
 
 olad_plugin_api_DeviceTester_SOURCES = olad/plugin_api/DeviceManagerTest.cpp \

--- a/olad/plugin_api/Makefile.mk
+++ b/olad/plugin_api/Makefile.mk
@@ -28,7 +28,8 @@ olad_plugin_api_libolaserverplugininterface_la_SOURCES = \
     olad/plugin_api/Universe.cpp \
     olad/plugin_api/UniverseStore.cpp \
     olad/plugin_api/UniverseStore.h
-olad_plugin_api_libolaserverplugininterface_la_CXXFLAGS = $(COMMON_CXXFLAGS)
+olad_plugin_api_libolaserverplugininterface_la_CXXFLAGS = $(COMMON_CXXFLAGS) \
+    $(COMMON_PROTOBUF_CXXFLAGS)
 olad_plugin_api_libolaserverplugininterface_la_LIBADD = \
     common/libolacommon.la \
     common/web/libolaweb.la \

--- a/olad/plugin_api/Makefile.mk
+++ b/olad/plugin_api/Makefile.mk
@@ -52,8 +52,7 @@ COMMON_OLAD_PLUGIN_API_TEST_LDADD = \
     common/libolacommon.la
 
 olad_plugin_api_ClientTester_SOURCES = olad/plugin_api/ClientTest.cpp
-olad_plugin_api_ClientTester_CXXFLAGS = $(COMMON_TESTING_FLAGS) \
-                                        $(COMMON_PROTOBUF_CXXFLAGS)
+olad_plugin_api_ClientTester_CXXFLAGS = $(COMMON_TESTING_PROTOBUF_FLAGS)
 olad_plugin_api_ClientTester_LDADD = $(COMMON_OLAD_PLUGIN_API_TEST_LDADD)
 
 olad_plugin_api_DeviceTester_SOURCES = olad/plugin_api/DeviceManagerTest.cpp \

--- a/olad/plugin_api/Makefile.mk
+++ b/olad/plugin_api/Makefile.mk
@@ -28,7 +28,7 @@ olad_plugin_api_libolaserverplugininterface_la_SOURCES = \
     olad/plugin_api/Universe.cpp \
     olad/plugin_api/UniverseStore.cpp \
     olad/plugin_api/UniverseStore.h
-olad_plugin_api_libolaserverplugininterface_la_CXXFLAGS = $(COMMON_CXXFLAGS) \
+olad_plugin_api_libolaserverplugininterface_la_CXXFLAGS = \
     $(COMMON_PROTOBUF_CXXFLAGS)
 olad_plugin_api_libolaserverplugininterface_la_LIBADD = \
     common/libolacommon.la \

--- a/plugins/artnet/Makefile.mk
+++ b/plugins/artnet/Makefile.mk
@@ -20,6 +20,7 @@ plugins_artnet_libolaartnet_la_SOURCES = \
     plugins/artnet/ArtNetDevice.h \
     plugins/artnet/ArtNetPort.cpp \
     plugins/artnet/ArtNetPort.h
+plugins_artnet_libolaartnet_la_CXXFLAGS = $(COMMON_PROTOBUF_CXXFLAGS)
 plugins_artnet_libolaartnet_la_LIBADD = \
     olad/plugin_api/libolaserverplugininterface.la \
     plugins/artnet/libolaartnetnode.la \

--- a/plugins/e131/Makefile.mk
+++ b/plugins/e131/Makefile.mk
@@ -12,6 +12,7 @@ plugins_e131_libolae131_la_SOURCES = \
     plugins/e131/E131Plugin.h \
     plugins/e131/E131Port.cpp \
     plugins/e131/E131Port.h
+plugins_e131_libolae131_la_CXXFLAGS = $(COMMON_PROTOBUF_CXXFLAGS)
 plugins_e131_libolae131_la_LIBADD = \
     olad/plugin_api/libolaserverplugininterface.la \
     plugins/e131/messages/libolae131conf.la \

--- a/plugins/usbpro/Makefile.mk
+++ b/plugins/usbpro/Makefile.mk
@@ -54,6 +54,7 @@ plugins_usbpro_libolausbpro_la_SOURCES = \
     plugins/usbpro/UsbSerialDevice.h \
     plugins/usbpro/UsbSerialPlugin.cpp \
     plugins/usbpro/UsbSerialPlugin.h
+plugins_usbpro_libolausbpro_la_CXXFLAGS = $(COMMON_PROTOBUF_CXXFLAGS)
 plugins_usbpro_libolausbpro_la_LIBADD = \
     olad/plugin_api/libolaserverplugininterface.la \
     plugins/usbpro/libolausbprowidget.la \

--- a/protoc/Makefile.mk
+++ b/protoc/Makefile.mk
@@ -15,6 +15,7 @@ protoc_ola_protoc_plugin_SOURCES = \
     protoc/StrUtil.cpp \
     protoc/StrUtil.h \
 	protoc/ola-protoc-generator-plugin.cpp
+protoc_ola_protoc_plugin_CXXFLAGS = $(COMMON_PROTOBUF_CXXFLAGS)
 protoc_ola_protoc_plugin_LDADD = $(libprotobuf_LIBS) -lprotoc
 
 else


### PR DESCRIPTION
Building OLA with a GCC 6 cross-toolchain fails:

```
/usr/bin/arm-linux-g++ -DHAVE_CONFIG_H -I.   -D_LARGEFILE_SOURCE
-D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -I./include -I./include
-Wall -Wformat -W -isystem
/usr/arm-buildroot-linux-gnueabihf/sysroot/usr/include -pthread
-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os
-pthread -c -o libs/acn/e131_transmit_test.o
libs/acn/e131_transmit_test.cpp
/usr/bin/arm-linux-g++ -DHAVE_CONFIG_H -I.   -D_LARGEFILE_SOURCE
-D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -I./include -I./include
-Wall -Wformat -W -isystem
/usr/arm-buildroot-linux-gnueabihf/sysroot/usr/include -pthread
-D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -Os
-pthread -c -o libs/acn/E131TestFramework.o
libs/acn/E131TestFramework.cpp
In file included from
/opt/ext-toolchain/arm-buildroot-linux-gnueabihf/include/c++/6.1.0/ext/string_conversions.h:41:0,
                 from
/opt/ext-toolchain/arm-buildroot-linux-gnueabihf/include/c++/6.1.0/bits/basic_string.h:5402,
                 from
/opt/ext-toolchain/arm-buildroot-linux-gnueabihf/include/c++/6.1.0/string:52,
                 from ./tools/ola_trigger/config.ypp:2:
/opt/ext-toolchain/arm-buildroot-linux-gnueabihf/include/c++/6.1.0/cstdlib:75:25:
fatal error: stdlib.h: No such file or directory
 #include_next <stdlib.h>
                         ^
compilation terminated.
```

The C++ library in GCC 6 now provides its own `<stdlib.h>` header that
wraps the C library header of the same name, so in `<cstdlib>` the
header include

```
#include <stdlib.h>
```

has become

```
#include_next <stdlib.h>
```

`#include_next` is sensitive to the order of directories in the
preprocessor's search path, so if that order is changed with `-isystem`
then the compiler can't find the right header:

```
[1] /usr/arm-buildroot-linux-gnueabihf/sysroot/usr/include
[2] /opt/ext-toolchain/arm-buildroot-linux-gnueabihf/include/c++/6.1.0
[..]
End of search list.
```

`<cstdlib>` is located in [2] whereas `<stdlib.h>` (C library header) is
in [1]. In this case, the `#include_next <stdlib.h>` statement in
`<cstdlib>`, located in [2], is evaluated **after** the search path [1],
so the compiler does not find the right system header.

The problem is that the OLA build system replaces the `-I` in the CFLAGS
from libprotobuf with `-isystem` to fix some warnings treated as errors
in the libprotobuf header files.

`-isystem` should be used to suppress warnings in system headers only
and the libprotobuf header files are not system files.

The correct fix is to compile with less restrictions and remove
`-Werror` for the build.

As using `-isystem` is reordering GCCs search path and using `-isystem`
is really not necessary, remove the faulty replacement of `-I`.

Closes: #1125
