### PR TITLE
Cleaned up error handling of close system calls. They are now mostly …

### DIFF
--- a/common/base/Init.cpp
+++ b/common/base/Init.cpp
@@ -372,7 +372,7 @@ void Daemonise() {
   }
 
   for (int fd = 0; fd < maxfd; fd++) {
-    close(fd);
+    close(fd); // ignore errors. Hope for the best. :-)
   }
 
   // send stdout, in and err to /dev/null

--- a/common/file/Util.cpp
+++ b/common/file/Util.cpp
@@ -137,7 +137,7 @@ bool FindMatchingFiles(const string &directory,
 
   if (readdir_r(dp, &dir_ent, &dir_ent_p)) {
     OLA_WARN << "readdir_r(" << directory << "): " << strerror(errno);
-    closedir(dp);
+    closedir(dp); // ignore possible error, we've reported an error already. 
     return false;
   }
 
@@ -152,7 +152,7 @@ bool FindMatchingFiles(const string &directory,
     }
     if (readdir_r(dp, &dir_ent, &dir_ent_p)) {
       OLA_WARN << "readdir_r(" << directory << "): " << strerror(errno);
-      closedir(dp);
+      closedir(dp);// ignore possible error, we've reported an error already. 
       return false;
     }
   }

--- a/common/io/EPoller.cpp
+++ b/common/io/EPoller.cpp
@@ -158,7 +158,9 @@ EPoller::EPoller(ExportMap *export_map, Clock* clock)
 
 EPoller::~EPoller() {
   if (m_epoll_fd != INVALID_DESCRIPTOR) {
-    close(m_epoll_fd);
+    if (close(m_epoll_fd)) {
+      OLA_WARN << "close: " << strerror(errno);
+    }
   }
 
   {

--- a/common/io/KQueuePoller.cpp
+++ b/common/io/KQueuePoller.cpp
@@ -106,7 +106,9 @@ KQueuePoller::KQueuePoller(ExportMap *export_map, Clock* clock)
 
 KQueuePoller::~KQueuePoller() {
   if (m_kqueue_fd != INVALID_DESCRIPTOR) {
-    close(m_kqueue_fd);
+    if (close(m_kqueue_fd)) {
+      OLA_WARN << "close: " << strerror(errno);
+    }
   }
 
   {

--- a/common/network/Socket.cpp
+++ b/common/network/Socket.cpp
@@ -184,7 +184,7 @@ bool UDPSocket::Close() {
 #else
   if (close(fd)) {
 #endif  // _WIN32
-    OLA_WARN << "close() failed, " << strerror(errno);
+    OLA_WARN << "UDPSocket close() failed, " << strerror(errno);
     return false;
   }
   return true;

--- a/common/network/SocketCloser.cpp
+++ b/common/network/SocketCloser.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "ola/network/SocketCloser.h"
+#include <ola/Logging.h>
 
 #include <errno.h>
 #include <string.h>
@@ -35,7 +36,9 @@ SocketCloser::~SocketCloser() {
 #ifdef _WIN32
     closesocket(m_fd);
 #else
-    close(m_fd);
+    if (close(m_fd)) {
+       OLA_WARN << "socketcloser close: " << strerror(errno);
+    }
 #endif  // _WIN32
   }
 }

--- a/common/network/TCPConnector.cpp
+++ b/common/network/TCPConnector.cpp
@@ -83,7 +83,9 @@ void PendingTCPConnection::Close() {
 #ifdef _WIN32
   close(m_handle.m_handle.m_fd);
 #else
-  close(m_handle);
+  if (close(m_handle)) {
+    OLA_WARN << "PendingTCPConnection close: " << strerror(errno);
+  }
 #endif  // _WIN32
 }
 
@@ -145,7 +147,7 @@ TCPConnector::TCPConnectionID TCPConnector::Connect(
       int error = errno;
       OLA_WARN << "connect() to " << endpoint << " returned, "
                << strerror(error);
-      close(sd);
+      close(sd); // we're already on an error return path, don't report followup errors.
       callback->Run(-1, error);
       return 0;
     }

--- a/common/network/TCPConnectorTest.cpp
+++ b/common/network/TCPConnectorTest.cpp
@@ -303,7 +303,9 @@ void TCPConnectorTest::OnConnect(int fd, int error) {
 #ifdef _WIN32
     closesocket(fd);
 #else
-    close(fd);
+    if (close(fd)) {
+      OLA_WARN << "TCPConnectorTest close: " << strerror(errno);
+    }
 #endif  // _WIN32
   }
   m_sucessfull_calls++;

--- a/common/network/TCPSocket.cpp
+++ b/common/network/TCPSocket.cpp
@@ -103,7 +103,9 @@ bool TCPSocket::Close() {
 #ifdef _WIN32
     closesocket(m_handle.m_handle.m_fd);
 #else
-    close(m_handle);
+    if (close(m_handle)) {
+      OLA_WARN << "close: " << strerror(errno);
+    }
 #endif  // _WIN32
     m_handle = ola::io::INVALID_DESCRIPTOR;
   }

--- a/common/testing/MockUDPSocket.cpp
+++ b/common/testing/MockUDPSocket.cpp
@@ -93,7 +93,12 @@ bool MockUDPSocket::Close() {
 #ifdef _WIN32
     closesocket(m_dummy_handle.m_handle.m_fd);
 #else
-    close(m_dummy_handle);
+    if (close(m_dummy_handle)) {
+       OLA_WARN << "close: " << strerror(errno);
+       // XXX What can a caller do if it fails? -- REW
+       // Update: the UDPSocket close function also returns false when it fails. 
+       return false; 
+    }
 #endif  // _WIN32
   }
   return true;

--- a/plugins/gpio/GPIODriver.cpp
+++ b/plugins/gpio/GPIODriver.cpp
@@ -148,7 +148,9 @@ bool GPIODriver::SetupGPIO() {
                << strerror(errno);
       failed = true;
     }
-    close(fd);
+    if (close(fd)) {
+       OLA_WARN << "setupGPIO close: " << strerror(errno);
+    }
 
     m_gpio_pins.push_back(pin);
   }
@@ -205,7 +207,9 @@ bool GPIODriver::UpdateGPIOPins(const DmxBuffer &dmx) {
 void GPIODriver::CloseGPIOFDs() {
   GPIOPins::iterator iter = m_gpio_pins.begin();
   for (; iter != m_gpio_pins.end(); ++iter) {
-    close(iter->fd);
+    if (close(iter->fd)) {
+      OLA_WARN << "closeGPIOFDs: " << strerror(errno);
+    }
   }
   m_gpio_pins.clear();
 }

--- a/plugins/karate/KaratePlugin.cpp
+++ b/plugins/karate/KaratePlugin.cpp
@@ -62,7 +62,9 @@ bool KaratePlugin::StartHook() {
     // first check if it's there
     int fd;
     if (ola::io::Open(*iter, O_WRONLY, &fd)) {
-      close(fd);
+      if (close(fd)) {
+	OLA_WARN << "close device: " << strerror(errno);
+      }
       KarateDevice *device = new KarateDevice(
           this,
           KARATE_DEVICE_NAME,

--- a/plugins/opendmx/OpenDmxThread.cpp
+++ b/plugins/opendmx/OpenDmxThread.cpp
@@ -102,8 +102,10 @@ void *OpenDmxThread::Run() {
         // if you unplug the dongle
         OLA_WARN << "Error writing to device: " << strerror(errno);
 
-        if (close(m_fd) < 0)
-          OLA_WARN << "Close failed " << strerror(errno);
+        if (close(m_fd)) {
+	  // XXX policy throughout is now: don't warn if the close fails on the error path. -- REW
+          OLA_WARN << "OpenDmxThread: close failed: " << strerror(errno);
+	}
         m_fd = INVALID_FD;
       }
     }

--- a/plugins/spi/SPIBackend.cpp
+++ b/plugins/spi/SPIBackend.cpp
@@ -282,7 +282,9 @@ bool HardwareBackend::SetupGPIO() {
                << strerror(errno);
       failed = true;
     }
-    close(fd);
+    if (close(fd)) {
+      OLA_WARN << "HardwareBackend SetupGPIO close: " << strerror(errno);
+    }
   }
 
   if (failed) {
@@ -295,7 +297,9 @@ bool HardwareBackend::SetupGPIO() {
 void HardwareBackend::CloseGPIOFDs() {
   GPIOFds::iterator iter = m_gpio_fds.begin();
   for (; iter != m_gpio_fds.end(); ++iter) {
-    close(*iter);
+    if (close(*iter)) {
+      OLA_WARN << "CloseGPIOFDs: " << strerror(errno);
+    }
   }
   m_gpio_fds.clear();
 }

--- a/plugins/spi/SPIWriter.cpp
+++ b/plugins/spi/SPIWriter.cpp
@@ -69,8 +69,11 @@ SPIWriter::SPIWriter(const string &spi_device,
 }
 
 SPIWriter::~SPIWriter() {
-  if (m_fd >= 0)
-    close(m_fd);
+  if (m_fd >= 0) {
+    if (close(m_fd)) {
+      OLA_WARN << "close: " << strerror(errno);
+    }
+  }
 }
 
 bool SPIWriter::Init() {

--- a/plugins/uartdmx/UartDmxPlugin.cpp
+++ b/plugins/uartdmx/UartDmxPlugin.cpp
@@ -72,7 +72,9 @@ bool UartDmxPlugin::StartHook() {
     }
 
     // can open device, so shut the temporary file descriptor
-    close(fd);
+    if (close(fd)) {  
+      OLA_WARN << "StartHook close: " << strerror(errno);
+    }
     std::auto_ptr<UartDmxDevice> device(new UartDmxDevice(
         this, m_preferences, PLUGIN_NAME, *iter));
 

--- a/plugins/uartdmx/UartWidget.cpp
+++ b/plugins/uartdmx/UartWidget.cpp
@@ -83,14 +83,14 @@ bool UartWidget::Close() {
     return true;
   }
 
-  if (close(m_fd) > 0) {
+  if (close(m_fd)) {
     OLA_WARN << Name() << " error closing";
     m_fd = NOT_OPEN;
     return false;
-  } else {
-    m_fd = NOT_OPEN;
-    return true;
   }
+
+  m_fd = NOT_OPEN;
+  return true;
 }
 
 bool UartWidget::IsOpen() const {


### PR DESCRIPTION
…uniform.


The return value of "close" is documented to be zero on success. So if (close (..)) works. 
On error paths (except for ONE existing case) the close return value is not checked. 

I've been naughty. In this commit I've also downgraded the "Device /dev/ttyUSB0 doesn't exist, so there's no point trying to acquire a lock" message in Serial.CPP from INFO to DEBUG. It clutters the output when running with -l 3, and nothing is happening. 

What I would like to do too, as a cleanup is for where WIN32 is different create a 
CLOSEHandle(h) define that evaluates to CloseHandle(toHandle (h)) on WIN32 and to close(h) on others. This removes 5 lines-of-code at a time, all over that source file..... Is my suggestion for the name of the define sensible (acceptable with C++ programming practises?)


