### PR TITLE
GCC7 Implicit-fallthrough

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,8 @@ x/y/2017 ola-0.10.4
  * 
 
  Bugs:
- * 
+ * Implement OLA_FALLTHROUGH macro for adding fallthrough attributes to 
+   switchcases in gcc versions higher than 7 #1193 Debian #853583
 
  Internal:
  *

--- a/common/utils/StringUtils.cpp
+++ b/common/utils/StringUtils.cpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <vector>
 #include "ola/StringUtils.h"
+#include "ola/base/Macro.h"
 
 namespace ola {
 
@@ -416,9 +417,11 @@ void CapitalizeLabel(string *s) {
     switch (*iter) {
       case '-':
         // fall through, also convert to space then capitalize next character
+	OLA_FALLTHROUGH
       case '_':
         *iter = ' ';
         // fall through, also convert to space then capitalize next character
+	OLA_FALLTHROUGH
       case ' ':
         capitalize = true;
         break;

--- a/common/utils/StringUtils.cpp
+++ b/common/utils/StringUtils.cpp
@@ -417,11 +417,11 @@ void CapitalizeLabel(string *s) {
     switch (*iter) {
       case '-':
         // fall through, also convert to space then capitalize next character
-	OLA_FALLTHROUGH
+        OLA_FALLTHROUGH
       case '_':
         *iter = ' ';
         // fall through, also convert to space then capitalize next character
-	OLA_FALLTHROUGH
+        OLA_FALLTHROUGH
       case ' ':
         capitalize = true;
         break;

--- a/common/web/JsonLexer.cpp
+++ b/common/web/JsonLexer.cpp
@@ -31,6 +31,7 @@
 #include <string>
 #include "ola/Logging.h"
 #include "ola/web/Json.h"
+#include "ola/base/Macro.h"
 
 namespace ola {
 namespace web {
@@ -196,6 +197,7 @@ static bool ParseNumber(const char **input, JsonParserInterface *parser) {
       case '-':
         negative_exponent = true;
         // fall through
+        OLA_FALLTHROUGH
       case '+':
         (*input)++;
         break;

--- a/common/web/JsonPatchParser.cpp
+++ b/common/web/JsonPatchParser.cpp
@@ -27,6 +27,7 @@
 #include "ola/stl/STLUtils.h"
 #include "ola/web/Json.h"
 #include "ola/web/JsonLexer.h"
+#include "ola/base/Macro.h"
 
 namespace ola {
 namespace web {
@@ -159,6 +160,7 @@ void JsonPatchParser::OpenArray() {
       m_parser_depth = 0;
       m_state = VALUE;
       // fall through
+      OLA_FALLTHROUGH
     case VALUE:
       m_parser_depth++;
       m_parser.OpenArray();
@@ -203,6 +205,7 @@ void JsonPatchParser::OpenObject() {
       m_parser_depth = 0;
       m_state = VALUE;
       // fall through
+      OLA_FALLTHROUGH
     case VALUE:
       m_parser_depth++;
       m_parser.OpenObject();

--- a/examples/ola-dmxconsole.cpp
+++ b/examples/ola-dmxconsole.cpp
@@ -446,6 +446,7 @@ void changepalette(int p) {
     default:
       palette_number = 0;
       // fall through, use 0 as default palette
+      OLA_FALLTHROUGH
     case 0:
       init_pair(CHANNEL, COLOR_BLACK, COLOR_CYAN);
       init_pair(ZERO, COLOR_BLACK, COLOR_WHITE);

--- a/examples/ola-dmxmonitor.cpp
+++ b/examples/ola-dmxmonitor.cpp
@@ -563,6 +563,7 @@ void DmxMonitor::ChangePalette(int p) {
     default:
       m_palette_number = 0;
       // fall through, use 0 as default palette
+      OLA_FALLTHROUGH
     case 0:
       init_pair(CHANNEL, COLOR_BLACK, COLOR_CYAN);
       init_pair(ZERO, COLOR_BLACK, COLOR_WHITE);

--- a/include/ola/base/Macro.h
+++ b/include/ola/base/Macro.h
@@ -65,7 +65,8 @@
 /**
  * @def OLA_FALLTHROUGH
  * @brief Mark switch cases as fallthrough when required
- * @note we are not using [[fallthrough]]; because C++98 compatibility
+ * @note We are not currently using [[fallthrough]]; because we need C++98
+ * compatibility
  *
  * @examplepara
  *   @code

--- a/include/ola/base/Macro.h
+++ b/include/ola/base/Macro.h
@@ -63,6 +63,30 @@
 #endif  // __GNUC__
 
 /**
+ * @def OLA_FALLTHROUGH
+ * @brief Mark switch cases as fallthrough when required
+ *
+ * @examplepara
+ *   @code
+ *   switch (cond) {
+ *     case 'foo':
+ *       doFoo();
+ *       //after foo fallthrough to bar because $REASON
+ *       OLA_FALLTHROUGH
+ *     case 'bar':
+ *   @endcode
+ */
+#ifdef __GNUC__
+#if __GNUC__ >= 7
+#define OLA_FALLTHROUGH __attribute__ ((fallthrough));
+#else
+#define OLA_FALLTHROUGH
+#endif // __GNUC__ >= 7
+#else
+#define OLA_FALLTHROUGH
+#endif // __GNUC__
+
+/**
  * @def STATIC_ASSERT
  * @brief Compile time assert().
  *

--- a/include/ola/base/Macro.h
+++ b/include/ola/base/Macro.h
@@ -65,6 +65,7 @@
 /**
  * @def OLA_FALLTHROUGH
  * @brief Mark switch cases as fallthrough when required
+ * @note we are not using [[fallthrough]]; because C++98 compatibility
  *
  * @examplepara
  *   @code

--- a/include/ola/base/Macro.h
+++ b/include/ola/base/Macro.h
@@ -71,7 +71,7 @@
  *   switch (cond) {
  *     case 'foo':
  *       doFoo();
- *       //after foo fallthrough to bar because $REASON
+ *       // after foo fallthrough to bar because $REASON
  *       OLA_FALLTHROUGH
  *     case 'bar':
  *   @endcode
@@ -81,10 +81,10 @@
 #define OLA_FALLTHROUGH __attribute__ ((fallthrough));
 #else
 #define OLA_FALLTHROUGH
-#endif // __GNUC__ >= 7
+#endif  // __GNUC__ >= 7
 #else
 #define OLA_FALLTHROUGH
-#endif // __GNUC__
+#endif  // __GNUC__
 
 /**
  * @def STATIC_ASSERT

--- a/plugins/espnet/RunLengthDecoder.cpp
+++ b/plugins/espnet/RunLengthDecoder.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <ola/Constants.h>
+#include <ola/base/Macro.h>
 #include "plugins/espnet/RunLengthDecoder.h"
 
 namespace ola {
@@ -49,6 +50,7 @@ void RunLengthDecoder::Decode(DmxBuffer *dst,
       case ESCAPE_VALUE:
         value++;
         // fall through
+        OLA_FALLTHROUGH
       default:
         dst->SetChannel(i, *value);
         i++;

--- a/plugins/usbpro/BaseRobeWidget.cpp
+++ b/plugins/usbpro/BaseRobeWidget.cpp
@@ -120,7 +120,7 @@ void BaseRobeWidget::ReceiveMessage() {
       } while (m_header.som != SOM);
       m_state = RECV_PACKET_TYPE;
 
-      // if we don't return fallthrough
+      // if we don't return, fallthrough
       OLA_FALLTHROUGH
     case RECV_PACKET_TYPE:
       m_descriptor->Receive(&m_header.packet_type, 1, count);
@@ -128,7 +128,7 @@ void BaseRobeWidget::ReceiveMessage() {
         return;
       m_state = RECV_SIZE_LO;
 
-      // if we don't return fallthrough
+      // if we don't return, fallthrough
       OLA_FALLTHROUGH
     case RECV_SIZE_LO:
       m_descriptor->Receive(&m_header.len, 1, count);
@@ -136,7 +136,7 @@ void BaseRobeWidget::ReceiveMessage() {
         return;
       m_state = RECV_SIZE_HI;
 
-      // if we don't return fallthrough
+      // if we don't return, fallthrough
       OLA_FALLTHROUGH
     case RECV_SIZE_HI:
       m_descriptor->Receive(&m_header.len_hi, 1, count);
@@ -152,7 +152,7 @@ void BaseRobeWidget::ReceiveMessage() {
       m_bytes_received = 0;
       m_state = RECV_HEADER_CRC;
 
-      // if we don't return fallthrough
+      // if we don't return, fallthrough
       OLA_FALLTHROUGH
     case RECV_HEADER_CRC:
       m_descriptor->Receive(&m_header.header_crc, 1, count);
@@ -174,7 +174,7 @@ void BaseRobeWidget::ReceiveMessage() {
       else
         m_state = RECV_CRC;
 
-      // if we don't return fallthrough
+      // if we don't return, fallthrough
       OLA_FALLTHROUGH
     case RECV_BODY:
       m_descriptor->Receive(
@@ -191,7 +191,7 @@ void BaseRobeWidget::ReceiveMessage() {
 
       m_state = RECV_CRC;
 
-      // if we don't return fallthrough
+      // if we don't return, fallthrough
       OLA_FALLTHROUGH
     case RECV_CRC:
       // check this is a valid frame
@@ -214,7 +214,7 @@ void BaseRobeWidget::ReceiveMessage() {
       }
       m_state = PRE_SOM;
 
-      // if we don't return fallthrough
+      // if we don't return, fallthrough
       OLA_FALLTHROUGH
   }
   return;

--- a/plugins/usbpro/BaseRobeWidget.cpp
+++ b/plugins/usbpro/BaseRobeWidget.cpp
@@ -21,6 +21,7 @@
 #include <string.h>
 #include "ola/Constants.h"
 #include "ola/Logging.h"
+#include "ola/base/Macro.h"
 #include "plugins/usbpro/BaseRobeWidget.h"
 
 namespace ola {
@@ -118,16 +119,25 @@ void BaseRobeWidget::ReceiveMessage() {
           return;
       } while (m_header.som != SOM);
       m_state = RECV_PACKET_TYPE;
+
+      // if we don't return fallthrough
+      OLA_FALLTHROUGH
     case RECV_PACKET_TYPE:
       m_descriptor->Receive(&m_header.packet_type, 1, count);
       if (count != 1)
         return;
       m_state = RECV_SIZE_LO;
+
+      // if we don't return fallthrough
+      OLA_FALLTHROUGH
     case RECV_SIZE_LO:
       m_descriptor->Receive(&m_header.len, 1, count);
       if (count != 1)
         return;
       m_state = RECV_SIZE_HI;
+
+      // if we don't return fallthrough
+      OLA_FALLTHROUGH
     case RECV_SIZE_HI:
       m_descriptor->Receive(&m_header.len_hi, 1, count);
       if (count != 1)
@@ -141,6 +151,9 @@ void BaseRobeWidget::ReceiveMessage() {
 
       m_bytes_received = 0;
       m_state = RECV_HEADER_CRC;
+
+      // if we don't return fallthrough
+      OLA_FALLTHROUGH
     case RECV_HEADER_CRC:
       m_descriptor->Receive(&m_header.header_crc, 1, count);
       if (count != 1)
@@ -160,6 +173,9 @@ void BaseRobeWidget::ReceiveMessage() {
         m_state = RECV_BODY;
       else
         m_state = RECV_CRC;
+
+      // if we don't return fallthrough
+      OLA_FALLTHROUGH
     case RECV_BODY:
       m_descriptor->Receive(
           reinterpret_cast<uint8_t*>(&m_recv_buffer) + m_bytes_received,
@@ -174,6 +190,9 @@ void BaseRobeWidget::ReceiveMessage() {
         return;
 
       m_state = RECV_CRC;
+
+      // if we don't return fallthrough
+      OLA_FALLTHROUGH
     case RECV_CRC:
       // check this is a valid frame
       uint8_t crc;
@@ -194,6 +213,9 @@ void BaseRobeWidget::ReceiveMessage() {
                       m_data_size);
       }
       m_state = PRE_SOM;
+
+      // if we don't return fallthrough
+      OLA_FALLTHROUGH
   }
   return;
 }

--- a/plugins/usbpro/BaseUsbProWidget.cpp
+++ b/plugins/usbpro/BaseUsbProWidget.cpp
@@ -33,6 +33,7 @@
 #include "ola/Logging.h"
 #include "ola/io/IOUtils.h"
 #include "ola/io/Serial.h"
+#include "ola/base/Macro.h"
 #include "plugins/usbpro/BaseUsbProWidget.h"
 
 namespace ola {
@@ -158,18 +159,21 @@ void BaseUsbProWidget::ReceiveMessage() {
       } while (m_header.som != SOM);
       m_state = RECV_LABEL;
       // fall through
+      OLA_FALLTHROUGH
     case RECV_LABEL:
       m_descriptor->Receive(&m_header.label, 1, count);
       if (count != 1)
         return;
       m_state = RECV_SIZE_LO;
       // fall through
+      OLA_FALLTHROUGH
     case RECV_SIZE_LO:
       m_descriptor->Receive(&m_header.len, 1, count);
       if (count != 1)
         return;
       m_state = RECV_SIZE_HI;
       // fall through
+      OLA_FALLTHROUGH
     case RECV_SIZE_HI:
       m_descriptor->Receive(&m_header.len_hi, 1, count);
       if (count != 1)
@@ -187,6 +191,7 @@ void BaseUsbProWidget::ReceiveMessage() {
       m_bytes_received = 0;
       m_state = RECV_BODY;
       // fall through
+      OLA_FALLTHROUGH
     case RECV_BODY:
       packet_length = (m_header.len_hi << 8) + m_header.len;
       m_descriptor->Receive(
@@ -203,6 +208,7 @@ void BaseUsbProWidget::ReceiveMessage() {
 
       m_state = RECV_EOM;
       // fall through
+      OLA_FALLTHROUGH
     case RECV_EOM:
       // check this is a valid frame with an end byte
       uint8_t eom;

--- a/tools/rdmpro/rdm-sniffer.cpp
+++ b/tools/rdmpro/rdm-sniffer.cpp
@@ -29,6 +29,7 @@
 #include <ola/base/Flags.h>
 #include <ola/base/Init.h>
 #include <ola/base/SysExits.h>
+#include <ola/base/Macro.h>
 #include <ola/io/SelectServer.h>
 #include <ola/network/NetworkUtils.h>
 #include <ola/rdm/CommandPrinter.h>
@@ -235,10 +236,12 @@ void RDMSniffer::ProcessTuple(uint8_t control_byte, uint8_t data_byte) {
     switch (m_state) {
       case IDLE:
         // fall through
+        OLA_FALLTHROUGH
       case MAB:
         m_state = DATA;
         m_frame.Reset();
         // fall through
+        OLA_FALLTHROUGH
       case DATA:
         m_frame.AddByte(data_byte);
         break;


### PR DESCRIPTION
This is the initial macro for solving switch case fallthrough errors. It
is non-empty in all major GCC versions higher than 7 and defines
```OLA_FALLTHROUGH``` as ```__attribute__ ((fallthrough));```

```OLA_FALLTHROUGH``` has to be used at the end of the case to work.

This fixes github bug #1193 and debian bug [853583](https://bugs.debian.org/853583)