### PR TITLE
Fix protobuf 2.6 build on latest OS X since #1132

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,10 +65,12 @@ if ! USING_WIN32
 if FATAL_WARNINGS
   COMMON_CXXFLAGS += -Werror
   COMMON_PROTOBUF_CXXFLAGS += -Werror -Wno-error=unused-parameter \
-                              -Wno-error=deprecated-declarations
+                              -Wno-error=deprecated-declarations \
+                              -Wno-error=sign-compare
   COMMON_TESTING_FLAGS += -Werror
   COMMON_TESTING_PROTOBUF_FLAGS += -Werror -Wno-error=unused-parameter \
                                    -Wno-error=deprecated-declarations
+                                   -Wno-error=sign-compare
 endif
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,7 +69,7 @@ if FATAL_WARNINGS
                               -Wno-error=sign-compare
   COMMON_TESTING_FLAGS += -Werror
   COMMON_TESTING_PROTOBUF_FLAGS += -Werror -Wno-error=unused-parameter \
-                                   -Wno-error=deprecated-declarations
+                                   -Wno-error=deprecated-declarations \
                                    -Wno-error=sign-compare
 endif
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,8 +69,7 @@ if FATAL_WARNINGS
                               -Wno-error=sign-compare
   COMMON_TESTING_FLAGS += -Werror
   COMMON_TESTING_PROTOBUF_FLAGS += -Werror -Wno-error=unused-parameter \
-                                   -Wno-error=deprecated-declarations \
-                                   -Wno-error=sign-compare
+                                   -Wno-error=deprecated-declarations
 endif
 endif
 


### PR DESCRIPTION
See https://buildbot.openlighting.org/builders/buildcheck-ola-0.10-macos-x86_64-1/builds/717/steps/make/logs/stdio