### PR TITLE
More Windows fixes (InterfacePicker and LibUSB)

### DIFF
--- a/README.mingw32
+++ b/README.mingw32
@@ -10,7 +10,6 @@ You need to select:
 - mingw-developer-toolkit
 - mingw32-base
 - mingw32-gcc-g++
-- mingw32-libncurses
 - mingw32-pthreads-w32
 - msys-base
 - msys-coreutils

--- a/common/network/InterfacePickerTest.cpp
+++ b/common/network/InterfacePickerTest.cpp
@@ -64,7 +64,13 @@ CPPUNIT_TEST_SUITE_REGISTRATION(InterfacePickerTest);
 void InterfacePickerTest::testGetInterfaces() {
   auto_ptr<InterfacePicker> picker(InterfacePicker::NewPicker());
   vector<Interface> interfaces = picker->GetInterfaces(true);
-  OLA_ASSERT_TRUE(interfaces.size() > 0);
+#ifndef _WIN32
+  // If a Windows box is not on a network, and doesn't have it's loopback, there
+  // may be zero interfaces present so we skip this check
+  OLA_ASSERT_GT(interfaces.size(), 0);
+#else
+  OLA_WARN << "Windows found " << interfaces.size() << " interfaces";
+#endif  // _WIN32
 
   vector<Interface>::iterator iter;
   cout << endl;
@@ -88,7 +94,13 @@ void InterfacePickerTest::testGetInterfaces() {
 void InterfacePickerTest::testGetLoopbackInterfaces() {
   auto_ptr<InterfacePicker> picker(InterfacePicker::NewPicker());
   vector<Interface> interfaces = picker->GetInterfaces(true);
-  OLA_ASSERT_TRUE(interfaces.size() > 0);
+#ifndef _WIN32
+  // If a Windows box is not on a network, and doesn't have it's loopback, there
+  // may be zero interfaces present so we skip this check
+  OLA_ASSERT_GT(interfaces.size(), 0);
+#else
+  OLA_WARN << "Windows found " << interfaces.size() << " interfaces";
+#endif  // _WIN32
 
   vector<Interface>::iterator iter;
   unsigned int loopback_count = 0;

--- a/common/network/WindowsInterfacePicker.cpp
+++ b/common/network/WindowsInterfacePicker.cpp
@@ -77,10 +77,15 @@ vector<Interface> WindowsInterfacePicker::GetInterfaces(
   for (pAdapter = pAdapterInfo;
        pAdapter && pAdapter < pAdapterInfo + ulOutBufLen;
        pAdapter = pAdapter->Next) {
-    if (pAdapter->Type != MIB_IF_TYPE_ETHERNET) {
+    // Since Vista, wireless interfaces return a different type
+    // See https://msdn.microsoft.com/en-us/library/windows/desktop/aa366062(v=vs.85).aspx
+    if ((pAdapter->Type != MIB_IF_TYPE_ETHERNET) &&
+        (pAdapter->Type != IF_TYPE_IEEE80211)) {
       OLA_INFO << "Skipping " << pAdapter->AdapterName
+               << " (" << pAdapter->Description << ")"
                << " as it's not MIB_IF_TYPE_ETHERNET"
-               << " got " << pAdapter->Type << " instead";
+               << " or IF_TYPE_IEEE80211, got "
+               << pAdapter->Type << " instead";
       continue;
     }
 

--- a/libs/usb/HotplugAgent.cpp
+++ b/libs/usb/HotplugAgent.cpp
@@ -46,10 +46,10 @@ using std::pair;
 
 namespace {
 #ifdef HAVE_LIBUSB_HOTPLUG_API
-int hotplug_callback(OLA_UNUSED struct libusb_context *ctx,
-                     struct libusb_device *dev,
-                     libusb_hotplug_event event,
-                     void *user_data) {
+int LIBUSB_CALL hotplug_callback(OLA_UNUSED struct libusb_context *ctx,
+                                 struct libusb_device *dev,
+                                 libusb_hotplug_event event,
+                                 void *user_data) {
   HotplugAgent *agent = reinterpret_cast<HotplugAgent*>(user_data);
   agent->HotPlugEvent(dev, event);
   return 0;
@@ -84,7 +84,7 @@ bool HotplugAgent::Init() {
   OLA_DEBUG << "libusb_set_debug(" << m_debug_level << ")";
   libusb_set_debug(m_context, m_debug_level);
 
-  m_use_hotplug = HotplugSupported();
+  m_use_hotplug = ola::usb::LibUsbAdaptor::HotplugSupported();
   OLA_DEBUG << "HotplugSupported(): " << m_use_hotplug;
 #ifdef HAVE_LIBUSB_HOTPLUG_API
   if (m_use_hotplug) {
@@ -204,13 +204,11 @@ void HotplugAgent::HotPlugEvent(struct libusb_device *usb_device,
  * @brief Check if this platform supports hotplug.
  * @returns true if hotplug is supported and enabled on this platform, false
  *   otherwise.
+ * @deprecated This is only here for backwards compatibility. New code should
+ *   use ola::usb::LibUsbAdaptor::HotplugSupported().
  */
 bool HotplugAgent::HotplugSupported() {
-#ifdef HAVE_LIBUSB_HOTPLUG_API
-  return libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG) != 0;
-#else
-  return false;
-#endif  // HAVE_LIBUSB_HOTPLUG_API
+  return ola::usb::LibUsbAdaptor::HotplugSupported();
 }
 
 /*

--- a/libs/usb/LibUsbAdaptor.cpp
+++ b/libs/usb/LibUsbAdaptor.cpp
@@ -155,6 +155,14 @@ bool LibUsbAdaptor::CheckProduct(const string &expected,
   return true;
 }
 
+bool LibUsbAdaptor::HotplugSupported() {
+#ifdef HAVE_LIBUSB_HOTPLUG_API
+  return libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG) != 0;
+#else
+  return false;
+#endif  // HAVE_LIBUSB_HOTPLUG_API
+}
+
 string LibUsbAdaptor::ErrorCodeToString(const int error_code) {
 #ifdef HAVE_LIBUSB_ERROR_NAME
   return libusb_error_name(error_code);

--- a/libs/usb/LibUsbAdaptor.h
+++ b/libs/usb/LibUsbAdaptor.h
@@ -415,6 +415,13 @@ class LibUsbAdaptor {
                            const DeviceInformation &device_info);
 
   /**
+   * @brief Check if this platform supports hotplug.
+   * @returns true if hotplug is supported and enabled on this platform, false
+   *   otherwise.
+   */
+  static bool HotplugSupported();
+
+  /**
    * @brief Try and convert an error code to a string
    * @param error_code The error code.
    * @returns A string representing the error code.


### PR DESCRIPTION
- Skip interface count checks on Windows, as it may fail them if it's not on a network
- Fix LibUSB code on Windows, especially when the Hotplug functionality exists but isn't available
- Support Wireless interfaces since Vista