### PR TITLE
Add cast to fix build error (0.10 branch)

### DIFF
--- a/ola/AutoStart.cpp
+++ b/ola/AutoStart.cpp
@@ -105,7 +105,8 @@ TCPSocket *ConnectToServer(unsigned short port) {
 
     // Try to start the server, we pass --daemon (fork into background) and
     // --syslog (log to syslog).
-    execlp("olad", "olad", "--daemon", "--syslog", NULL);
+    execlp("olad", "olad", "--daemon", "--syslog",
+           reinterpret_cast<char*>(NULL));
     OLA_WARN << "Failed to exec: " << strerror(errno);
     _exit(1);
   }


### PR DESCRIPTION
The error is the following:

ola/AutoStart.cpp: In function 'ola::network::TCPSocket* ola::client::ConnectToServer(short unsigned int)':
ola/AutoStart.cpp:108:56: error: missing sentinel in function call [-Werror=format=]
     execlp("olad", "olad", "--daemon", "--syslog", NULL);

From execlp(3):

  The list of arguments must be terminated by a null pointer, and, since these
  are variadic functions, this pointer must be cast (char *) NULL.

This is with "gcc (Alpine 6.2.1) 6.2.1 20160822" on Alpine Linux x86_64.

Found it from

  http://stackoverflow.com/questions/12095865/spurious-missing-sentinel-in-function-call