### PR TITLE
Search for tcmalloc with AC_CHECK_LIB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -693,7 +693,7 @@ AS_IF([test "x$enable_root_check" = xno],
 # Use tcmalloc. This is used by the buildbot leak checks.
 AC_ARG_ENABLE([tcmalloc], AS_HELP_STRING([--enable-tcmalloc], [Use tcmalloc]))
 AS_IF([test "x$enable_tcmalloc" = xyes],
-      [LDFLAGS="$LDFLAGS -ltcmalloc"])
+      [AC_CHECK_LIB([tcmalloc], [malloc], [LDFLAGS="$LDFLAGS -ltcmalloc"], [AS_ERROR([tcmalloc not found, but enabled on command line])])])
 
 # Optionally set the Doxygen version to "Latest Git" for website latest
 # version.


### PR DESCRIPTION
Currently we just unconditionally add it to LDFLAGS, without checking
whether it even exists. That creates confusing error messages down the
line.

Instead, use AC_CHECK_LIB to see whether the library is there, and
provide a proper error message if not. This should fix
OpenLightingProject/ola#1201.

(cherry picked from commit 16ee3bc890cedc1d26a84db458ba788ecb28533d)