### PR TITLE
Throw an error if we don't have an old enough protobuf

### DIFF
--- a/config/ola.m4
+++ b/config/ola.m4
@@ -24,6 +24,9 @@ AC_DEFUN([PROTOBUF_SUPPORT],
 AC_REQUIRE_CPP()
 PKG_CHECK_MODULES(libprotobuf, [protobuf >= $1])
 
+PKG_CHECK_MODULES(libprotobuf2, [protobuf < 3.2], [],
+                  [AC_MSG_ERROR([OLA currently requires protobuf < 3.2, see issue 1192])])
+
 AC_SUBST([libprotobuf_CFLAGS])
 
 AC_ARG_WITH([protoc],


### PR DESCRIPTION
Until we fix #1192, rather than a confusing compiler error