### PR TITLE
Make all plugins CamelCase

### DIFF
--- a/olad/DynamicPluginLoader.cpp
+++ b/olad/DynamicPluginLoader.cpp
@@ -68,7 +68,7 @@
 #endif  // USE_OPENPIXELCONTROL
 
 #ifdef USE_OSC
-#include "plugins/osc/OSCPlugin.h"
+#include "plugins/osc/OscPlugin.h"
 #endif  // USE_OSC
 
 #ifdef USE_PATHPORT
@@ -185,7 +185,7 @@ void DynamicPluginLoader::PopulatePlugins() {
 
 #ifdef USE_OSC
   m_plugins.push_back(
-      new ola::plugin::osc::OSCPlugin(m_plugin_adaptor));
+      new ola::plugin::osc::OscPlugin(m_plugin_adaptor));
 #endif  // USE_OSC
 
 #ifdef USE_RENARD

--- a/olad/DynamicPluginLoader.cpp
+++ b/olad/DynamicPluginLoader.cpp
@@ -88,7 +88,7 @@
 #endif  // USE_SHOWNET
 
 #ifdef USE_SPI
-#include "plugins/spi/SPIPlugin.h"
+#include "plugins/spi/SpiPlugin.h"
 #endif  // USE_SPI
 
 #ifdef USE_STAGEPROFI
@@ -205,7 +205,7 @@ void DynamicPluginLoader::PopulatePlugins() {
 
 #ifdef USE_SPI
   m_plugins.push_back(
-      new ola::plugin::spi::SPIPlugin(m_plugin_adaptor));
+      new ola::plugin::spi::SpiPlugin(m_plugin_adaptor));
 #endif  // USE_SPI
 
 #ifdef USE_STAGEPROFI

--- a/olad/DynamicPluginLoader.cpp
+++ b/olad/DynamicPluginLoader.cpp
@@ -44,7 +44,7 @@
 #endif  // USE_ESPNET
 
 #ifdef USE_GPIO
-#include "plugins/gpio/GPIOPlugin.h"
+#include "plugins/gpio/GpioPlugin.h"
 #endif  // USE_GPIO
 
 #ifdef USE_KARATE
@@ -156,7 +156,7 @@ void DynamicPluginLoader::PopulatePlugins() {
 #endif  // USE_ESPNET
 
 #ifdef USE_GPIO
-  m_plugins.push_back(new ola::plugin::gpio::GPIOPlugin(m_plugin_adaptor));
+  m_plugins.push_back(new ola::plugin::gpio::GpioPlugin(m_plugin_adaptor));
 #endif  // USE_GPIO
 
 #ifdef USE_KARATE

--- a/olad/DynamicPluginLoader.cpp
+++ b/olad/DynamicPluginLoader.cpp
@@ -64,7 +64,7 @@
 #endif  // USE_OPENDMX
 
 #ifdef USE_OPENPIXELCONTROL
-#include "plugins/openpixelcontrol/OPCPlugin.h"
+#include "plugins/openpixelcontrol/OpcPlugin.h"
 #endif  // USE_OPENPIXELCONTROL
 
 #ifdef USE_OSC
@@ -180,7 +180,7 @@ void DynamicPluginLoader::PopulatePlugins() {
 
 #ifdef USE_OPENPIXELCONTROL
   m_plugins.push_back(
-      new ola::plugin::openpixelcontrol::OPCPlugin(m_plugin_adaptor));
+      new ola::plugin::openpixelcontrol::OpcPlugin(m_plugin_adaptor));
 #endif  // USE_OPENPIXELCONTROL
 
 #ifdef USE_OSC

--- a/plugins/gpio/GpioDevice.cpp
+++ b/plugins/gpio/GpioDevice.cpp
@@ -13,49 +13,38 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * GPIODevice.h
+ * GpioDevice.cpp
  * The GPIO Device.
  * Copyright (C) 2014 Simon Newton
  */
+#include "plugins/gpio/GpioDevice.h"
 
-#ifndef PLUGINS_GPIO_GPIODEVICE_H_
-#define PLUGINS_GPIO_GPIODEVICE_H_
-
-#include <memory>
-#include <string>
-#include <vector>
-
-#include "olad/Device.h"
-#include "plugins/gpio/GPIODriver.h"
+#include "plugins/gpio/GpioPort.h"
+#include "plugins/gpio/GpioPlugin.h"
+#include "plugins/gpio/GpioDriver.h"
 
 namespace ola {
 namespace plugin {
 namespace gpio {
 
-/**
- * @brief The GPIO Device
+/*
+ * Create a new device
  */
-class GPIODevice: public ola::Device {
- public:
-  /**
-   * @brief Create a new GPIODevice.
-   * @param owner The Plugin that owns this device.
-   * @param options the options to use for the new device.
-   */
-  GPIODevice(class GPIOPlugin *owner,
-             const GPIODriver::Options &options);
+GpioDevice::GpioDevice(GpioPlugin *owner,
+                       const GpioDriver::Options &options)
+    : Device(owner, "General Purpose I/O Device"),
+      m_options(options) {
+}
 
-  std::string DeviceId() const { return "1"; }
-
- protected:
-  bool StartHook();
-
- private:
-  const GPIODriver::Options m_options;
-
-  DISALLOW_COPY_AND_ASSIGN(GPIODevice);
-};
+bool GpioDevice::StartHook() {
+  GpioOutputPort *port = new GpioOutputPort(this, m_options);
+  if (!port->Init()) {
+    delete port;
+    return false;
+  }
+  AddPort(port);
+  return true;
+}
 }  // namespace gpio
 }  // namespace plugin
 }  // namespace ola
-#endif  // PLUGINS_GPIO_GPIODEVICE_H_

--- a/plugins/gpio/GpioDevice.h
+++ b/plugins/gpio/GpioDevice.h
@@ -13,46 +13,49 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * GPIOPort.cpp
- * An OLA GPIO Port.
+ * GpioDevice.h
+ * The GPIO Device.
  * Copyright (C) 2014 Simon Newton
  */
 
-#include "plugins/gpio/GPIOPort.h"
+#ifndef PLUGINS_GPIO_GPIODEVICE_H_
+#define PLUGINS_GPIO_GPIODEVICE_H_
 
-#include <sstream>
+#include <memory>
 #include <string>
 #include <vector>
 
-#include "ola/StringUtils.h"
-#include "plugins/gpio/GPIODriver.h"
+#include "olad/Device.h"
+#include "plugins/gpio/GpioDriver.h"
 
 namespace ola {
 namespace plugin {
 namespace gpio {
 
-using std::string;
-using std::vector;
+/**
+ * @brief The GPIO Device
+ */
+class GpioDevice: public ola::Device {
+ public:
+  /**
+   * @brief Create a new GpioDevice.
+   * @param owner The Plugin that owns this device.
+   * @param options the options to use for the new device.
+   */
+  GpioDevice(class GpioPlugin *owner,
+             const GpioDriver::Options &options);
 
-GPIOOutputPort::GPIOOutputPort(GPIODevice *parent,
-                               const GPIODriver::Options &options)
-    : BasicOutputPort(parent, 1),
-      m_driver(new GPIODriver(options)) {
-}
+  std::string DeviceId() const { return "1"; }
 
-bool GPIOOutputPort::Init() {
-  return m_driver->Init();
-}
+ protected:
+  bool StartHook();
 
-string GPIOOutputPort::Description() const {
-  vector<uint16_t> pins = m_driver->PinList();
-  return "Pins " + ola::StringJoin(", ", pins);
-}
+ private:
+  const GpioDriver::Options m_options;
 
-bool GPIOOutputPort::WriteDMX(const DmxBuffer &buffer,
-                              OLA_UNUSED uint8_t priority) {
-  return m_driver->SendDmx(buffer);
-}
+  DISALLOW_COPY_AND_ASSIGN(GpioDevice);
+};
 }  // namespace gpio
 }  // namespace plugin
 }  // namespace ola
+#endif  // PLUGINS_GPIO_GPIODEVICE_H_

--- a/plugins/gpio/GpioDriver.cpp
+++ b/plugins/gpio/GpioDriver.cpp
@@ -13,12 +13,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * GPIODriver.cpp
+ * GpioDriver.cpp
  * Uses data in a DMXBuffer to drive GPIO pins.
  * Copyright (C) 2014 Simon Newton
  */
 
-#include "plugins/gpio/GPIODriver.h"
+#include "plugins/gpio/GpioDriver.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -40,19 +40,19 @@ namespace ola {
 namespace plugin {
 namespace gpio {
 
-const char GPIODriver::GPIO_BASE_DIR[] = "/sys/class/gpio/gpio";
+const char GpioDriver::GPIO_BASE_DIR[] = "/sys/class/gpio/gpio";
 
 using ola::thread::MutexLocker;
 using std::string;
 using std::vector;
 
-GPIODriver::GPIODriver(const Options &options)
+GpioDriver::GpioDriver(const Options &options)
     : m_options(options),
       m_term(false),
       m_dmx_changed(false) {
 }
 
-GPIODriver::~GPIODriver() {
+GpioDriver::~GpioDriver() {
   {
     MutexLocker locker(&m_mutex);
     m_term = true;
@@ -60,18 +60,18 @@ GPIODriver::~GPIODriver() {
   m_cond.Signal();
   Join();
 
-  CloseGPIOFDs();
+  CloseGpioFDs();
 }
 
-bool GPIODriver::Init() {
-  if (!SetupGPIO()) {
+bool GpioDriver::Init() {
+  if (!SetupGpio()) {
     return false;
   }
 
   return Start();
 }
 
-bool GPIODriver::SendDmx(const DmxBuffer &dmx) {
+bool GpioDriver::SendDmx(const DmxBuffer &dmx) {
   {
     MutexLocker locker(&m_mutex);
     // avoid the reference counting
@@ -82,7 +82,7 @@ bool GPIODriver::SendDmx(const DmxBuffer &dmx) {
   return true;
 }
 
-void *GPIODriver::Run() {
+void *GpioDriver::Run() {
   Clock clock;
   DmxBuffer output;
 
@@ -109,13 +109,13 @@ void *GPIODriver::Run() {
     }
     m_mutex.Unlock();
     if (update_pins) {
-      UpdateGPIOPins(output);
+      UpdateGpioPins(output);
     }
   }
   return NULL;
 }
 
-bool GPIODriver::SetupGPIO() {
+bool GpioDriver::SetupGpio() {
   /**
    * This relies on the pins being exported:
    *   echo N > /sys/class/gpio/export
@@ -133,7 +133,7 @@ bool GPIODriver::SetupGPIO() {
       break;
     }
 
-    GPIOPin pin = {pin_fd, UNDEFINED, false};
+    GpioPin pin = {pin_fd, UNDEFINED, false};
 
     // Set dir
     str.str("");
@@ -154,13 +154,13 @@ bool GPIODriver::SetupGPIO() {
   }
 
   if (failed) {
-    CloseGPIOFDs();
+    CloseGpioFDs();
     return false;
   }
   return true;
 }
 
-bool GPIODriver::UpdateGPIOPins(const DmxBuffer &dmx) {
+bool GpioDriver::UpdateGpioPins(const DmxBuffer &dmx) {
   enum Action {
     TURN_ON,
     TURN_OFF,
@@ -202,8 +202,8 @@ bool GPIODriver::UpdateGPIOPins(const DmxBuffer &dmx) {
   return true;
 }
 
-void GPIODriver::CloseGPIOFDs() {
-  GPIOPins::iterator iter = m_gpio_pins.begin();
+void GpioDriver::CloseGpioFDs() {
+  GpioPins::iterator iter = m_gpio_pins.begin();
   for (; iter != m_gpio_pins.end(); ++iter) {
     close(iter->fd);
   }

--- a/plugins/gpio/GpioDriver.h
+++ b/plugins/gpio/GpioDriver.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * GPIODriver.h
+ * GpioDriver.h
  * Uses data in a DMXBuffer to drive GPIO pins.
  * Copyright (C) 2014 Simon Newton
  */
@@ -35,7 +35,7 @@ namespace gpio {
 /**
  * @brief Uses data in a DMXBuffer to drive GPIO pins.
  */
-class GPIODriver : private ola::thread::Thread {
+class GpioDriver : private ola::thread::Thread {
  public:
   /**
    * @brief The Options.
@@ -66,18 +66,18 @@ class GPIODriver : private ola::thread::Thread {
   };
 
   /**
-   * @brief Create a new GPIODriver.
+   * @brief Create a new GpioDriver.
    * @param options the Options struct.
    */
-  explicit GPIODriver(const Options &options);
+  explicit GpioDriver(const Options &options);
 
   /**
    * @brief Destructor.
    */
-  ~GPIODriver();
+  ~GpioDriver();
 
   /**
-   * @brief Initialize the GPIODriver.
+   * @brief Initialize the GpioDriver.
    * @returns true is successful, false otherwise.
    */
   bool Init();
@@ -98,22 +98,22 @@ class GPIODriver : private ola::thread::Thread {
   void *Run();
 
  private:
-  enum GPIOState {
+  enum GpioState {
     ON,
     OFF,
     UNDEFINED,
   };
 
-  struct GPIOPin {
+  struct GpioPin {
     int fd;
-    GPIOState state;
+    GpioState state;
     bool last_value;
   };
 
-  typedef std::vector<GPIOPin> GPIOPins;
+  typedef std::vector<GpioPin> GpioPins;
 
   const Options m_options;
-  GPIOPins m_gpio_pins;
+  GpioPins m_gpio_pins;
 
   DmxBuffer m_buffer;
   bool m_term;  // GUARDED_BY(m_mutex);
@@ -121,13 +121,13 @@ class GPIODriver : private ola::thread::Thread {
   ola::thread::Mutex m_mutex;
   ola::thread::ConditionVariable m_cond;
 
-  bool SetupGPIO();
-  bool UpdateGPIOPins(const DmxBuffer &dmx);
-  void CloseGPIOFDs();
+  bool SetupGpio();
+  bool UpdateGpioPins(const DmxBuffer &dmx);
+  void CloseGpioFDs();
 
   static const char GPIO_BASE_DIR[];
 
-  DISALLOW_COPY_AND_ASSIGN(GPIODriver);
+  DISALLOW_COPY_AND_ASSIGN(GpioDriver);
 };
 }  // namespace gpio
 }  // namespace plugin

--- a/plugins/gpio/GpioPlugin.cpp
+++ b/plugins/gpio/GpioPlugin.cpp
@@ -13,12 +13,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * GPIOPlugin.cpp
+ * GpioPlugin.cpp
  * The General Purpose digital I/O plugin.
  * Copyright (C) 2014 Simon Newton
  */
 
-#include "plugins/gpio/GPIOPlugin.h"
+#include "plugins/gpio/GpioPlugin.h"
 
 #include <memory>
 #include <string>
@@ -26,9 +26,9 @@
 #include "olad/Preferences.h"
 #include "ola/Logging.h"
 #include "ola/StringUtils.h"
-#include "plugins/gpio/GPIODevice.h"
-#include "plugins/gpio/GPIODriver.h"
-#include "plugins/gpio/GPIOPluginDescription.h"
+#include "plugins/gpio/GpioDevice.h"
+#include "plugins/gpio/GpioDriver.h"
+#include "plugins/gpio/GpioPluginDescription.h"
 
 namespace ola {
 namespace plugin {
@@ -38,15 +38,15 @@ using std::auto_ptr;
 using std::string;
 using std::vector;
 
-const char GPIOPlugin::GPIO_PINS_KEY[] = "gpio_pins";
-const char GPIOPlugin::GPIO_SLOT_OFFSET_KEY[] = "gpio_slot_offset";
-const char GPIOPlugin::GPIO_TURN_OFF_KEY[] = "gpio_turn_off";
-const char GPIOPlugin::GPIO_TURN_ON_KEY[] = "gpio_turn_on";
-const char GPIOPlugin::PLUGIN_NAME[] = "GPIO";
-const char GPIOPlugin::PLUGIN_PREFIX[] = "gpio";
+const char GpioPlugin::GPIO_PINS_KEY[] = "gpio_pins";
+const char GpioPlugin::GPIO_SLOT_OFFSET_KEY[] = "gpio_slot_offset";
+const char GpioPlugin::GPIO_TURN_OFF_KEY[] = "gpio_turn_off";
+const char GpioPlugin::GPIO_TURN_ON_KEY[] = "gpio_turn_on";
+const char GpioPlugin::PLUGIN_NAME[] = "GPIO";
+const char GpioPlugin::PLUGIN_PREFIX[] = "gpio";
 
-bool GPIOPlugin::StartHook() {
-  GPIODriver::Options options;
+bool GpioPlugin::StartHook() {
+  GpioDriver::Options options;
   if (!StringToInt(m_preferences->GetValue(GPIO_TURN_ON_KEY),
                    &options.turn_on)) {
     OLA_WARN << "Invalid value for " << GPIO_TURN_ON_KEY;
@@ -91,7 +91,7 @@ bool GPIOPlugin::StartHook() {
     return true;
   }
 
-  std::auto_ptr<GPIODevice> device(new GPIODevice(this, options));
+  std::auto_ptr<GpioDevice> device(new GpioDevice(this, options));
   if (!device->Start()) {
     return false;
   }
@@ -101,7 +101,7 @@ bool GPIOPlugin::StartHook() {
   return true;
 }
 
-bool GPIOPlugin::StopHook() {
+bool GpioPlugin::StopHook() {
   if (m_device) {
     m_plugin_adaptor->UnregisterDevice(m_device);
     m_device->Stop();
@@ -111,11 +111,11 @@ bool GPIOPlugin::StopHook() {
   return true;
 }
 
-string GPIOPlugin::Description() const {
+string GpioPlugin::Description() const {
   return plugin_description;
 }
 
-bool GPIOPlugin::SetDefaultPreferences() {
+bool GpioPlugin::SetDefaultPreferences() {
   bool save = false;
 
   if (!m_preferences)

--- a/plugins/gpio/GpioPlugin.h
+++ b/plugins/gpio/GpioPlugin.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * GPIOPlugin.h
+ * GpioPlugin.h
  * The General Purpose digital I/O plugin.
  * Copyright (C) 2014 Simon Newton
  */
@@ -32,13 +32,13 @@ namespace gpio {
 /**
  * @brief A plugin that drives general purpose digital I/O lines.
  */
-class GPIOPlugin: public ola::Plugin {
+class GpioPlugin: public ola::Plugin {
  public:
   /**
-   * @brief Create a new GPIOPlugin.
+   * @brief Create a new GpioPlugin.
    * @param plugin_adaptor the PluginAdaptor to use
    */
-  explicit GPIOPlugin(class ola::PluginAdaptor *plugin_adaptor)
+  explicit GpioPlugin(class ola::PluginAdaptor *plugin_adaptor)
       : Plugin(plugin_adaptor),
         m_device(NULL) {}
 
@@ -48,7 +48,7 @@ class GPIOPlugin: public ola::Plugin {
   std::string PluginPrefix() const { return PLUGIN_PREFIX; }
 
  private:
-  class GPIODevice *m_device;
+  class GpioDevice *m_device;
 
   bool StartHook();
   bool StopHook();
@@ -61,7 +61,7 @@ class GPIOPlugin: public ola::Plugin {
   static const char PLUGIN_NAME[];
   static const char PLUGIN_PREFIX[];
 
-  DISALLOW_COPY_AND_ASSIGN(GPIOPlugin);
+  DISALLOW_COPY_AND_ASSIGN(GpioPlugin);
 };
 }  // namespace gpio
 }  // namespace plugin

--- a/plugins/gpio/GpioPort.cpp
+++ b/plugins/gpio/GpioPort.cpp
@@ -13,37 +13,45 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * GPIODevice.cpp
- * The GPIO Device.
+ * GpioPort.cpp
+ * An OLA GPIO Port.
  * Copyright (C) 2014 Simon Newton
  */
-#include "plugins/gpio/GPIODevice.h"
 
-#include "plugins/gpio/GPIOPort.h"
-#include "plugins/gpio/GPIOPlugin.h"
-#include "plugins/gpio/GPIODriver.h"
+#include "plugins/gpio/GpioPort.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "ola/StringUtils.h"
+#include "plugins/gpio/GpioDriver.h"
 
 namespace ola {
 namespace plugin {
 namespace gpio {
 
-/*
- * Create a new device
- */
-GPIODevice::GPIODevice(GPIOPlugin *owner,
-                       const GPIODriver::Options &options)
-    : Device(owner, "General Purpose I/O Device"),
-      m_options(options) {
+using std::string;
+using std::vector;
+
+GpioOutputPort::GpioOutputPort(GpioDevice *parent,
+                               const GpioDriver::Options &options)
+    : BasicOutputPort(parent, 1),
+      m_driver(new GpioDriver(options)) {
 }
 
-bool GPIODevice::StartHook() {
-  GPIOOutputPort *port = new GPIOOutputPort(this, m_options);
-  if (!port->Init()) {
-    delete port;
-    return false;
-  }
-  AddPort(port);
-  return true;
+bool GpioOutputPort::Init() {
+  return m_driver->Init();
+}
+
+string GpioOutputPort::Description() const {
+  vector<uint16_t> pins = m_driver->PinList();
+  return "Pins " + ola::StringJoin(", ", pins);
+}
+
+bool GpioOutputPort::WriteDMX(const DmxBuffer &buffer,
+                              OLA_UNUSED uint8_t priority) {
+  return m_driver->SendDmx(buffer);
 }
 }  // namespace gpio
 }  // namespace plugin

--- a/plugins/gpio/GpioPort.h
+++ b/plugins/gpio/GpioPort.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * GPIOPort.h
+ * GpioPort.h
  * An OLA GPIO Port.
  * Copyright (C) 2014 Simon Newton
  */
@@ -24,8 +24,8 @@
 #include <string>
 #include "ola/DmxBuffer.h"
 #include "olad/Port.h"
-#include "plugins/gpio/GPIODevice.h"
-#include "plugins/gpio/GPIODriver.h"
+#include "plugins/gpio/GpioDevice.h"
+#include "plugins/gpio/GpioDriver.h"
 
 namespace ola {
 namespace plugin {
@@ -34,20 +34,20 @@ namespace gpio {
 /**
  * @brief The GPIO Output port.
  */
-class GPIOOutputPort: public BasicOutputPort {
+class GpioOutputPort: public BasicOutputPort {
  public:
   /**
-   * @brief Create a new GPIOOutputPort.
+   * @brief Create a new GpioOutputPort.
    * @param parent The parent device.
-   * @param options the Options for the GPIODriver.
+   * @param options the Options for the GpioDriver.
    */
-  GPIOOutputPort(GPIODevice *parent,
-                 const GPIODriver::Options &options);
+  GpioOutputPort(GpioDevice *parent,
+                 const GpioDriver::Options &options);
 
   /**
    * @brief Destructor.
    */
-  ~GPIOOutputPort() {}
+  ~GpioOutputPort() {}
 
   /**
    * @brief Initialize the port.
@@ -60,9 +60,9 @@ class GPIOOutputPort: public BasicOutputPort {
   bool WriteDMX(const DmxBuffer &buffer, uint8_t priority);
 
  private:
-  std::auto_ptr<GPIODriver> m_driver;
+  std::auto_ptr<GpioDriver> m_driver;
 
-  DISALLOW_COPY_AND_ASSIGN(GPIOOutputPort);
+  DISALLOW_COPY_AND_ASSIGN(GpioOutputPort);
 };
 }  // namespace gpio
 }  // namespace plugin

--- a/plugins/gpio/Makefile.mk
+++ b/plugins/gpio/Makefile.mk
@@ -6,24 +6,24 @@ lib_LTLIBRARIES += plugins/gpio/libolagpiocore.la \
 
 # This is a library which isn't coupled to olad
 plugins_gpio_libolagpiocore_la_SOURCES = \
-    plugins/gpio/GPIODriver.cpp \
-    plugins/gpio/GPIODriver.h
+    plugins/gpio/GpioDriver.cpp \
+    plugins/gpio/GpioDriver.h
 plugins_gpio_libolagpiocore_la_LIBADD = common/libolacommon.la
 
 # Plugin description is generated from README.md
-built_sources += plugins/gpio/GPIOPluginDescription.h
+built_sources += plugins/gpio/GpioPluginDescription.h
 nodist_plugins_gpio_libolagpio_la_SOURCES = \
-    plugins/gpio/GPIOPluginDescription.h
-plugins/gpio/GPIOPluginDescription.h: plugins/gpio/README.md plugins/gpio/Makefile.mk plugins/convert_README_to_header.sh
-	sh $(top_srcdir)/plugins/convert_README_to_header.sh $(top_srcdir)/plugins/gpio $(top_builddir)/plugins/gpio/GPIOPluginDescription.h
+    plugins/gpio/GpioPluginDescription.h
+plugins/gpio/GpioPluginDescription.h: plugins/gpio/README.md plugins/gpio/Makefile.mk plugins/convert_README_to_header.sh
+	sh $(top_srcdir)/plugins/convert_README_to_header.sh $(top_srcdir)/plugins/gpio $(top_builddir)/plugins/gpio/GpioPluginDescription.h
 
 plugins_gpio_libolagpio_la_SOURCES = \
-    plugins/gpio/GPIODevice.cpp \
-    plugins/gpio/GPIODevice.h \
-    plugins/gpio/GPIOPlugin.cpp \
-    plugins/gpio/GPIOPlugin.h \
-    plugins/gpio/GPIOPort.cpp \
-    plugins/gpio/GPIOPort.h
+    plugins/gpio/GpioDevice.cpp \
+    plugins/gpio/GpioDevice.h \
+    plugins/gpio/GpioPlugin.cpp \
+    plugins/gpio/GpioPlugin.h \
+    plugins/gpio/GpioPort.cpp \
+    plugins/gpio/GpioPort.h
 plugins_gpio_libolagpio_la_LIBADD = \
     common/libolacommon.la \
     olad/plugin_api/libolaserverplugininterface.la \

--- a/plugins/openpixelcontrol/Makefile.mk
+++ b/plugins/openpixelcontrol/Makefile.mk
@@ -5,30 +5,30 @@ if USE_OPENPIXELCONTROL
 # This is a library which isn't coupled to olad
 noinst_LTLIBRARIES += plugins/openpixelcontrol/libolaopc.la
 plugins_openpixelcontrol_libolaopc_la_SOURCES = \
-    plugins/openpixelcontrol/OPCClient.cpp \
-    plugins/openpixelcontrol/OPCClient.h \
-    plugins/openpixelcontrol/OPCConstants.h \
-    plugins/openpixelcontrol/OPCServer.cpp \
-    plugins/openpixelcontrol/OPCServer.h
+    plugins/openpixelcontrol/OpcClient.cpp \
+    plugins/openpixelcontrol/OpcClient.h \
+    plugins/openpixelcontrol/OpcConstants.h \
+    plugins/openpixelcontrol/OpcServer.cpp \
+    plugins/openpixelcontrol/OpcServer.h
 plugins_openpixelcontrol_libolaopc_la_LIBADD = \
     common/libolacommon.la
 
 lib_LTLIBRARIES += plugins/openpixelcontrol/libolaopenpixelcontrol.la
 
 # Plugin description is generated from README.md
-built_sources += plugins/openpixelcontrol/OPCPluginDescription.h
+built_sources += plugins/openpixelcontrol/OpcPluginDescription.h
 nodist_plugins_openpixelcontrol_libolaopenpixelcontrol_la_SOURCES = \
-    plugins/openpixelcontrol/OPCPluginDescription.h
-plugins/openpixelcontrol/OPCPluginDescription.h: plugins/openpixelcontrol/README.md plugins/openpixelcontrol/Makefile.mk plugins/convert_README_to_header.sh
-	sh $(top_srcdir)/plugins/convert_README_to_header.sh $(top_srcdir)/plugins/openpixelcontrol $(top_builddir)/plugins/openpixelcontrol/OPCPluginDescription.h
+    plugins/openpixelcontrol/OpcPluginDescription.h
+plugins/openpixelcontrol/OpcPluginDescription.h: plugins/openpixelcontrol/README.md plugins/openpixelcontrol/Makefile.mk plugins/convert_README_to_header.sh
+	sh $(top_srcdir)/plugins/convert_README_to_header.sh $(top_srcdir)/plugins/openpixelcontrol $(top_builddir)/plugins/openpixelcontrol/OpcPluginDescription.h
 
 plugins_openpixelcontrol_libolaopenpixelcontrol_la_SOURCES = \
-    plugins/openpixelcontrol/OPCDevice.cpp \
-    plugins/openpixelcontrol/OPCDevice.h \
-    plugins/openpixelcontrol/OPCPlugin.cpp \
-    plugins/openpixelcontrol/OPCPlugin.h \
-    plugins/openpixelcontrol/OPCPort.cpp \
-    plugins/openpixelcontrol/OPCPort.h
+    plugins/openpixelcontrol/OpcDevice.cpp \
+    plugins/openpixelcontrol/OpcDevice.h \
+    plugins/openpixelcontrol/OpcPlugin.cpp \
+    plugins/openpixelcontrol/OpcPlugin.h \
+    plugins/openpixelcontrol/OpcPort.cpp \
+    plugins/openpixelcontrol/OpcPort.h
 
 plugins_openpixelcontrol_libolaopenpixelcontrol_la_LIBADD = \
     common/libolacommon.la \
@@ -38,20 +38,20 @@ plugins_openpixelcontrol_libolaopenpixelcontrol_la_LIBADD = \
 # TESTS
 ##################################################
 test_programs += \
-    plugins/openpixelcontrol/OPCClientTester \
-    plugins/openpixelcontrol/OPCServerTester
+    plugins/openpixelcontrol/OpcClientTester \
+    plugins/openpixelcontrol/OpcServerTester
 
-plugins_openpixelcontrol_OPCClientTester_SOURCES = \
-    plugins/openpixelcontrol/OPCClientTest.cpp
-plugins_openpixelcontrol_OPCClientTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
-plugins_openpixelcontrol_OPCClientTester_LDADD = \
+plugins_openpixelcontrol_OpcClientTester_SOURCES = \
+    plugins/openpixelcontrol/OpcClientTest.cpp
+plugins_openpixelcontrol_OpcClientTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
+plugins_openpixelcontrol_OpcClientTester_LDADD = \
     $(COMMON_TESTING_LIBS) \
     plugins/openpixelcontrol/libolaopc.la
 
-plugins_openpixelcontrol_OPCServerTester_SOURCES = \
-    plugins/openpixelcontrol/OPCServerTest.cpp
-plugins_openpixelcontrol_OPCServerTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
-plugins_openpixelcontrol_OPCServerTester_LDADD = \
+plugins_openpixelcontrol_OpcServerTester_SOURCES = \
+    plugins/openpixelcontrol/OpcServerTest.cpp
+plugins_openpixelcontrol_OpcServerTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
+plugins_openpixelcontrol_OpcServerTester_LDADD = \
     $(COMMON_TESTING_LIBS) \
     plugins/openpixelcontrol/libolaopc.la
 endif

--- a/plugins/openpixelcontrol/OpcClient.h
+++ b/plugins/openpixelcontrol/OpcClient.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCClient.h
+ * OpcClient.h
  * The Open Pixel Control Client.
  * Copyright (C) 2014 Simon Newton
  */
@@ -46,7 +46,7 @@ namespace openpixelcontrol {
  *
  * The OPC client connects to a remote IP:port and sends OPC messages.
  */
-class OPCClient {
+class OpcClient {
  public:
   /**
    * @brief Called when the socket changes state.
@@ -54,17 +54,17 @@ class OPCClient {
   typedef ola::Callback1<void, bool> SocketEventCallback;
 
   /**
-   * @brief Create a new OPCClient.
+   * @brief Create a new OpcClient.
    * @param ss The SelectServer to use
    * @param target the remote IP:port to connect to.
    */
-  OPCClient(ola::io::SelectServerInterface *ss,
+  OpcClient(ola::io::SelectServerInterface *ss,
             const ola::network::IPV4SocketAddress &target);
 
   /**
    * @brief Destructor.
    */
-  ~OPCClient();
+  ~OpcClient();
 
   /**
    * @brief Return the remote address for this Client.
@@ -102,7 +102,7 @@ class OPCClient {
   void NewData();
   void SocketClosed();
 
-  DISALLOW_COPY_AND_ASSIGN(OPCClient);
+  DISALLOW_COPY_AND_ASSIGN(OpcClient);
 };
 }  // namespace openpixelcontrol
 }  // namespace plugin

--- a/plugins/openpixelcontrol/OpcClientTest.cpp
+++ b/plugins/openpixelcontrol/OpcClientTest.cpp
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCClientTest.cpp
- * Test fixture for the OPCClient class
+ * OpcClientTest.cpp
+ * Test fixture for the OpcClient class
  * Copyright (C) 2014 Simon Newton
  */
 
@@ -30,24 +30,24 @@
 #include "ola/network/SocketAddress.h"
 #include "ola/testing/TestUtils.h"
 #include "ola/util/Utils.h"
-#include "plugins/openpixelcontrol/OPCClient.h"
-#include "plugins/openpixelcontrol/OPCServer.h"
+#include "plugins/openpixelcontrol/OpcClient.h"
+#include "plugins/openpixelcontrol/OpcServer.h"
 
 
 using ola::DmxBuffer;
 using ola::network::IPV4Address;
 using ola::network::IPV4SocketAddress;
-using ola::plugin::openpixelcontrol::OPCClient;
-using ola::plugin::openpixelcontrol::OPCServer;
+using ola::plugin::openpixelcontrol::OpcClient;
+using ola::plugin::openpixelcontrol::OpcServer;
 using std::auto_ptr;
 
-class OPCClientTest: public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(OPCClientTest);
+class OpcClientTest: public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(OpcClientTest);
   CPPUNIT_TEST(testTransmit);
   CPPUNIT_TEST_SUITE_END();
 
  public:
-  OPCClientTest()
+  OpcClientTest()
       : CppUnit::TestFixture(),
         m_ss(NULL) {
   }
@@ -57,7 +57,7 @@ class OPCClientTest: public CppUnit::TestFixture {
 
  private:
   ola::io::SelectServer m_ss;
-  auto_ptr<OPCServer> m_server;
+  auto_ptr<OpcServer> m_server;
   DmxBuffer m_received_data;
   uint8_t m_command;
 
@@ -67,7 +67,7 @@ class OPCClientTest: public CppUnit::TestFixture {
     m_ss.Terminate();
   }
 
-  void SendDMX(OPCClient *client, DmxBuffer *buffer, bool connected) {
+  void SendDMX(OpcClient *client, DmxBuffer *buffer, bool connected) {
     if (connected) {
       OLA_ASSERT_TRUE(client->SendDmx(CHANNEL, *buffer));
     } else {
@@ -78,20 +78,20 @@ class OPCClientTest: public CppUnit::TestFixture {
   static const uint8_t CHANNEL = 1;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(OPCClientTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(OpcClientTest);
 
-void OPCClientTest::setUp() {
+void OpcClientTest::setUp() {
   IPV4SocketAddress listen_addr(IPV4Address::Loopback(), 0);
-  m_server.reset(new OPCServer(&m_ss, listen_addr));
+  m_server.reset(new OpcServer(&m_ss, listen_addr));
   m_server->SetCallback(
       CHANNEL,
-      ola::NewCallback(this, &OPCClientTest::CaptureData));
+      ola::NewCallback(this, &OpcClientTest::CaptureData));
 
   OLA_ASSERT_TRUE(m_server->Init());
 }
 
-void OPCClientTest::testTransmit() {
-  OPCClient client(&m_ss, m_server->ListenAddress());
+void OpcClientTest::testTransmit() {
+  OpcClient client(&m_ss, m_server->ListenAddress());
   OLA_ASSERT_EQ(m_server->ListenAddress().ToString(),
                 client.GetRemoteAddress());
 
@@ -99,7 +99,7 @@ void OPCClientTest::testTransmit() {
   buffer.SetFromString("1,2,3,4");
 
   client.SetSocketCallback(
-      ola::NewCallback(this, &OPCClientTest::SendDMX, &client, &buffer));
+      ola::NewCallback(this, &OpcClientTest::SendDMX, &client, &buffer));
 
   m_ss.Run();
   OLA_ASSERT_EQ(m_received_data, buffer);

--- a/plugins/openpixelcontrol/OpcConstants.h
+++ b/plugins/openpixelcontrol/OpcConstants.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCConstants.h
+ * OpcConstants.h
  * Constants for the Open Pixel Control Protocol.
  * Copyright (C) 2014 Simon Newton
  */

--- a/plugins/openpixelcontrol/OpcDevice.cpp
+++ b/plugins/openpixelcontrol/OpcDevice.cpp
@@ -13,12 +13,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCDevice.cpp
+ * OpcDevice.cpp
  * The Open Pixel Control Device.
  * Copyright (C) 2014 Simon Newton
  */
 
-#include "plugins/openpixelcontrol/OPCDevice.h"
+#include "plugins/openpixelcontrol/OpcDevice.h"
 
 #include <sstream>
 #include <set>
@@ -27,7 +27,7 @@
 
 #include "ola/Logging.h"
 #include "olad/Preferences.h"
-#include "plugins/openpixelcontrol/OPCPort.h"
+#include "plugins/openpixelcontrol/OpcPort.h"
 
 namespace ola {
 namespace plugin {
@@ -57,7 +57,7 @@ set<uint8_t> DeDupChannels(const vector<string> &channels) {
 }
 }  // namespace
 
-OPCServerDevice::OPCServerDevice(
+OpcServerDevice::OpcServerDevice(
     AbstractPlugin *owner,
     PluginAdaptor *plugin_adaptor,
     Preferences *preferences,
@@ -66,14 +66,14 @@ OPCServerDevice::OPCServerDevice(
       m_plugin_adaptor(plugin_adaptor),
       m_preferences(preferences),
       m_listen_addr(listen_addr),
-      m_server(new OPCServer(plugin_adaptor, listen_addr)) {
+      m_server(new OpcServer(plugin_adaptor, listen_addr)) {
 }
 
-string OPCServerDevice::DeviceId() const {
+string OpcServerDevice::DeviceId() const {
   return m_listen_addr.ToString();
 }
 
-bool OPCServerDevice::StartHook() {
+bool OpcServerDevice::StartHook() {
   if (!m_server->Init()) {
     return false;
   }
@@ -84,14 +84,14 @@ bool OPCServerDevice::StartHook() {
       m_preferences->GetMultipleValue(str.str()));
   set<uint8_t>::const_iterator iter = channels.begin();
   for (; iter != channels.end(); ++iter) {
-    OPCInputPort *port = new OPCInputPort(this, *iter, m_plugin_adaptor,
+    OpcInputPort *port = new OpcInputPort(this, *iter, m_plugin_adaptor,
                                           m_server.get());
     AddPort(port);
   }
   return true;
 }
 
-OPCClientDevice::OPCClientDevice(AbstractPlugin *owner,
+OpcClientDevice::OpcClientDevice(AbstractPlugin *owner,
                                  PluginAdaptor *plugin_adaptor,
                                  Preferences *preferences,
                                  const ola::network::IPV4SocketAddress target)
@@ -99,21 +99,21 @@ OPCClientDevice::OPCClientDevice(AbstractPlugin *owner,
       m_plugin_adaptor(plugin_adaptor),
       m_preferences(preferences),
       m_target(target),
-      m_client(new OPCClient(plugin_adaptor, target)) {
+      m_client(new OpcClient(plugin_adaptor, target)) {
 }
 
-string OPCClientDevice::DeviceId() const {
+string OpcClientDevice::DeviceId() const {
   return m_target.ToString();
 }
 
-bool OPCClientDevice::StartHook() {
+bool OpcClientDevice::StartHook() {
   ostringstream str;
   str << "target_" << m_target << "_channel";
   set<uint8_t> channels = DeDupChannels(
       m_preferences->GetMultipleValue(str.str()));
   set<uint8_t>::const_iterator iter = channels.begin();
   for (; iter != channels.end(); ++iter) {
-    OPCOutputPort *port = new OPCOutputPort(this, *iter, m_client.get());
+    OpcOutputPort *port = new OpcOutputPort(this, *iter, m_client.get());
     AddPort(port);
   }
   return true;

--- a/plugins/openpixelcontrol/OpcDevice.h
+++ b/plugins/openpixelcontrol/OpcDevice.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCDevice.h
+ * OpcDevice.h
  * The Open Pixel Control Device.
  * Copyright (C) 2014 Simon Newton
  */
@@ -26,8 +26,8 @@
 
 #include "ola/network/Socket.h"
 #include "olad/Device.h"
-#include "plugins/openpixelcontrol/OPCClient.h"
-#include "plugins/openpixelcontrol/OPCServer.h"
+#include "plugins/openpixelcontrol/OpcClient.h"
+#include "plugins/openpixelcontrol/OpcServer.h"
 
 namespace ola {
 
@@ -36,7 +36,7 @@ class AbstractPlugin;
 namespace plugin {
 namespace openpixelcontrol {
 
-class OPCServerDevice: public ola::Device {
+class OpcServerDevice: public ola::Device {
  public:
   /**
    * @brief Create a new OPC server device.
@@ -45,7 +45,7 @@ class OPCServerDevice: public ola::Device {
    * @param preferences the Preferences container.
    * @param listen_addr the IP:port to listen on.
    */
-  OPCServerDevice(AbstractPlugin *owner,
+  OpcServerDevice(AbstractPlugin *owner,
                   PluginAdaptor *plugin_adaptor,
                   Preferences *preferences,
                   const ola::network::IPV4SocketAddress listen_addr);
@@ -61,12 +61,12 @@ class OPCServerDevice: public ola::Device {
   PluginAdaptor* const m_plugin_adaptor;
   Preferences* const m_preferences;
   const ola::network::IPV4SocketAddress m_listen_addr;
-  std::auto_ptr<class OPCServer> m_server;
+  std::auto_ptr<class OpcServer> m_server;
 
-  DISALLOW_COPY_AND_ASSIGN(OPCServerDevice);
+  DISALLOW_COPY_AND_ASSIGN(OpcServerDevice);
 };
 
-class OPCClientDevice: public ola::Device {
+class OpcClientDevice: public ola::Device {
  public:
   /**
    * @brief Create a new OPC client device.
@@ -75,7 +75,7 @@ class OPCClientDevice: public ola::Device {
    * @param preferences the Preferences container.
    * @param target the IP:port to connect to.
    */
-  OPCClientDevice(AbstractPlugin *owner,
+  OpcClientDevice(AbstractPlugin *owner,
                   PluginAdaptor *plugin_adaptor,
                   Preferences *preferences,
                   const ola::network::IPV4SocketAddress target);
@@ -91,9 +91,9 @@ class OPCClientDevice: public ola::Device {
   PluginAdaptor* const m_plugin_adaptor;
   Preferences* const m_preferences;
   const ola::network::IPV4SocketAddress m_target;
-  std::auto_ptr<class OPCClient> m_client;
+  std::auto_ptr<class OpcClient> m_client;
 
-  DISALLOW_COPY_AND_ASSIGN(OPCClientDevice);
+  DISALLOW_COPY_AND_ASSIGN(OpcClientDevice);
 };
 }  // namespace openpixelcontrol
 }  // namespace plugin

--- a/plugins/openpixelcontrol/OpcPlugin.cpp
+++ b/plugins/openpixelcontrol/OpcPlugin.cpp
@@ -13,12 +13,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCPlugin.cpp
+ * OpcPlugin.cpp
  * The Open Pixel Control Plugin.
  * Copyright (C) 2014 Simon Newton
  */
 
-#include "plugins/openpixelcontrol/OPCPlugin.h"
+#include "plugins/openpixelcontrol/OpcPlugin.h"
 
 #include <memory>
 #include <string>
@@ -29,8 +29,8 @@
 #include "olad/Device.h"
 #include "olad/PluginAdaptor.h"
 #include "olad/Preferences.h"
-#include "plugins/openpixelcontrol/OPCDevice.h"
-#include "plugins/openpixelcontrol/OPCPluginDescription.h"
+#include "plugins/openpixelcontrol/OpcDevice.h"
+#include "plugins/openpixelcontrol/OpcPluginDescription.h"
 
 namespace ola {
 namespace plugin {
@@ -40,24 +40,24 @@ using ola::network::IPV4SocketAddress;
 using std::string;
 using std::vector;
 
-const char OPCPlugin::LISTEN_KEY[] = "listen";
-const char OPCPlugin::PLUGIN_NAME[] = "Open Pixel Control";
-const char OPCPlugin::PLUGIN_PREFIX[] = "openpixelcontrol";
-const char OPCPlugin::TARGET_KEY[] = "target";
+const char OpcPlugin::LISTEN_KEY[] = "listen";
+const char OpcPlugin::PLUGIN_NAME[] = "Open Pixel Control";
+const char OpcPlugin::PLUGIN_PREFIX[] = "openpixelcontrol";
+const char OpcPlugin::TARGET_KEY[] = "target";
 
-OPCPlugin::~OPCPlugin() {}
+OpcPlugin::~OpcPlugin() {}
 
-bool OPCPlugin::StartHook() {
+bool OpcPlugin::StartHook() {
   // Start Target (output) devices.
-  AddDevices<OPCClientDevice>(TARGET_KEY);
+  AddDevices<OpcClientDevice>(TARGET_KEY);
 
   // Start listen (input) devices.
-  AddDevices<OPCServerDevice>(LISTEN_KEY);
+  AddDevices<OpcServerDevice>(LISTEN_KEY);
   return true;
 }
 
-bool OPCPlugin::StopHook() {
-  OPCDevices::iterator iter = m_devices.begin();
+bool OpcPlugin::StopHook() {
+  OpcDevices::iterator iter = m_devices.begin();
   for (; iter != m_devices.end(); ++iter) {
     m_plugin_adaptor->UnregisterDevice(*iter);
     (*iter)->Stop();
@@ -67,11 +67,11 @@ bool OPCPlugin::StopHook() {
   return true;
 }
 
-string OPCPlugin::Description() const {
+string OpcPlugin::Description() const {
     return plugin_description;
 }
 
-bool OPCPlugin::SetDefaultPreferences() {
+bool OpcPlugin::SetDefaultPreferences() {
   if (!m_preferences) {
     return false;
   }
@@ -80,7 +80,7 @@ bool OPCPlugin::SetDefaultPreferences() {
 }
 
 template <typename DeviceClass>
-void OPCPlugin::AddDevices(const std::string &key) {
+void OpcPlugin::AddDevices(const std::string &key) {
   vector<string> addresses = m_preferences->GetMultipleValue(key);
   vector<string>::const_iterator iter = addresses.begin();
   for (; iter != addresses.end(); ++iter) {
@@ -94,7 +94,7 @@ void OPCPlugin::AddDevices(const std::string &key) {
         this, m_plugin_adaptor, m_preferences, target));
 
     if (!device->Start()) {
-      OLA_INFO << "Failed to start OPCDevice";
+      OLA_INFO << "Failed to start OpcDevice";
       continue;
     }
 

--- a/plugins/openpixelcontrol/OpcPlugin.h
+++ b/plugins/openpixelcontrol/OpcPlugin.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCPlugin.h
+ * OpcPlugin.h
  * The Open Pixel Control Plugin.
  * Copyright (C) 2014 Simon Newton
  */
@@ -31,11 +31,11 @@ namespace ola {
 namespace plugin {
 namespace openpixelcontrol {
 
-class OPCPlugin: public Plugin {
+class OpcPlugin: public Plugin {
  public:
-  explicit OPCPlugin(PluginAdaptor *plugin_adaptor)
+  explicit OpcPlugin(PluginAdaptor *plugin_adaptor)
       : Plugin(plugin_adaptor) {}
-  ~OPCPlugin();
+  ~OpcPlugin();
 
   std::string Name() const { return PLUGIN_NAME; }
   ola_plugin_id Id() const { return OLA_PLUGIN_OPENPIXELCONTROL; }
@@ -43,8 +43,8 @@ class OPCPlugin: public Plugin {
   std::string PluginPrefix() const { return PLUGIN_PREFIX; }
 
  private:
-  typedef std::vector<ola::Device*> OPCDevices;
-  OPCDevices m_devices;
+  typedef std::vector<ola::Device*> OpcDevices;
+  OpcDevices m_devices;
 
   bool StartHook();
   bool StopHook();

--- a/plugins/openpixelcontrol/OpcPort.cpp
+++ b/plugins/openpixelcontrol/OpcPort.cpp
@@ -13,19 +13,19 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCPort.cpp
+ * OpcPort.cpp
  * The OPC Port for ola
  * Copyright (C) 2014 Simon Newton
  */
 
-#include "plugins/openpixelcontrol/OPCPort.h"
+#include "plugins/openpixelcontrol/OpcPort.h"
 
 #include <string>
 #include "ola/base/Macro.h"
-#include "plugins/openpixelcontrol/OPCClient.h"
-#include "plugins/openpixelcontrol/OPCConstants.h"
-#include "plugins/openpixelcontrol/OPCDevice.h"
-#include "plugins/openpixelcontrol/OPCServer.h"
+#include "plugins/openpixelcontrol/OpcClient.h"
+#include "plugins/openpixelcontrol/OpcConstants.h"
+#include "plugins/openpixelcontrol/OpcDevice.h"
+#include "plugins/openpixelcontrol/OpcServer.h"
 
 namespace ola {
 namespace plugin {
@@ -33,17 +33,17 @@ namespace openpixelcontrol {
 
 using std::string;
 
-OPCInputPort::OPCInputPort(OPCServerDevice *parent,
+OpcInputPort::OpcInputPort(OpcServerDevice *parent,
                            uint8_t channel,
                            class PluginAdaptor *plugin_adaptor,
-                           class OPCServer *server)
+                           class OpcServer *server)
     : BasicInputPort(parent, channel, plugin_adaptor),
       m_channel(channel),
       m_server(server) {
-  m_server->SetCallback(channel, NewCallback(this, &OPCInputPort::NewData));
+  m_server->SetCallback(channel, NewCallback(this, &OpcInputPort::NewData));
 }
 
-void OPCInputPort::NewData(uint8_t command,
+void OpcInputPort::NewData(uint8_t command,
                            const uint8_t *data,
                            unsigned int length) {
   if (command != SET_PIXEL_COMMAND) {
@@ -55,27 +55,27 @@ void OPCInputPort::NewData(uint8_t command,
   DmxChanged();
 }
 
-string OPCInputPort::Description() const {
+string OpcInputPort::Description() const {
   std::ostringstream str;
   str << m_server->ListenAddress() << ", Channel "
       << static_cast<int>(m_channel);
   return str.str();
 }
 
-OPCOutputPort::OPCOutputPort(OPCClientDevice *parent,
+OpcOutputPort::OpcOutputPort(OpcClientDevice *parent,
                              uint8_t channel,
-                             OPCClient *client)
+                             OpcClient *client)
     : BasicOutputPort(parent, channel),
       m_client(client),
       m_channel(channel) {
 }
 
-bool OPCOutputPort::WriteDMX(const DmxBuffer &buffer,
+bool OpcOutputPort::WriteDMX(const DmxBuffer &buffer,
                              OLA_UNUSED uint8_t priority) {
   return m_client->SendDmx(m_channel, buffer);
 }
 
-string OPCOutputPort::Description() const {
+string OpcOutputPort::Description() const {
   std::ostringstream str;
   str << m_client->GetRemoteAddress() << ", Channel "
       << static_cast<int>(m_channel);

--- a/plugins/openpixelcontrol/OpcPort.h
+++ b/plugins/openpixelcontrol/OpcPort.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCPort.h
+ * OpcPort.h
  * Ports for the Open Pixel Control plugin.
  * Copyright (C) 2014 Simon Newton
  */
@@ -24,7 +24,7 @@
 #include <string>
 #include "ola/DmxBuffer.h"
 #include "olad/Port.h"
-#include "plugins/openpixelcontrol/OPCDevice.h"
+#include "plugins/openpixelcontrol/OpcDevice.h"
 
 namespace ola {
 namespace plugin {
@@ -33,21 +33,21 @@ namespace openpixelcontrol {
 /**
  * @brief An InputPort for the OPC plugin.
  *
- * OPCInputPorts correspond to a listening TCP socket.
+ * OpcInputPorts correspond to a listening TCP socket.
  */
-class OPCInputPort: public BasicInputPort {
+class OpcInputPort: public BasicInputPort {
  public:
   /**
    * @brief Create a new OPC Input Port.
-   * @param parent the OPCDevice this port belongs to
+   * @param parent the OpcDevice this port belongs to
    * @param channel the OPC channel for the port.
    * @param plugin_adaptor the PluginAdaptor to use
-   * @param server the OPCServer to use, ownership is not transferred.
+   * @param server the OpcServer to use, ownership is not transferred.
    */
-  OPCInputPort(OPCServerDevice *parent,
+  OpcInputPort(OpcServerDevice *parent,
                uint8_t channel,
                class PluginAdaptor *plugin_adaptor,
-               class OPCServer *server);
+               class OpcServer *server);
 
   const DmxBuffer &ReadDMX() const { return m_buffer; }
 
@@ -57,39 +57,39 @@ class OPCInputPort: public BasicInputPort {
 
  private:
   const uint8_t m_channel;
-  class OPCServer* const m_server;
+  class OpcServer* const m_server;
   DmxBuffer m_buffer;
 
   void NewData(uint8_t command, const uint8_t *data, unsigned int length);
 
-  DISALLOW_COPY_AND_ASSIGN(OPCInputPort);
+  DISALLOW_COPY_AND_ASSIGN(OpcInputPort);
 };
 
 /**
  * @brief An OutputPort for the OPC plugin.
  */
-class OPCOutputPort: public BasicOutputPort {
+class OpcOutputPort: public BasicOutputPort {
  public:
   /**
    * @brief Create a new OPC Output Port.
-   * @param parent the OPCDevice this port belongs to
+   * @param parent the OpcDevice this port belongs to
    * @param channel the OPC channel for the port.
-   * @param client the OPCClient to use for this port, ownership is not
+   * @param client the OpcClient to use for this port, ownership is not
    *   transferred.
    */
-  OPCOutputPort(OPCClientDevice *parent,
+  OpcOutputPort(OpcClientDevice *parent,
                 uint8_t channel,
-                class OPCClient *client);
+                class OpcClient *client);
 
   bool WriteDMX(const DmxBuffer &buffer, uint8_t priority);
 
   std::string Description() const;
 
  private:
-  class OPCClient* const m_client;
+  class OpcClient* const m_client;
   const uint8_t m_channel;
 
-  DISALLOW_COPY_AND_ASSIGN(OPCOutputPort);
+  DISALLOW_COPY_AND_ASSIGN(OpcOutputPort);
 };
 }  // namespace openpixelcontrol
 }  // namespace plugin

--- a/plugins/openpixelcontrol/OpcServer.cpp
+++ b/plugins/openpixelcontrol/OpcServer.cpp
@@ -13,12 +13,12 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCServer.cpp
+ * OpcServer.cpp
  * The Open Pixel Server.
  * Copyright (C) 2014 Simon Newton
  */
 
-#include "plugins/openpixelcontrol/OPCServer.h"
+#include "plugins/openpixelcontrol/OpcServer.h"
 
 #include <string>
 #include "ola/Callback.h"
@@ -45,7 +45,7 @@ void CleanupSocket(TCPSocket *socket) {
 }
 }  // namespace
 
-void OPCServer::RxState::CheckSize() {
+void OpcServer::RxState::CheckSize() {
   expected_size = utils::JoinUInt8(data[2], data[3]);
   if (static_cast<unsigned int>(expected_size) + OPC_HEADER_SIZE >
       buffer_size) {
@@ -57,15 +57,15 @@ void OPCServer::RxState::CheckSize() {
   }
 }
 
-OPCServer::OPCServer(ola::io::SelectServerInterface *ss,
+OpcServer::OpcServer(ola::io::SelectServerInterface *ss,
                      const ola::network::IPV4SocketAddress &listen_addr)
     : m_ss(ss),
       m_listen_addr(listen_addr),
       m_tcp_socket_factory(
-          ola::NewCallback(this, &OPCServer::NewTCPConnection)) {
+          ola::NewCallback(this, &OpcServer::NewTCPConnection)) {
 }
 
-OPCServer::~OPCServer() {
+OpcServer::~OpcServer() {
   if (m_listening_socket.get()) {
     m_ss->RemoveReadDescriptor(m_listening_socket.get());
     m_listening_socket.reset();
@@ -81,7 +81,7 @@ OPCServer::~OPCServer() {
   STLDeleteValues(&m_callbacks);
 }
 
-bool OPCServer::Init() {
+bool OpcServer::Init() {
   std::auto_ptr<TCPAcceptingSocket> listening_socket(
       new TCPAcceptingSocket(&m_tcp_socket_factory));
   if (!listening_socket->Listen(m_listen_addr)) {
@@ -92,7 +92,7 @@ bool OPCServer::Init() {
   return true;
 }
 
-IPV4SocketAddress OPCServer::ListenAddress() const {
+IPV4SocketAddress OpcServer::ListenAddress() const {
   if (m_listening_socket.get()) {
     GenericSocketAddress addr = m_listening_socket->GetLocalAddress();
     if (addr.Family() == AF_INET) {
@@ -102,11 +102,11 @@ IPV4SocketAddress OPCServer::ListenAddress() const {
   return IPV4SocketAddress();
 }
 
-void OPCServer::SetCallback(uint8_t channel, ChannelCallback *callback) {
+void OpcServer::SetCallback(uint8_t channel, ChannelCallback *callback) {
   STLReplaceAndDelete(&m_callbacks, channel, callback);
 }
 
-void OPCServer::NewTCPConnection(TCPSocket *socket) {
+void OpcServer::NewTCPConnection(TCPSocket *socket) {
   if (!socket)
     return;
 
@@ -114,14 +114,14 @@ void OPCServer::NewTCPConnection(TCPSocket *socket) {
 
   socket->SetNoDelay();
   socket->SetOnData(
-      NewCallback(this, &OPCServer::SocketReady, socket, rx_state));
+      NewCallback(this, &OpcServer::SocketReady, socket, rx_state));
   socket->SetOnClose(
-      NewSingleCallback(this, &OPCServer::SocketClosed, socket));
+      NewSingleCallback(this, &OpcServer::SocketClosed, socket));
   m_ss->AddReadDescriptor(socket);
   STLReplaceAndDelete(&m_clients, socket, rx_state);
 }
 
-void OPCServer::SocketReady(TCPSocket *socket, RxState *rx_state) {
+void OpcServer::SocketReady(TCPSocket *socket, RxState *rx_state) {
   unsigned int data_received = 0;
   if (socket->Receive(rx_state->data + rx_state->offset,
                       rx_state->buffer_size - rx_state->offset,
@@ -154,7 +154,7 @@ void OPCServer::SocketReady(TCPSocket *socket, RxState *rx_state) {
   rx_state->expected_size = 0;
 }
 
-void OPCServer::SocketClosed(TCPSocket *socket) {
+void OpcServer::SocketClosed(TCPSocket *socket) {
   m_ss->RemoveReadDescriptor(socket);
   STLRemoveAndDelete(&m_clients, socket);
 

--- a/plugins/openpixelcontrol/OpcServer.h
+++ b/plugins/openpixelcontrol/OpcServer.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCServer.h
+ * OpcServer.h
  * The Open Pixel Server.
  * Copyright (C) 2014 Simon Newton
  */
@@ -30,7 +30,7 @@
 #include "ola/network/SocketAddress.h"
 #include "ola/network/TCPSocket.h"
 #include "ola/network/TCPSocketFactory.h"
-#include "plugins/openpixelcontrol/OPCConstants.h"
+#include "plugins/openpixelcontrol/OpcConstants.h"
 
 namespace ola {
 namespace plugin {
@@ -41,7 +41,7 @@ namespace openpixelcontrol {
  *
  * The server listens on a TCP port and receives OPC data.
  */
-class OPCServer {
+class OpcServer {
  public:
   /**
    * @brief The callback executed when new OPC data arrives.
@@ -50,20 +50,20 @@ class OPCServer {
       ChannelCallback;
 
   /**
-   * @brief Create a new OPCServer.
+   * @brief Create a new OpcServer.
    * @param ss The SelectServer to use
    * @param listen_addr the IP:port to listen on.
    */
-  OPCServer(ola::io::SelectServerInterface *ss,
+  OpcServer(ola::io::SelectServerInterface *ss,
             const ola::network::IPV4SocketAddress &listen_addr);
 
   /**
    * @brief Destructor.
    */
-  ~OPCServer();
+  ~OpcServer();
 
   /**
-   * @brief Initialize the OPCServer.
+   * @brief Initialize the OpcServer.
    * @returns true if the server is now listening for new connections, false
    *   otherwise.
    */
@@ -120,7 +120,7 @@ class OPCServer {
   void SocketReady(ola::network::TCPSocket *socket, RxState *rx_state);
   void SocketClosed(ola::network::TCPSocket *socket);
 
-  DISALLOW_COPY_AND_ASSIGN(OPCServer);
+  DISALLOW_COPY_AND_ASSIGN(OpcServer);
 };
 }  // namespace openpixelcontrol
 }  // namespace plugin

--- a/plugins/openpixelcontrol/OpcServerTest.cpp
+++ b/plugins/openpixelcontrol/OpcServerTest.cpp
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OPCServerTest.cpp
- * Test fixture for the OPCServer class
+ * OpcServerTest.cpp
+ * Test fixture for the OpcServer class
  * Copyright (C) 2014 Simon Newton
  */
 
@@ -31,18 +31,18 @@
 #include "ola/network/TCPSocket.h"
 #include "ola/testing/TestUtils.h"
 #include "ola/util/Utils.h"
-#include "plugins/openpixelcontrol/OPCServer.h"
+#include "plugins/openpixelcontrol/OpcServer.h"
 
 
 using ola::DmxBuffer;
 using ola::network::IPV4Address;
 using ola::network::IPV4SocketAddress;
 using ola::network::TCPSocket;
-using ola::plugin::openpixelcontrol::OPCServer;
+using ola::plugin::openpixelcontrol::OpcServer;
 using std::auto_ptr;
 
-class OPCServerTest: public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(OPCServerTest);
+class OpcServerTest: public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(OpcServerTest);
   CPPUNIT_TEST(testReceiveDmx);
   CPPUNIT_TEST(testUnknownCommand);
   CPPUNIT_TEST(testLargeFrame);
@@ -50,7 +50,7 @@ class OPCServerTest: public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE_END();
 
  public:
-  OPCServerTest()
+  OpcServerTest()
       : CppUnit::TestFixture(),
         m_ss(NULL) {
   }
@@ -63,7 +63,7 @@ class OPCServerTest: public CppUnit::TestFixture {
 
  private:
   ola::io::SelectServer m_ss;
-  auto_ptr<OPCServer> m_server;
+  auto_ptr<OpcServer> m_server;
   auto_ptr<TCPSocket> m_client_socket;
   DmxBuffer m_received_data;
   uint8_t m_command;
@@ -81,21 +81,21 @@ class OPCServerTest: public CppUnit::TestFixture {
   static const uint8_t SET_PIXELS_COMMAND = 0;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(OPCServerTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(OpcServerTest);
 
-void OPCServerTest::setUp() {
+void OpcServerTest::setUp() {
   IPV4SocketAddress listen_addr(IPV4Address::Loopback(), 0);
-  m_server.reset(new OPCServer(&m_ss, listen_addr));
+  m_server.reset(new OpcServer(&m_ss, listen_addr));
   m_server->SetCallback(
       CHANNEL,
-      ola::NewCallback(this, &OPCServerTest::CaptureData));
+      ola::NewCallback(this, &OpcServerTest::CaptureData));
 
   OLA_ASSERT_TRUE(m_server->Init());
 
   m_client_socket.reset(TCPSocket::Connect(m_server->ListenAddress()));
 }
 
-void OPCServerTest::SendDataAndCheck(uint8_t channel,
+void OpcServerTest::SendDataAndCheck(uint8_t channel,
                                      const DmxBuffer &buffer) {
   unsigned int dmx_size = buffer.Size();
   uint8_t data[dmx_size + 4];
@@ -109,7 +109,7 @@ void OPCServerTest::SendDataAndCheck(uint8_t channel,
   OLA_ASSERT_EQ(m_received_data, buffer);
 }
 
-void OPCServerTest::testReceiveDmx() {
+void OpcServerTest::testReceiveDmx() {
   DmxBuffer buffer;
   buffer.SetFromString("1,2,3,4");
   SendDataAndCheck(CHANNEL, buffer);
@@ -119,7 +119,7 @@ void OPCServerTest::testReceiveDmx() {
   SendDataAndCheck(CHANNEL, buffer);
 }
 
-void OPCServerTest::testUnknownCommand() {
+void OpcServerTest::testUnknownCommand() {
   uint8_t data[] = {1, 1, 0, 2, 3, 4};
   m_client_socket->Send(data, arraysize(data));
   m_ss.Run();
@@ -130,7 +130,7 @@ void OPCServerTest::testUnknownCommand() {
   OLA_ASSERT_EQ(m_received_data, buffer);
 }
 
-void OPCServerTest::testLargeFrame() {
+void OpcServerTest::testLargeFrame() {
   uint8_t data[1028];
   data[0] = 1;
   data[1] = 0;
@@ -147,7 +147,7 @@ void OPCServerTest::testLargeFrame() {
   OLA_ASSERT_EQ(m_received_data, buffer);
 }
 
-void OPCServerTest::testHangingFrame() {
+void OpcServerTest::testHangingFrame() {
   uint8_t data[] = {1, 0};
   m_client_socket->Send(data, arraysize(data));
 }

--- a/plugins/osc/Makefile.mk
+++ b/plugins/osc/Makefile.mk
@@ -4,30 +4,30 @@ if USE_OSC
 # This is a library which isn't coupled to olad
 noinst_LTLIBRARIES += plugins/osc/libolaoscnode.la
 plugins_osc_libolaoscnode_la_SOURCES = \
-    plugins/osc/OSCAddressTemplate.cpp \
-    plugins/osc/OSCAddressTemplate.h \
-    plugins/osc/OSCNode.cpp \
-    plugins/osc/OSCNode.h \
-    plugins/osc/OSCTarget.h
+    plugins/osc/OscAddressTemplate.cpp \
+    plugins/osc/OscAddressTemplate.h \
+    plugins/osc/OscNode.cpp \
+    plugins/osc/OscNode.h \
+    plugins/osc/OscTarget.h
 plugins_osc_libolaoscnode_la_CXXFLAGS = $(COMMON_CXXFLAGS) $(liblo_CFLAGS)
 plugins_osc_libolaoscnode_la_LIBADD = $(liblo_LIBS)
 
 lib_LTLIBRARIES += plugins/osc/libolaosc.la
 
 # Plugin description is generated from README.md
-built_sources += plugins/osc/OSCPluginDescription.h
+built_sources += plugins/osc/OscPluginDescription.h
 nodist_plugins_osc_libolaosc_la_SOURCES = \
-    plugins/osc/OSCPluginDescription.h
-plugins/osc/OSCPluginDescription.h: plugins/osc/README.md plugins/osc/Makefile.mk plugins/convert_README_to_header.sh
-	sh $(top_srcdir)/plugins/convert_README_to_header.sh $(top_srcdir)/plugins/osc $(top_builddir)/plugins/osc/OSCPluginDescription.h
+    plugins/osc/OscPluginDescription.h
+plugins/osc/OscPluginDescription.h: plugins/osc/README.md plugins/osc/Makefile.mk plugins/convert_README_to_header.sh
+	sh $(top_srcdir)/plugins/convert_README_to_header.sh $(top_srcdir)/plugins/osc $(top_builddir)/plugins/osc/OscPluginDescription.h
 
 plugins_osc_libolaosc_la_SOURCES = \
-    plugins/osc/OSCDevice.cpp \
-    plugins/osc/OSCDevice.h \
-    plugins/osc/OSCPlugin.cpp \
-    plugins/osc/OSCPlugin.h \
-    plugins/osc/OSCPort.cpp \
-    plugins/osc/OSCPort.h
+    plugins/osc/OscDevice.cpp \
+    plugins/osc/OscDevice.h \
+    plugins/osc/OscPlugin.cpp \
+    plugins/osc/OscPlugin.h \
+    plugins/osc/OscPort.cpp \
+    plugins/osc/OscPort.h
 plugins_osc_libolaosc_la_CXXFLAGS = $(COMMON_CXXFLAGS) $(liblo_CFLAGS)
 plugins_osc_libolaosc_la_LIBADD = \
     olad/plugin_api/libolaserverplugininterface.la \
@@ -35,13 +35,13 @@ plugins_osc_libolaosc_la_LIBADD = \
 
 # TESTS
 ##################################################
-test_programs += plugins/osc/OSCTester
+test_programs += plugins/osc/OscTester
 
-plugins_osc_OSCTester_SOURCES = \
-    plugins/osc/OSCAddressTemplateTest.cpp \
-    plugins/osc/OSCNodeTest.cpp
-plugins_osc_OSCTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
-plugins_osc_OSCTester_LDADD = $(COMMON_TESTING_LIBS) \
+plugins_osc_OscTester_SOURCES = \
+    plugins/osc/OscAddressTemplateTest.cpp \
+    plugins/osc/OscNodeTest.cpp
+plugins_osc_OscTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
+plugins_osc_OscTester_LDADD = $(COMMON_TESTING_LIBS) \
                   plugins/osc/libolaoscnode.la \
                   common/libolacommon.la
 endif

--- a/plugins/osc/OscAddressTemplate.cpp
+++ b/plugins/osc/OscAddressTemplate.cpp
@@ -13,14 +13,14 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCAddressTemplate.cpp
+ * OscAddressTemplate.cpp
  * Expand a template, substituting values.
  * Copyright (C) 2012 Simon Newton
  */
 
 #include <string>
 #include "ola/StringUtils.h"
-#include "plugins/osc/OSCAddressTemplate.h"
+#include "plugins/osc/OscAddressTemplate.h"
 
 namespace ola {
 namespace plugin {

--- a/plugins/osc/OscAddressTemplate.h
+++ b/plugins/osc/OscAddressTemplate.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCAddressTemplate.h
+ * OscAddressTemplate.h
  * Expand a template, substituting values.
  * Copyright (C) 2012 Simon Newton
  */

--- a/plugins/osc/OscAddressTemplateTest.cpp
+++ b/plugins/osc/OscAddressTemplateTest.cpp
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCAddressTemplateTest.cpp
- * Test fixture for the OSCAddressTemplate function.
+ * OscAddressTemplateTest.cpp
+ * Test fixture for the OscAddressTemplate function.
  * Copyright (C) 2012 Simon Newton
  */
 
@@ -22,13 +22,13 @@
 #include <string>
 
 #include "ola/testing/TestUtils.h"
-#include "plugins/osc/OSCAddressTemplate.h"
+#include "plugins/osc/OscAddressTemplate.h"
 
 using ola::plugin::osc::ExpandTemplate;
 using std::string;
 
-class OSCAddressTemplateTest: public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(OSCAddressTemplateTest);
+class OscAddressTemplateTest: public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(OscAddressTemplateTest);
   // The tests to run.
   CPPUNIT_TEST(testExpand);
   CPPUNIT_TEST_SUITE_END();
@@ -39,12 +39,12 @@ class OSCAddressTemplateTest: public CppUnit::TestFixture {
 };
 
 // Register this test class
-CPPUNIT_TEST_SUITE_REGISTRATION(OSCAddressTemplateTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(OscAddressTemplateTest);
 
 /**
  * Check that ExpandTemplate() works.
  */
-void OSCAddressTemplateTest::testExpand() {
+void OscAddressTemplateTest::testExpand() {
   OLA_ASSERT_EQ(string(""), ExpandTemplate("", 0));
   OLA_ASSERT_EQ(string("foo"), ExpandTemplate("foo", 0));
   OLA_ASSERT_EQ(string("/dmx/universe/0"),

--- a/plugins/osc/OscDevice.cpp
+++ b/plugins/osc/OscDevice.cpp
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCDevice.cpp
+ * OscDevice.cpp
  * The OSC Device.
  * Copyright (C) 2012 Simon Newton
  */
@@ -23,8 +23,8 @@
 
 #include "ola/Logging.h"
 #include "ola/io/SelectServerInterface.h"
-#include "plugins/osc/OSCDevice.h"
-#include "plugins/osc/OSCPort.h"
+#include "plugins/osc/OscDevice.h"
+#include "plugins/osc/OscPort.h"
 
 namespace ola {
 namespace plugin {
@@ -33,10 +33,10 @@ namespace osc {
 using std::string;
 using std::vector;
 
-const char OSCDevice::DEVICE_NAME[] = "OSC Device";
+const char OscDevice::DEVICE_NAME[] = "OSC Device";
 
 /**
- * Constructor for the OSCDevice
+ * Constructor for the OscDevice
  * @param owner the plugin which created this device
  * @param plugin_adaptor a pointer to a PluginAdaptor object
  * @param udp_port the UDP port to listen on
@@ -44,7 +44,7 @@ const char OSCDevice::DEVICE_NAME[] = "OSC Device";
  *   ports.
  * @param port_configs config to use for the ports
  */
-OSCDevice::OSCDevice(AbstractPlugin *owner,
+OscDevice::OscDevice(AbstractPlugin *owner,
                      PluginAdaptor *plugin_adaptor,
                      uint16_t udp_port,
                      const vector<string> &addresses,
@@ -53,10 +53,10 @@ OSCDevice::OSCDevice(AbstractPlugin *owner,
       m_plugin_adaptor(plugin_adaptor),
       m_port_addresses(addresses),
       m_port_configs(port_configs) {
-  OSCNode::OSCNodeOptions options;
+  OscNode::OscNodeOptions options;
   options.listen_port = udp_port;
-  // allocate a new OSCNode but delay the call to Init() until later
-  m_osc_node.reset(new OSCNode(plugin_adaptor, plugin_adaptor->GetExportMap(),
+  // allocate a new OscNode but delay the call to Init() until later
+  m_osc_node.reset(new OscNode(plugin_adaptor, plugin_adaptor->GetExportMap(),
                                options));
 }
 
@@ -64,14 +64,14 @@ OSCDevice::OSCDevice(AbstractPlugin *owner,
  * Start this device.
  * @returns true if the device started successfully, false otherwise.
  */
-bool OSCDevice::StartHook() {
+bool OscDevice::StartHook() {
   bool ok = true;
   if (!m_osc_node->Init())
     return false;
 
   // Create an input port for each OSC Address.
   for (unsigned int i = 0; i < m_port_addresses.size(); ++i) {
-    OSCInputPort *port = new OSCInputPort(this, i, m_plugin_adaptor,
+    OscInputPort *port = new OscInputPort(this, i, m_plugin_adaptor,
                                           m_osc_node.get(),
                                           m_port_addresses[i]);
     if (!AddPort(port)) {
@@ -89,7 +89,7 @@ bool OSCDevice::StartHook() {
       continue;
     }
 
-    OSCOutputPort *port = new OSCOutputPort(this, i, m_osc_node.get(),
+    OscOutputPort *port = new OscOutputPort(this, i, m_osc_node.get(),
                                             port_config.targets,
                                             port_config.data_format);
     if (!AddPort(port)) {

--- a/plugins/osc/OscDevice.h
+++ b/plugins/osc/OscDevice.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCDevice.h
+ * OscDevice.h
  * The OSC Device.
  * Copyright (C) 2012 Simon Newton
  */
@@ -27,8 +27,8 @@
 #include "ola/io/SelectServerInterface.h"
 #include "ola/network/SocketAddress.h"
 #include "olad/Device.h"
-#include "plugins/osc/OSCTarget.h"
-#include "plugins/osc/OSCNode.h"
+#include "plugins/osc/OscTarget.h"
+#include "plugins/osc/OscNode.h"
 
 namespace ola {
 
@@ -37,18 +37,18 @@ class AbstractPlugin;
 namespace plugin {
 namespace osc {
 
-class OSCDevice: public Device {
+class OscDevice: public Device {
  public:
     struct PortConfig {
-      PortConfig() : data_format(OSCNode::FORMAT_BLOB) {}
+      PortConfig() : data_format(OscNode::FORMAT_BLOB) {}
 
-      std::vector<OSCTarget> targets;
-      OSCNode::DataFormat data_format;
+      std::vector<OscTarget> targets;
+      OscNode::DataFormat data_format;
     };
 
     typedef std::vector<PortConfig> PortConfigs;
 
-    OSCDevice(AbstractPlugin *owner,
+    OscDevice(AbstractPlugin *owner,
               PluginAdaptor *plugin_adaptor,
               uint16_t udp_port,
               const std::vector<std::string> &addresses,
@@ -62,7 +62,7 @@ class OSCDevice: public Device {
     PluginAdaptor *m_plugin_adaptor;
     const std::vector<std::string> m_port_addresses;
     const PortConfigs m_port_configs;
-    std::auto_ptr<class OSCNode> m_osc_node;
+    std::auto_ptr<class OscNode> m_osc_node;
 
     bool StartHook();
 

--- a/plugins/osc/OscNode.h
+++ b/plugins/osc/OscNode.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCNode.h
+ * OscNode.h
  * A DMX orientated, C++ wrapper around liblo.
  * Copyright (C) 2012 Simon Newton
  */
@@ -32,32 +32,32 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include "plugins/osc/OSCTarget.h"
+#include "plugins/osc/OscTarget.h"
 
 namespace ola {
 namespace plugin {
 namespace osc {
 
 /**
- * The OSCNode object handles sending and receiving DMX data using OSC.
+ * The OscNode object handles sending and receiving DMX data using OSC.
  *
  * Sending:
  *   For sending, OSC Targets are assigned to groups. A group ID is just an
  *   arbitary integer used to identify the group. It's not sent in the OSC
  *   packets. For example:
  *
- *   OSCNode node(OSCNode::OSCNodeOptions(), ...);
+ *   OscNode node(OscNode::OscNodeOptions(), ...);
  *   node.Init();
  *
- *   node.AddTarget(1, OSCTarget(...));
- *   node.AddTarget(1, OSCTarget(...));
+ *   node.AddTarget(1, OscTarget(...));
+ *   node.AddTarget(1, OscTarget(...));
  *   node.SendData(1, FORMAT_BLOB, dmx);
  *
  * Receiving:
  *   To receive DMX data, register a Callback for a specific OSC Address. For
  *   example:
  *
- *   OSCNode node(OSCNode::OSCNodeOptions(), ...);
+ *   OscNode node(OscNode::OscNodeOptions(), ...);
  *   node.Init();
  *
  *   node.RegisterAddress("/dmx/1", NewCallback(...));
@@ -66,7 +66,7 @@ namespace osc {
  *   // once it's time to stop, de-register this address
  *   node.RegisterAddress("/dmx/1", NULL);
  */
-class OSCNode {
+class OscNode {
  public:
   // The different data formats we can send in.
   enum DataFormat {
@@ -77,27 +77,27 @@ class OSCNode {
     FORMAT_FLOAT_INDIVIDUAL,
   };
 
-  // The options for the OSCNode object.
-  struct OSCNodeOptions {
+  // The options for the OscNode object.
+  struct OscNodeOptions {
     uint16_t listen_port;  // UDP port to listen on
 
-    OSCNodeOptions() : listen_port(DEFAULT_OSC_PORT) {}
+    OscNodeOptions() : listen_port(DEFAULT_OSC_PORT) {}
   };
 
   // The callback run when we receive new DMX data.
   typedef Callback1<void, const DmxBuffer&> DMXCallback;
 
-  OSCNode(ola::io::SelectServerInterface *ss,
+  OscNode(ola::io::SelectServerInterface *ss,
           ola::ExportMap *export_map,
-          const OSCNodeOptions &options);
-  ~OSCNode();
+          const OscNodeOptions &options);
+  ~OscNode();
 
   bool Init();
   void Stop();
 
   // Sending methods
-  void AddTarget(unsigned int group, const OSCTarget &target);
-  bool RemoveTarget(unsigned int group, const OSCTarget &target);
+  void AddTarget(unsigned int group, const OscTarget &target);
+  bool RemoveTarget(unsigned int group, const OscTarget &target);
   bool SendData(unsigned int group, DataFormat data_format,
                 const ola::DmxBuffer &data);
 
@@ -113,17 +113,17 @@ class OSCNode {
   uint16_t ListeningPort() const;
 
  private:
-  class NodeOSCTarget {
+  class NodeOscTarget {
    public:
-    explicit NodeOSCTarget(const OSCTarget &target);
-    ~NodeOSCTarget();
+    explicit NodeOscTarget(const OscTarget &target);
+    ~NodeOscTarget();
 
-    bool operator==(const NodeOSCTarget &other) const {
+    bool operator==(const NodeOscTarget &other) const {
       return (socket_address == other.socket_address &&
               osc_address == other.osc_address);
     }
 
-    bool operator==(const OSCTarget &other) const {
+    bool operator==(const OscTarget &other) const {
       return (socket_address == other.socket_address &&
               osc_address == other.osc_address);
     }
@@ -133,26 +133,26 @@ class OSCNode {
     lo_address liblo_address;
 
    private:
-    NodeOSCTarget(const NodeOSCTarget&);
-    NodeOSCTarget& operator=(const NodeOSCTarget&);
+    NodeOscTarget(const NodeOscTarget&);
+    NodeOscTarget& operator=(const NodeOscTarget&);
   };
 
-  typedef std::vector<NodeOSCTarget*> OSCTargetVector;
+  typedef std::vector<NodeOscTarget*> OscTargetVector;
 
-  struct OSCOutputGroup {
-    OSCTargetVector targets;
+  struct OscOutputGroup {
+    OscTargetVector targets;
     DmxBuffer dmx;  // holds the last values.
   };
 
-  struct OSCInputGroup {
-    explicit OSCInputGroup(DMXCallback *callback) : callback(callback) {}
+  struct OscInputGroup {
+    explicit OscInputGroup(DMXCallback *callback) : callback(callback) {}
 
     DmxBuffer dmx;
     std::auto_ptr<DMXCallback> callback;
   };
 
-  typedef std::map<unsigned int, OSCOutputGroup*> OutputGroupMap;
-  typedef std::map<std::string, OSCInputGroup*> InputUniverseMap;
+  typedef std::map<unsigned int, OscOutputGroup*> OutputGroupMap;
+  typedef std::map<std::string, OscInputGroup*> InputUniverseMap;
 
   struct SlotMessage {
     unsigned int slot;
@@ -167,19 +167,19 @@ class OSCNode {
   InputUniverseMap m_input_map;
 
   void DescriptorReady();
-  bool SendBlob(const DmxBuffer &data, const OSCTargetVector &targets);
+  bool SendBlob(const DmxBuffer &data, const OscTargetVector &targets);
   bool SendIndividualFloats(const DmxBuffer &data,
-                            OSCOutputGroup *group);
+                            OscOutputGroup *group);
   bool SendIndividualInts(const DmxBuffer &data,
-                          OSCOutputGroup *group);
+                          OscOutputGroup *group);
   bool SendIntArray(const DmxBuffer &data,
-                    const OSCTargetVector &targets);
+                    const OscTargetVector &targets);
   bool SendFloatArray(const DmxBuffer &data,
-                      const OSCTargetVector &targets);
+                      const OscTargetVector &targets);
   bool SendMessageToTargets(lo_message message,
-                            const OSCTargetVector &targets);
+                            const OscTargetVector &targets);
   bool SendIndividualMessages(const DmxBuffer &data,
-                              OSCOutputGroup *group,
+                              OscOutputGroup *group,
                               const std::string &osc_type);
 
   static const uint16_t DEFAULT_OSC_PORT = 7770;

--- a/plugins/osc/OscNodeTest.cpp
+++ b/plugins/osc/OscNodeTest.cpp
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCNodeTest.cpp
- * Test fixture for the OSCNode class
+ * OscNodeTest.cpp
+ * Test fixture for the OscNode class
  * Copyright (C) 2012 Simon Newton
  */
 
@@ -30,8 +30,8 @@
 #include "ola/network/Socket.h"
 #include "ola/network/SocketAddress.h"
 #include "ola/testing/TestUtils.h"
-#include "plugins/osc/OSCNode.h"
-#include "plugins/osc/OSCTarget.h"
+#include "plugins/osc/OscNode.h"
+#include "plugins/osc/OscTarget.h"
 
 using ola::DmxBuffer;
 using ola::NewCallback;
@@ -39,30 +39,30 @@ using ola::io::SelectServer;
 using ola::network::IPV4Address;
 using ola::network::IPV4SocketAddress;
 using ola::network::UDPSocket;
-using ola::plugin::osc::OSCNode;
-using ola::plugin::osc::OSCTarget;
+using ola::plugin::osc::OscNode;
+using ola::plugin::osc::OscTarget;
 using std::auto_ptr;
 
 
 /**
- * The test fixture for the OSCNode.
+ * The test fixture for the OscNode.
  */
-class OSCNodeTest: public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(OSCNodeTest);
+class OscNodeTest: public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(OscNodeTest);
   CPPUNIT_TEST(testSendBlob);
   CPPUNIT_TEST(testReceive);
   CPPUNIT_TEST_SUITE_END();
 
  public:
     /**
-     * Initilize the OSCNode and the timeout_id
+     * Initilize the OscNode and the timeout_id
      */
-    OSCNodeTest()
+    OscNodeTest()
         : CppUnit::TestFixture(),
           m_timeout_id(ola::thread::INVALID_TIMEOUT) {
-      OSCNode::OSCNodeOptions options;
+      OscNode::OscNodeOptions options;
       options.listen_port = 0;
-      m_osc_node.reset(new OSCNode(&m_ss, NULL, options));
+      m_osc_node.reset(new OscNode(&m_ss, NULL, options));
     }
 
     // The setUp and tearDown methods. These are run before and after each test
@@ -79,7 +79,7 @@ class OSCNodeTest: public CppUnit::TestFixture {
 
  private:
     ola::io::SelectServer m_ss;
-    auto_ptr<OSCNode> m_osc_node;
+    auto_ptr<OscNode> m_osc_node;
     UDPSocket m_udp_socket;
     ola::thread::timeout_id m_timeout_id;
     DmxBuffer m_dmx_data;
@@ -100,11 +100,11 @@ class OSCNodeTest: public CppUnit::TestFixture {
     static const char TEST_OSC_ADDRESS[];
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(OSCNodeTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(OscNodeTest);
 
 // A OSC blob packet. See http://opensoundcontrol.org/ for what each
 // byte means.
-const uint8_t OSCNodeTest::OSC_BLOB_DATA[] = {
+const uint8_t OscNodeTest::OSC_BLOB_DATA[] = {
   // osc address
   '/', 'd', 'm', 'x', '/', 'u', 'n', 'i',
   'v', 'e', 'r', 's', 'e', '/', '1', '0',
@@ -117,7 +117,7 @@ const uint8_t OSCNodeTest::OSC_BLOB_DATA[] = {
 };
 
 // An OSC single float packet for slot 1
-const uint8_t OSCNodeTest::OSC_SINGLE_FLOAT_DATA[] = {
+const uint8_t OscNodeTest::OSC_SINGLE_FLOAT_DATA[] = {
   // osc address
   '/', 'd', 'm', 'x', '/', 'u', 'n', 'i',
   'v', 'e', 'r', 's', 'e', '/', '1', '0',
@@ -129,7 +129,7 @@ const uint8_t OSCNodeTest::OSC_SINGLE_FLOAT_DATA[] = {
 };
 
 // An OSC single int packet for slot 5
-const uint8_t OSCNodeTest::OSC_SINGLE_INT_DATA[] = {
+const uint8_t OscNodeTest::OSC_SINGLE_INT_DATA[] = {
   // osc address
   '/', 'd', 'm', 'x', '/', 'u', 'n', 'i',
   'v', 'e', 'r', 's', 'e', '/', '1', '0',
@@ -141,7 +141,7 @@ const uint8_t OSCNodeTest::OSC_SINGLE_INT_DATA[] = {
 };
 
 // An OSC 'ii' packet for slot 7
-const uint8_t OSCNodeTest::OSC_INT_TUPLE_DATA[] = {
+const uint8_t OscNodeTest::OSC_INT_TUPLE_DATA[] = {
   // osc address
   '/', 'd', 'm', 'x', '/', 'u', 'n', 'i',
   'v', 'e', 'r', 's', 'e', '/', '1', '0',
@@ -154,7 +154,7 @@ const uint8_t OSCNodeTest::OSC_INT_TUPLE_DATA[] = {
 };
 
 // An OSC 'if' packet for slot 8
-const uint8_t OSCNodeTest::OSC_FLOAT_TUPLE_DATA[] = {
+const uint8_t OscNodeTest::OSC_FLOAT_TUPLE_DATA[] = {
   // osc address
   '/', 'd', 'm', 'x', '/', 'u', 'n', 'i',
   'v', 'e', 'r', 's', 'e', '/', '1', '0',
@@ -167,9 +167,9 @@ const uint8_t OSCNodeTest::OSC_FLOAT_TUPLE_DATA[] = {
 };
 
 // An OSC Address used for testing.
-const char OSCNodeTest::TEST_OSC_ADDRESS[] = "/dmx/universe/10";
+const char OscNodeTest::TEST_OSC_ADDRESS[] = "/dmx/universe/10";
 
-void OSCNodeTest::setUp() {
+void OscNodeTest::setUp() {
   // Init logging
   ola::InitLogging(ola::OLA_LOG_INFO, ola::OLA_LOG_STDERR);
   ola::NetworkInit();
@@ -177,7 +177,7 @@ void OSCNodeTest::setUp() {
   // Setup and register the Timeout.
   m_timeout_id = m_ss.RegisterSingleTimeout(
         ABORT_TIMEOUT_IN_MS,
-        ola::NewSingleCallback(this, &OSCNodeTest::Timeout));
+        ola::NewSingleCallback(this, &OscNodeTest::Timeout));
   OLA_ASSERT_TRUE(m_timeout_id);
 
   // Init our UDP socket.
@@ -185,7 +185,7 @@ void OSCNodeTest::setUp() {
   // Put some data into the DMXBuffer
   m_dmx_data.SetFromString("0,1,2,3,4,5,6,7,8,9,10");
 
-  // Initialize the OSCNode
+  // Initialize the OscNode
   OLA_ASSERT_TRUE(m_osc_node->Init());
 }
 
@@ -193,7 +193,7 @@ void OSCNodeTest::setUp() {
  * Called when data arrives on our UDP socket. We check that this data matches
  * the expected OSC packet
  */
-void OSCNodeTest::UDPSocketReady() {
+void OscNodeTest::UDPSocketReady() {
   uint8_t data[500];  // 500 bytes is more than enough
   ssize_t data_read = sizeof(data);
   // Read the received packet into 'data'.
@@ -208,7 +208,7 @@ void OSCNodeTest::UDPSocketReady() {
  * Called when we receive DMX data via OSC. We check this matches what we
  * expect, and then stop the SelectServer.
  */
-void OSCNodeTest::DMXHandler(const DmxBuffer &dmx) {
+void OscNodeTest::DMXHandler(const DmxBuffer &dmx) {
   m_received_data = dmx;
   m_ss.Terminate();
 }
@@ -217,24 +217,24 @@ void OSCNodeTest::DMXHandler(const DmxBuffer &dmx) {
 /**
  * Check that we send OSC messages correctly.
  */
-void OSCNodeTest::testSendBlob() {
+void OscNodeTest::testSendBlob() {
   // First up create a UDP socket to receive the messages on.
   // Port 0 means 'ANY'
   IPV4SocketAddress socket_address(IPV4Address::Loopback(), 0);
   // Bind the socket, set the callback, and register with the select server.
   OLA_ASSERT_TRUE(m_udp_socket.Bind(socket_address));
-  m_udp_socket.SetOnData(NewCallback(this, &OSCNodeTest::UDPSocketReady));
+  m_udp_socket.SetOnData(NewCallback(this, &OscNodeTest::UDPSocketReady));
   OLA_ASSERT_TRUE(m_ss.AddReadDescriptor(&m_udp_socket));
   // Store the local address of the UDP socket so we know where to tell the
-  // OSCNode to send to.
+  // OscNode to send to.
   OLA_ASSERT_TRUE(m_udp_socket.GetSocketAddress(&socket_address));
 
-  // Setup the OSCTarget pointing to the local socket address
-  OSCTarget target(socket_address, TEST_OSC_ADDRESS);
+  // Setup the OscTarget pointing to the local socket address
+  OscTarget target(socket_address, TEST_OSC_ADDRESS);
   // Add the target to the node.
   m_osc_node->AddTarget(TEST_GROUP, target);
   // Send the data
-  OLA_ASSERT_TRUE(m_osc_node->SendData(TEST_GROUP, OSCNode::FORMAT_BLOB,
+  OLA_ASSERT_TRUE(m_osc_node->SendData(TEST_GROUP, OscNode::FORMAT_BLOB,
                   m_dmx_data));
 
   // Run the SelectServer this will return either when UDPSocketReady
@@ -254,22 +254,22 @@ void OSCNodeTest::testSendBlob() {
 /**
  * Check that we receive OSC messages correctly.
  */
-void OSCNodeTest::testReceive() {
+void OscNodeTest::testReceive() {
   DmxBuffer expected_data;
 
-  // Register the test OSC Address with the OSCNode using the DMXHandler as the
+  // Register the test OSC Address with the OscNode using the DMXHandler as the
   // callback.
   OLA_ASSERT_TRUE(m_osc_node->RegisterAddress(
-      TEST_OSC_ADDRESS, NewCallback(this, &OSCNodeTest::DMXHandler)));
+      TEST_OSC_ADDRESS, NewCallback(this, &OscNodeTest::DMXHandler)));
 
   // Attempt to register the same address with a different path, this should
   // return false
   OLA_ASSERT_FALSE(m_osc_node->RegisterAddress(
       TEST_OSC_ADDRESS,
-      NewCallback(this, &OSCNodeTest::DMXHandler)));
+      NewCallback(this, &OscNodeTest::DMXHandler)));
 
   // Using our test UDP socket, send the OSC_BLOB_DATA to the default OSC
-  // port. The OSCNode should receive the packet and call DMXHandler.
+  // port. The OscNode should receive the packet and call DMXHandler.
   IPV4SocketAddress dest_address(IPV4Address::Loopback(),
                                  m_osc_node->ListeningPort());
 

--- a/plugins/osc/OscPlugin.cpp
+++ b/plugins/osc/OscPlugin.cpp
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCPlugin.cpp
+ * OscPlugin.cpp
  * The OSC plugin for ola. This creates a single OSC device.
  * Copyright (C) 2012 Simon Newton
  */
@@ -30,10 +30,10 @@
 #include "ola/StringUtils.h"
 #include "olad/PluginAdaptor.h"
 #include "olad/Preferences.h"
-#include "plugins/osc/OSCAddressTemplate.h"
-#include "plugins/osc/OSCDevice.h"
-#include "plugins/osc/OSCPlugin.h"
-#include "plugins/osc/OSCPluginDescription.h"
+#include "plugins/osc/OscAddressTemplate.h"
+#include "plugins/osc/OscDevice.h"
+#include "plugins/osc/OscPlugin.h"
+#include "plugins/osc/OscPluginDescription.h"
 
 namespace ola {
 namespace plugin {
@@ -44,27 +44,27 @@ using std::set;
 using std::string;
 using std::vector;
 
-const char OSCPlugin::DEFAULT_ADDRESS_TEMPLATE[] = "/dmx/universe/%d";
-const char OSCPlugin::DEFAULT_TARGETS_TEMPLATE[] = "";
-const char OSCPlugin::INPUT_PORT_COUNT_KEY[] = "input_ports";
-const char OSCPlugin::OUTPUT_PORT_COUNT_KEY[] = "output_ports";
-const char OSCPlugin::PLUGIN_NAME[] = "OSC";
-const char OSCPlugin::PLUGIN_PREFIX[] = "osc";
-const char OSCPlugin::PORT_ADDRESS_TEMPLATE[] = "port_%d_address";
-const char OSCPlugin::PORT_TARGETS_TEMPLATE[] = "port_%d_targets";
-const char OSCPlugin::PORT_FORMAT_TEMPLATE[] = "port_%d_output_format";
-const char OSCPlugin::UDP_PORT_KEY[] = "udp_listen_port";
+const char OscPlugin::DEFAULT_ADDRESS_TEMPLATE[] = "/dmx/universe/%d";
+const char OscPlugin::DEFAULT_TARGETS_TEMPLATE[] = "";
+const char OscPlugin::INPUT_PORT_COUNT_KEY[] = "input_ports";
+const char OscPlugin::OUTPUT_PORT_COUNT_KEY[] = "output_ports";
+const char OscPlugin::PLUGIN_NAME[] = "OSC";
+const char OscPlugin::PLUGIN_PREFIX[] = "osc";
+const char OscPlugin::PORT_ADDRESS_TEMPLATE[] = "port_%d_address";
+const char OscPlugin::PORT_TARGETS_TEMPLATE[] = "port_%d_targets";
+const char OscPlugin::PORT_FORMAT_TEMPLATE[] = "port_%d_output_format";
+const char OscPlugin::UDP_PORT_KEY[] = "udp_listen_port";
 
-const char OSCPlugin::BLOB_FORMAT[] = "blob";
-const char OSCPlugin::FLOAT_ARRAY_FORMAT[] = "float_array";
-const char OSCPlugin::FLOAT_INDIVIDUAL_FORMAT[] = "individual_float";
-const char OSCPlugin::INT_ARRAY_FORMAT[] = "int_array";
-const char OSCPlugin::INT_INDIVIDUAL_FORMAT[] = "individual_int";
+const char OscPlugin::BLOB_FORMAT[] = "blob";
+const char OscPlugin::FLOAT_ARRAY_FORMAT[] = "float_array";
+const char OscPlugin::FLOAT_INDIVIDUAL_FORMAT[] = "individual_float";
+const char OscPlugin::INT_ARRAY_FORMAT[] = "int_array";
+const char OscPlugin::INT_INDIVIDUAL_FORMAT[] = "individual_int";
 
 /*
  * Start the plugin.
  */
-bool OSCPlugin::StartHook() {
+bool OscPlugin::StartHook() {
   // Get the value of UDP_PORT_KEY or use the default value if it isn't valid.
   uint16_t udp_port = StringToIntOrDefault(
       m_preferences->GetValue(UDP_PORT_KEY),
@@ -77,11 +77,11 @@ bool OSCPlugin::StartHook() {
     port_addresses.push_back(m_preferences->GetValue(key));
   }
 
-  // For each ouput port, extract the list of OSCTargets and store them in
+  // For each ouput port, extract the list of OscTargets and store them in
   // port_targets.
-  OSCDevice::PortConfigs port_configs;
+  OscDevice::PortConfigs port_configs;
   for (unsigned int i = 0; i < GetPortCount(OUTPUT_PORT_COUNT_KEY); i++) {
-    OSCDevice::PortConfig port_config;
+    OscDevice::PortConfig port_config;
 
     const string format_key = ExpandTemplate(PORT_FORMAT_TEMPLATE, i);
     SetDataFormat(m_preferences->GetValue(format_key), &port_config);
@@ -92,8 +92,8 @@ bool OSCPlugin::StartHook() {
 
     vector<string>::const_iterator iter = tokens.begin();
     for (; iter != tokens.end(); ++iter) {
-      OSCTarget target;
-      if (ExtractOSCTarget(*iter, &target)) {
+      OscTarget target;
+      if (ExtractOscTarget(*iter, &target)) {
         port_config.targets.push_back(target);
       }
     }
@@ -101,9 +101,9 @@ bool OSCPlugin::StartHook() {
     port_configs.push_back(port_config);
   }
 
-  // Finally create the new OSCDevice, start it and register the device.
-  std::auto_ptr<OSCDevice> device(
-    new OSCDevice(this, m_plugin_adaptor, udp_port, port_addresses,
+  // Finally create the new OscDevice, start it and register the device.
+  std::auto_ptr<OscDevice> device(
+    new OscDevice(this, m_plugin_adaptor, udp_port, port_addresses,
                   port_configs));
   if (!device->Start()) {
     return false;
@@ -118,7 +118,7 @@ bool OSCPlugin::StartHook() {
  * Stop the plugin
  * @return true on success, false on failure
  */
-bool OSCPlugin::StopHook() {
+bool OscPlugin::StopHook() {
   if (m_device) {
     m_plugin_adaptor->UnregisterDevice(m_device);
     bool ret = m_device->Stop();
@@ -129,7 +129,7 @@ bool OSCPlugin::StopHook() {
 }
 
 
-string OSCPlugin::Description() const {
+string OscPlugin::Description() const {
   return plugin_description;
 }
 
@@ -137,7 +137,7 @@ string OSCPlugin::Description() const {
 /**
  * Set the default preferences for the OSC plugin.
  */
-bool OSCPlugin::SetDefaultPreferences() {
+bool OscPlugin::SetDefaultPreferences() {
   if (!m_preferences) {
     return false;
   }
@@ -196,7 +196,7 @@ bool OSCPlugin::SetDefaultPreferences() {
  *
  * Defaults to DEFAULT_PORT_COUNT if the value was invalid.
  */
-unsigned int OSCPlugin::GetPortCount(const string& key) const {
+unsigned int OscPlugin::GetPortCount(const string& key) const {
   unsigned int port_count;
   if (!StringToInt(m_preferences->GetValue(key), &port_count)) {
     return DEFAULT_PORT_COUNT;
@@ -208,8 +208,8 @@ unsigned int OSCPlugin::GetPortCount(const string& key) const {
 /**
  * Try to parse the string as an OSC Target.
  */
-bool OSCPlugin::ExtractOSCTarget(const string &str,
-                                 OSCTarget *target) {
+bool OscPlugin::ExtractOscTarget(const string &str,
+                                 OscTarget *target) {
   size_t pos = str.find_first_of("/");
   if (pos == string::npos) {
     return false;
@@ -227,20 +227,20 @@ bool OSCPlugin::ExtractOSCTarget(const string &str,
 /**
  * Set the PortConfig data format based on the option the user provides
  */
-void OSCPlugin::SetDataFormat(const string &format_option,
-                              OSCDevice::PortConfig *port_config) {
+void OscPlugin::SetDataFormat(const string &format_option,
+                              OscDevice::PortConfig *port_config) {
   if (format_option == BLOB_FORMAT) {
-    port_config->data_format = OSCNode::FORMAT_BLOB;
+    port_config->data_format = OscNode::FORMAT_BLOB;
   } else if (format_option == FLOAT_ARRAY_FORMAT) {
-    port_config->data_format = OSCNode::FORMAT_FLOAT_ARRAY;
+    port_config->data_format = OscNode::FORMAT_FLOAT_ARRAY;
   } else if (format_option == FLOAT_INDIVIDUAL_FORMAT) {
-    port_config->data_format = OSCNode::FORMAT_FLOAT_INDIVIDUAL;
+    port_config->data_format = OscNode::FORMAT_FLOAT_INDIVIDUAL;
   } else if (format_option == INT_ARRAY_FORMAT) {
-    port_config->data_format = OSCNode::FORMAT_INT_ARRAY;
+    port_config->data_format = OscNode::FORMAT_INT_ARRAY;
   } else if (format_option == INT_INDIVIDUAL_FORMAT) {
-    port_config->data_format = OSCNode::FORMAT_INT_INDIVIDUAL;
+    port_config->data_format = OscNode::FORMAT_INT_INDIVIDUAL;
   } else {
-    OLA_WARN << "Unknown OSC format " << format_option
+    OLA_WARN << "Unknown Osc format " << format_option
              << ", defaulting to blob";
   }
 }

--- a/plugins/osc/OscPlugin.h
+++ b/plugins/osc/OscPlugin.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCPlugin.h
+ * OscPlugin.h
  * Interface for the OSC plugin.
  * Copyright (C) 2012 Simon Newton
  */
@@ -24,18 +24,18 @@
 #include <string>
 #include "olad/Plugin.h"
 #include "ola/plugin_id.h"
-#include "plugins/osc/OSCDevice.h"
-#include "plugins/osc/OSCTarget.h"
+#include "plugins/osc/OscDevice.h"
+#include "plugins/osc/OscTarget.h"
 
 namespace ola {
 namespace plugin {
 namespace osc {
 
-class OSCDevice;
+class OscDevice;
 
-class OSCPlugin: public ola::Plugin {
+class OscPlugin: public ola::Plugin {
  public:
-    explicit OSCPlugin(ola::PluginAdaptor *plugin_adaptor):
+    explicit OscPlugin(ola::PluginAdaptor *plugin_adaptor):
       ola::Plugin(plugin_adaptor),
       m_device(NULL) {}
 
@@ -50,11 +50,11 @@ class OSCPlugin: public ola::Plugin {
     bool SetDefaultPreferences();
 
     unsigned int GetPortCount(const std::string &key) const;
-    bool ExtractOSCTarget(const std::string &str, OSCTarget *target);
+    bool ExtractOscTarget(const std::string &str, OscTarget *target);
     void SetDataFormat(const std::string &format_option,
-                       OSCDevice::PortConfig *port_config);
+                       OscDevice::PortConfig *port_config);
 
-    OSCDevice *m_device;
+    OscDevice *m_device;
     static const uint8_t DEFAULT_PORT_COUNT = 5;
     static const uint16_t DEFAULT_UDP_PORT = 7770;
 

--- a/plugins/osc/OscPort.cpp
+++ b/plugins/osc/OscPort.cpp
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCPort.cpp
- * The OSCInputPort and OSCOutputPort classes.
+ * OscPort.cpp
+ * The OscInputPort and OscOutputPort classes.
  * Copyright (C) 2012 Simon Newton
  */
 
@@ -23,10 +23,10 @@
 #include <vector>
 #include "ola/Logging.h"
 #include "olad/Port.h"
-#include "plugins/osc/OSCAddressTemplate.h"
-#include "plugins/osc/OSCDevice.h"
-#include "plugins/osc/OSCNode.h"
-#include "plugins/osc/OSCPort.h"
+#include "plugins/osc/OscAddressTemplate.h"
+#include "plugins/osc/OscDevice.h"
+#include "plugins/osc/OscNode.h"
+#include "plugins/osc/OscPort.h"
 
 namespace ola {
 namespace plugin {
@@ -36,11 +36,11 @@ using std::ostringstream;
 using std::string;
 using std::vector;
 
-OSCInputPort::OSCInputPort(
-    OSCDevice *parent,
+OscInputPort::OscInputPort(
+    OscDevice *parent,
     unsigned int port_id,
     PluginAdaptor *plugin_adaptor,
-    OSCNode *node,
+    OscNode *node,
     const string &address)
     : BasicInputPort(parent, port_id, plugin_adaptor),
       m_node(node),
@@ -48,7 +48,7 @@ OSCInputPort::OSCInputPort(
       m_actual_address(address) {
 }
 
-bool OSCInputPort::PreSetUniverse(Universe *old_universe,
+bool OscInputPort::PreSetUniverse(Universe *old_universe,
                                   Universe *new_universe) {
   // if the old_universe is not NULL, we need to de-register
   if (old_universe) {
@@ -62,7 +62,7 @@ bool OSCInputPort::PreSetUniverse(Universe *old_universe,
     string osc_address = ExpandTemplate(m_address, new_universe->UniverseId());
     bool ok = m_node->RegisterAddress(
         osc_address,
-        NewCallback(this, &OSCInputPort::NewDMXData));
+        NewCallback(this, &OscInputPort::NewDMXData));
 
     if (!ok)
       // means that another port is registered with the same address
@@ -73,18 +73,18 @@ bool OSCInputPort::PreSetUniverse(Universe *old_universe,
   return true;
 }
 
-void OSCInputPort::NewDMXData(const DmxBuffer &data) {
+void OscInputPort::NewDMXData(const DmxBuffer &data) {
   m_buffer = data;  // store the data
   DmxChanged();  // signal that our data has changed
 }
 
 
-OSCOutputPort::OSCOutputPort(
-    OSCDevice *device,
+OscOutputPort::OscOutputPort(
+    OscDevice *device,
     unsigned int port_id,
-    OSCNode *node,
-    const vector<OSCTarget> &targets,
-    OSCNode::DataFormat data_format)
+    OscNode *node,
+    const vector<OscTarget> &targets,
+    OscNode::DataFormat data_format)
     : BasicOutputPort(device, port_id),
       m_node(node),
       m_template_targets(targets),
@@ -92,22 +92,22 @@ OSCOutputPort::OSCOutputPort(
   SetUnpatchedDescription();
 }
 
-OSCOutputPort::~OSCOutputPort() {
+OscOutputPort::~OscOutputPort() {
   RemoveTargets();
 }
 
-bool OSCOutputPort::PreSetUniverse(Universe *,
+bool OscOutputPort::PreSetUniverse(Universe *,
                                    Universe *new_universe) {
   RemoveTargets();
 
-  vector<OSCTarget>::const_iterator iter = m_template_targets.begin();
+  vector<OscTarget>::const_iterator iter = m_template_targets.begin();
 
   if (new_universe) {
     ostringstream str;
     for (; iter != m_template_targets.end(); ++iter) {
       string osc_address = ExpandTemplate(iter->osc_address,
                                           new_universe->UniverseId());
-      OSCTarget new_target(iter->socket_address, osc_address);
+      OscTarget new_target(iter->socket_address, osc_address);
 
       m_node->AddTarget(PortId(), new_target);
       m_registered_targets.push_back(new_target);
@@ -124,17 +124,17 @@ bool OSCOutputPort::PreSetUniverse(Universe *,
   return true;
 }
 
-void OSCOutputPort::RemoveTargets() {
-  vector<OSCTarget>::const_iterator iter = m_registered_targets.begin();
+void OscOutputPort::RemoveTargets() {
+  vector<OscTarget>::const_iterator iter = m_registered_targets.begin();
   for (; iter != m_registered_targets.end(); ++iter) {
     m_node->RemoveTarget(PortId(), *iter);
   }
   m_registered_targets.clear();
 }
 
-void OSCOutputPort::SetUnpatchedDescription() {
+void OscOutputPort::SetUnpatchedDescription() {
   ostringstream str;
-  vector<OSCTarget>::const_iterator iter = m_template_targets.begin();
+  vector<OscTarget>::const_iterator iter = m_template_targets.begin();
   for (; iter != m_template_targets.end(); ++iter) {
     if (iter != m_template_targets.begin())
       str << ", ";

--- a/plugins/osc/OscPort.h
+++ b/plugins/osc/OscPort.h
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCPort.h
- * The OSCInputPort and OSCOutputPort classes.
+ * OscPort.h
+ * The OscInputPort and OscOutputPort classes.
  * Copyright (C) 2012 Simon Newton
  */
 
@@ -24,9 +24,9 @@
 #include <string>
 #include <vector>
 #include "olad/Port.h"
-#include "plugins/osc/OSCAddressTemplate.h"
-#include "plugins/osc/OSCDevice.h"
-#include "plugins/osc/OSCNode.h"
+#include "plugins/osc/OscAddressTemplate.h"
+#include "plugins/osc/OscDevice.h"
+#include "plugins/osc/OscNode.h"
 
 namespace ola {
 namespace plugin {
@@ -39,20 +39,20 @@ namespace osc {
  * unpatched from a universe (since the description can contain %d). Therefore
  * we store the description as a template, as well as the current value.
  */
-class OSCInputPort: public BasicInputPort {
+class OscInputPort: public BasicInputPort {
  public:
   /**
-   * Create an OSCInputPort.
+   * Create an OscInputPort.
    * @param parent the parent device
    * @param port_id the id for this port
    * @param plugin_adaptor a PluginAdaptor object, used by the base class.
-   * @param node the OSCNode object to use
+   * @param node the OscNode object to use
    * @param address the OSC address string for this port
    */
-  OSCInputPort(OSCDevice *parent,
+  OscInputPort(OscDevice *parent,
                unsigned int port_id,
                PluginAdaptor *plugin_adaptor,
-               OSCNode *node,
+               OscNode *node,
                const std::string &address);
 
   /**
@@ -72,7 +72,7 @@ class OSCInputPort: public BasicInputPort {
   std::string Description() const { return m_actual_address; }
 
  private:
-  OSCNode *m_node;
+  OscNode *m_node;
   DmxBuffer m_buffer;
   const std::string m_address;
   std::string m_actual_address;
@@ -87,22 +87,22 @@ class OSCInputPort: public BasicInputPort {
 /**
  * The Output Port class, for sending DMX via OSC.
  */
-class OSCOutputPort: public BasicOutputPort {
+class OscOutputPort: public BasicOutputPort {
  public:
   /**
-   * @brief Create an OSCOutputPort.
+   * @brief Create an OscOutputPort.
    * @param device the parent device
    * @param port_id the id for this port
-   * @param node the OSCNode object to use
+   * @param node the OscNode object to use
    * @param targets the OSC targets to send to
    * @param data_format the format of OSC to send
    */
-  OSCOutputPort(OSCDevice *device,
+  OscOutputPort(OscDevice *device,
                 unsigned int port_id,
-                OSCNode *node,
-                const std::vector<OSCTarget> &targets,
-                OSCNode::DataFormat data_format);
-  ~OSCOutputPort();
+                OscNode *node,
+                const std::vector<OscTarget> &targets,
+                OscNode::DataFormat data_format);
+  ~OscOutputPort();
 
   /**
    * Called during the patch process, just before the Universe of this port
@@ -125,11 +125,11 @@ class OSCOutputPort: public BasicOutputPort {
   std::string Description() const { return m_description; }
 
  private:
-  OSCNode *m_node;
-  const std::vector<OSCTarget> m_template_targets;
-  std::vector<OSCTarget> m_registered_targets;
+  OscNode *m_node;
+  const std::vector<OscTarget> m_template_targets;
+  std::vector<OscTarget> m_registered_targets;
   std::string m_description;
-  OSCNode::DataFormat m_data_format;
+  OscNode::DataFormat m_data_format;
 
   void RemoveTargets();
   void SetUnpatchedDescription();

--- a/plugins/osc/OscTarget.h
+++ b/plugins/osc/OscTarget.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * OSCTarget.h
+ * OscTarget.h
  * Represents a IP:Port & OSC Address pair used to direct OSC messages.
  * Copyright (C) 2012 Simon Newton
  */
@@ -28,21 +28,21 @@ namespace ola {
 namespace plugin {
 namespace osc {
 
-struct OSCTarget {
+struct OscTarget {
   ola::network::IPV4SocketAddress socket_address;
   std::string osc_address;
 
   // The default constructor.
-  OSCTarget() {}
+  OscTarget() {}
 
   // The copy constructor
-  OSCTarget(const OSCTarget &target)
+  OscTarget(const OscTarget &target)
       : socket_address(target.socket_address),
         osc_address(target.osc_address) {
   }
 
   // A constuctor that initializes the member variables as well.
-  OSCTarget(const ola::network::IPV4SocketAddress &socket_address,
+  OscTarget(const ola::network::IPV4SocketAddress &socket_address,
             const std::string &osc_address)
       : socket_address(socket_address),
         osc_address(osc_address) {
@@ -53,11 +53,11 @@ struct OSCTarget {
   }
 
   /**
-   * @brief A helper function to write a OSCTarget to an ostream.
+   * @brief A helper function to write a OscTarget to an ostream.
    * @param out the ostream
-   * @param target the OSCTarget to write.
+   * @param target the OscTarget to write.
    */
-  friend std::ostream& operator<<(std::ostream &out, const OSCTarget &target) {
+  friend std::ostream& operator<<(std::ostream &out, const OscTarget &target) {
     return out << target.ToString();
   }
 };

--- a/plugins/osc/README.developer.md
+++ b/plugins/osc/README.developer.md
@@ -140,8 +140,8 @@ This sets the destination install directory for the shared object (the OSC
 plugin in this case) to the plugin directory. By default that's
 `/usr/local/lib/olad` but the user may have changed it.
 
-    EXTRA_DIST = OSCAddressTemplate.h OSCDevice.h OSCNode.h OSCPlugin.h \
-                 OSCPort.h OSCTarget.h
+    EXTRA_DIST = OscAddressTemplate.h OscDevice.h OscNode.h OscPlugin.h \
+                 OscPort.h OscTarget.h
 
 This specifies the header files that need to be included in the tarball.
 
@@ -150,34 +150,34 @@ This specifies the header files that need to be included in the tarball.
 Everything from this point onwards is only run if `HAVE_LIBLO` was true.
 
     noinst_LTLIBRARIES = libolaoscnode.la
-    libolaoscnode_la_SOURCES = OSCAddressTemplate.cpp OSCNode.cpp
+    libolaoscnode_la_SOURCES = OscAddressTemplate.cpp OscNode.cpp
     libolaoscnode_la_CXXFLAGS = $(COMMON_CXXFLAGS) $(liblo_CFLAGS)
     libolaoscnode_la_LIBADD = $(liblo_LIBS)
 
 This sets up our first build target, a shared library called
-`libolaoscnode.la`. This library contains the `OSCNode` class, along with
-the functions in `OSCAddressTemplate.cpp`. The `libolaoscnode.la` is a
+`libolaoscnode.la`. This library contains the `OscNode` class, along with
+the functions in `OscAddressTemplate.cpp`. The `libolaoscnode.la` is a
 helper library, it's not installed when the user runs `make install`(the
 `noinst_` prefix does this) but it simplifies the build rules since both the
 OSC plugin and the tests depend on it. Because we depend on liblo we need to
 add `liblo_CFLAGS` and `liblo_LIBS` to the appropriate lines.
 
     lib_LTLIBRARIES = libolaosc.la
-    libolaosc_la_SOURCES = OSCDevice.cpp OSCPlugin.cpp
+    libolaosc_la_SOURCES = OscDevice.cpp OscPlugin.cpp
     libolaosc_la_CXXFLAGS = $(COMMON_CXXFLAGS) $(liblo_CFLAGS)
     libolaosc_la_LIBADD = libolaoscnode.la
 
-Here is our `llibolaosc.la` plugin. This contains code from `OSCDevice.cpp`
-and `OSCPlugin.cpp`. Note that because the code in `OSCPort` is simple, all
-the code lives in `OSCPort.h` and there is no corresponding `.cpp` file. If
+Here is our `llibolaosc.la` plugin. This contains code from `OscDevice.cpp`
+and `OscPlugin.cpp`. Note that because the code in `OscPort` is simple, all
+the code lives in `OscPort.h` and there is no corresponding `.cpp` file. If
 there was we'd need to list it here as well. This depends on the
 `libolaoscnode.la` helper library.
 
     if BUILD_TESTS
-      TESTS = OSCTester
+      TESTS = OscTester
     endif
 
-On to the tests, These three lines add the OSCTester program to the list of
+On to the tests, These three lines add the OscTester program to the list of
 tests to execute when `make check` is run. If the user ran `./configure`
 with `--disable-unittests` we don't build or run any of the unittesting
 code.
@@ -186,16 +186,16 @@ code.
 
 This sets `check_PROGRAMS` to what's contained in the `$TESTS` variable.
 
-    OSCTester_SOURCES = OSCAddressTemplateTest.cpp \
-                        OSCNodeTest.cpp \
-                        OSCTester.cpp
-    OSCTester_CXXFLAGS = $(COMMON_CXXFLAGS) $(CPPUNIT_CFLAGS)
-    OSCTester_LDADD = $(CPPUNIT_LIBS) \
+    OscTester_SOURCES = OscAddressTemplateTest.cpp \
+                        OscNodeTest.cpp \
+                        OscTester.cpp
+    OscTester_CXXFLAGS = $(COMMON_CXXFLAGS) $(CPPUNIT_CFLAGS)
+    OscTester_LDADD = $(CPPUNIT_LIBS) \
                       libolaoscnode.la \
                       ../../common/libolacommon.la \
                       ../../common/testing/libolatesting.la
 
-Here are the rules for OSCTester. This specifies the 3 source files as well
+Here are the rules for OscTester. This specifies the 3 source files as well
 as the libraries the code depends on.
 
     endif
@@ -244,7 +244,7 @@ We need to tell the Plugin Loader to load our new OSC plugin. Remember the
 In `olad/DynamicPluginLoader.cpp` we add:
 
     #ifdef HAVE_LIBLO
-    #include "plugins/osc/OSCPlugin.h"
+    #include "plugins/osc/OscPlugin.h"
     #endif  // HAVE_LIBLO
 
 `DynamicPluginLoader.cpp` includes `config.h` at the top of the file, which
@@ -252,10 +252,10 @@ is how `HAVE_LIBLO` is defined.
 
     #ifdef HAVE_LIBLO
       m_plugins.push_back(
-          new ola::plugin::osc::OSCPlugin(m_plugin_adaptor));
+          new ola::plugin::osc::OscPlugin(m_plugin_adaptor));
     #endif  // HAVE_LIBLO
 
-If `HAVE_LIBLO` is defined, we go ahead and add the OSCPlugin to the vector
+If `HAVE_LIBLO` is defined, we go ahead and add the OscPlugin to the vector
 of plugins to load.
 
 That's it for the boilerplate.
@@ -266,18 +266,18 @@ Chapter 3, Helper Code
 
 The OSC code is divided into two parts:
 
-* OSCNode is a C++ & DMX orientated wrapper around liblo.
-* OSCPlugin, OSCDevice & OSCPort are the glue between OLA and the OSCNode.
+* OscNode is a C++ & DMX orientated wrapper around liblo.
+* OscPlugin, OscDevice & OscPort are the glue between OLA and the OscNode.
 
 There is a little bit of support code that is used in both parts, so we
 factor that out here.
 
-3.1 OSCTarget
+3.1 OscTarget
 -------------
 
-`OSCTarget.h` contains a struct used to represent OSC targets. Each target
+`OscTarget.h` contains a struct used to represent OSC targets. Each target
 has an IP & UDP Port, along with a string that holds the OSC address for the
-target. We also provide three constructors to help us create `OSCTarget`
+target. We also provide three constructors to help us create `OscTarget`
 structs. The first is the default constructor, the second is the copy
 constructor and the third takes an `IPV4SocketAddress` and string and
 initializes the member variables.
@@ -297,14 +297,14 @@ classes and code in other plugins.
 3.2 ExpandTemplate()
 --------------------
 
-`OSCAddressTemplate.h` provides a single method, `ExpandTemplate()` which
+`OscAddressTemplate.h` provides a single method, `ExpandTemplate()` which
 behaves a bit like `printf`. Why don't we just use `printf` you ask? Because
 the strings to expand are provided in the config file by the user and using
 `printf` for user specified strings is dangerous (see
 http://www.cis.syr.edu/~wedu/Teaching/cis643/LectureNotes_New/Format_String.pdf).
 
 At this point it's worth mentioning testing. Have a look at the
-`OSCAddressTemplateTest.cpp` file. We define a single test method
+`OscAddressTemplateTest.cpp` file. We define a single test method
 `testExpand` that confirms `ExpandTemplate()` behaves as we expect.
 
 If you're in the mood for experimentation, change
@@ -318,17 +318,17 @@ to
 Watch the tests fail and make sure you understand why.
 
 
-Chapter 4, OSCNode
+Chapter 4, OscNode
 ==================
 
-As mentioned, OSCNode is the C++ wrapper around liblo. It uses the OLA
+As mentioned, OscNode is the C++ wrapper around liblo. It uses the OLA
 network & IO classes so that it integrates nicely with OLA. As one would
-expect, the code is split across `OSCNode.h` and `OSCNode.cpp`.
+expect, the code is split across `OscNode.h` and `OscNode.cpp`.
 
-4.1 `OSCNode.h`
+4.1 `OscNode.h`
 ---------------
 
-Lets step through the interface to the `OSCNode` class. First we include all
+Lets step through the interface to the `OscNode` class. First we include all
 the headers we're going to depend on. Since all our code exists in the
 `ola::plugin::osc` namespace, we need to either add `using ...` directives
 or fully qualify the data types in the rest of the file. Generally if I'm
@@ -338,7 +338,7 @@ going to use a data type more than once in a file I'll typically add a
 Options Structure
 -----------------
 
-The `OSCNode` constructor takes a const reference to a `OSCNodeOptions`
+The `OscNode` constructor takes a const reference to a `OscNodeOptions`
 structure. Often the number of options passed to a constructor grows over
 the lifetime of the code. Consider a class `Foo`, which starts off with:
 
@@ -370,7 +370,7 @@ Ok, back to the code, the next line typedefs a
 `Callback1<void, const DmxBuffer&>` to `DMXCallback`. This shortens the code
 a bit, shorter code is usually easier to understand.
 
-The `OSCNode` constructor takes a `SelectServer`, `ExportMap` as well as the
+The `OscNode` constructor takes a `SelectServer`, `ExportMap` as well as the
 previously described options struct.
 
 Methods
@@ -383,7 +383,7 @@ Sending Data
 
 The next three methods (`AddTarget`, `RemoveTarget` & `SendData`) are used
 for sending DMX data using OSC. To ease the burden on the caller, we group
-`OSCTarget`s into groups (one target may exist in more than one group but
+`OscTarget`s into groups (one target may exist in more than one group but
 that's rare). In OLA, each group can be thought of as a universe.
 
 Groups are identified by their `group_id`, which is just an integer.
@@ -407,9 +407,9 @@ Finally `HandleDMXData()` is a method called by liblo.
 Private Types, Variables & Methods
 ----------------------------------
 
-Let's go over the internal data members of the `OSCNode` class.
+Let's go over the internal data members of the `OscNode` class.
 
-`NodeOSCTarget` is derived from `OSCTarget`. It includes a `lo_address`
+`NodeOscTarget` is derived from `OscTarget`. It includes a `lo_address`
 member. We do this because liblo doesn't provide a way to create
 `lo_address`es from a socket address, rather `lo_address_new()` takes
 strings, and then calls `inet_aton` to convert to the network data types. We
@@ -418,7 +418,7 @@ the `lo_address` object once for each target in `AddTarget()`.
 
 Next we have three typedefs, which are used with our internal data
 structures. On the sending side, we need to track a collection of
-`OSCTarget`s for each group. We do this with a map of vectors, so you can
+`OscTarget`s for each group. We do this with a map of vectors, so you can
 think of it like this:
 
     Group 1 ->
@@ -426,7 +426,7 @@ think of it like this:
     Group 2 ->
       [ target4 ]
 
-We could have used a set rather than a vector to hold the `NodeOSCTarget`
+We could have used a set rather than a vector to hold the `NodeOscTarget`
 objects, but then we'd need to define a `<` operator since the set container
 stores it's elements in sorted order. Using a set would also require us to
 store the objects directly rather than pointers to the objects, This would
@@ -434,9 +434,9 @@ incur additional copying when elements are inserted into the set but since
 we only do this once when the plugin starts and the number of elements (OSC
 Targets) is small it wouldn't matter.
 
-We typedef a vector of pointers to `NodeOSCTarget`s to `OSCTargetVector`,
-and then typedef a map of unsigned ints to pointers to `OSCTargetVector`s as
-a `OSCTargetMap`.
+We typedef a vector of pointers to `NodeOscTarget`s to `OscTargetVector`,
+and then typedef a map of unsigned ints to pointers to `OscTargetVector`s as
+a `OscTargetMap`.
 
 On the receiving side, we have a map of OSC addresses to callbacks:
 
@@ -447,13 +447,13 @@ On the receiving side, we have a map of OSC addresses to callbacks:
 
 We typedef a map of strings to callback objects to `AddressCallbackMap`.
 
-That's it for the types, the members are documented in the `OSCNode.h` file
+That's it for the types, the members are documented in the `OscNode.h` file
 itself. We store pointers to the `SelectServer` and `ExportMap` objects
 passed in to the constructor as well as the UDP port to listen on.
 
 We also hold a pointer to a `UnmanagedFileDescriptor` which is how we add
 the socket description used by liblo to the `SelectServer`. There is also
-the `lo_server` data, as well as the `OSCTargetMap` and `AddressCallbackMap`
+the `lo_server` data, as well as the `OscTargetMap` and `AddressCallbackMap`
 discussed above. On Windows, we need to create an
 `UnmanagedSocketDescriptor` instead.
 
@@ -464,25 +464,25 @@ Finally there are two static variables, `DEFAULT_OSC_PORT` which is the
 default UDP port to listen on and `OSC_PORT_VARIABLE`, which is what we use
 with the `ExportMap`.
 
-4.2 `OSCNode.cpp`
+4.2 `OscNode.cpp`
 -----------------
 
 Onwards to the implementation! Most of this is documented in the file itself
 so I'll just point out the interesting bits.
 
-    void OSCErrorHandler(int error_code, const char *msg, const char *stack)
+    void OscErrorHandler(int error_code, const char *msg, const char *stack)
 
 The call to `lo_server_new_with_proto()` takes a pointer to a function which
 is called when liblo wants to log an error message. We pass a pointer to
-`OSCErrorHandler` which uses the OLA logging mechanism.
+`OscErrorHandler` which uses the OLA logging mechanism.
 
-`OSCDataHandler` is what liblo calls when there is new OSC data. The last
-argument is a pointer back to the `OSCNode` object, so after we perform some
+`OscDataHandler` is what liblo calls when there is new OSC data. The last
+argument is a pointer back to the `OscNode` object, so after we perform some
 checks we call `HandleDMXData()`. We return 0 so that liblo doesn't try to
 find other OSC handlers to process the same data (see the liblo API for more
 info on this).
 
-In the `OSCNode` constructor, if an `ExportMap` was provided, we export the
+In the `OscNode` constructor, if an `ExportMap` was provided, we export the
 UDP port that liblo is listening on. If olad is built with the web server
 then users can navigate to http://<ip>:9090/debug and see the internal state
 of the server. The `ExportMap` provides an easy method to export this
@@ -495,7 +495,7 @@ previously, so we need to account for that.
 The `Init` method sets up the node. It creates a new `lo_server` and
 associates the socket description with the `SelectServer`.
 
-`Stop` deletes any of the entries in the `OSCTargetMap` and
+`Stop` deletes any of the entries in the `OscTargetMap` and
 `AddressCallbackMap`, cleans up the socket description and frees the
 `lo_server`. It's important to clear both maps once the entries have been
 deleted since `Stop()` may be called more than once. Similarly, once the
@@ -515,7 +515,7 @@ a detour and discuss about testing.
 
 All good code comes with tests and OLA is no exception. Well written tests
 increases the chance of having your plugin accepted into OLA. The
-`OSCNodeTest.cpp` contains the unittests for the `OSCNode` class.
+`OscNodeTest.cpp` contains the unittests for the `OscNode` class.
 
 To test the node, we create a second UDP socket (liblo creates the first
 one) which we then use to send and receive OSC messages. For each test we
@@ -526,14 +526,14 @@ shouldn't be since it's all localhost communication).
 In this test code we just use `OLA_ASSERT_TRUE`. `ola/testing/TestUtils.h`
 provides many more testing macros so take a look.
 
-Finally we need the `OSCTester.cpp` to pull it all together. This is just
+Finally we need the `OscTester.cpp` to pull it all together. This is just
 boiler plate code that sets up the unittests.
 
 
 Chapter 6, Plugins, Devices & Ports
 ===================================
 
-Now it's just a matter of building the OLA classes around the `OSCNode`. In
+Now it's just a matter of building the OLA classes around the `OscNode`. In
 OLA a Plugin creates objects of the Device type (if you use Java or other
 object orientated languages think of the Plugin class as a factory). Each
 device then has one of more input and output ports. For the OSC plugin, we
@@ -551,7 +551,7 @@ Each output port is configured with a list of OSC Targets in the form
 6.1 Plugin
 ----------
 
-The OSCPlugin is pretty simple. Like all OLA plugins, it inherits from the
+The OscPlugin is pretty simple. Like all OLA plugins, it inherits from the
 base `ola::Plugin` class. It's passed a pointer to a `PluginAdaptor` object,
 which is how the plugins interface with the rest of OLA.
 
@@ -570,49 +570,49 @@ changed, since if they do we need to write out the changes.
 
 Once `SetDefaultPreferences()` is called, the next method to run is
 `StartHook()`. This reads the configuration options, extracts the
-`OSCTarget`s from the string (by calling `ExtractOSCTarget()`) and adds them
+`OscTarget`s from the string (by calling `ExtractOscTarget()`) and adds them
 to a vector.
 
 Once the configuration options have been processed we create a new
-`OSCDevice`, call `Start()` and register it with OLA.
+`OscDevice`, call `Start()` and register it with OLA.
 
 The `StopHook()` method unregisters the device and deletes it.
 
 `GetPortCount()` is a helper method to save duplicating similar code more
 than once.
 
-`ExtractOSCTarget` unpacks a string in the form `ip:port/address` into a
-`OSCTarget` structure.
+`ExtractOscTarget` unpacks a string in the form `ip:port/address` into a
+`OscTarget` structure.
 
 6.2 Device
 ----------
 
-Like the Plugin, the device is also pretty simple. Each `OSCDevice` owns a
-`OSCNode` object. In the constructor, the `OSCDevice` takes a pointer to the
+Like the Plugin, the device is also pretty simple. Each `OscDevice` owns a
+`OscNode` object. In the constructor, the `OscDevice` takes a pointer to the
 plugin which created the device, as well as the UDP port to listen on, and a
 list of addresses (for the input ports) and targets (for the output ports).
 These data structures are saved as member variables since they are required
 in `StartHook()`.
 
-The `OSCDevice` uses the static ID of 1, which means we can only ever have
-one `OSCDevice`. This is probably fine unless people are doing fancy things
+The `OscDevice` uses the static ID of 1, which means we can only ever have
+one `OscDevice`. This is probably fine unless people are doing fancy things
 with multiple network interfaces.
 
 `AllowMultiPortPatching()` returns true, which means that multiple ports of
 the same type can be patched to the same universe. This is fine because the
-`RegisterAddress` method in `OSCNode` detects if we try to register the same
+`RegisterAddress` method in `OscNode` detects if we try to register the same
 address more than once.
 
 The only interesting method is `StartHook()`. This calls `Init` on the
-`OSCNode` and then sets up the ports. We call `Init()` from within
+`OscNode` and then sets up the ports. We call `Init()` from within
 `StartHook()` rather than in the constructor so that we can propagate a
 failure up the call change (constructors don't have return values so there
 is no way to notify the caller of an error). In general it's best to avoid
 any code that may fail in a constructor.
 
 `StartHook` iterates over the vector of addresses and creates an
-`OSCInputPort` for each. Similarly it iterates over the vector of vectors
-contains `OSCTarget`s and sets up an `OSCOutputPort` for each.
+`OscInputPort` for each. Similarly it iterates over the vector of vectors
+contains `OscTarget`s and sets up an `OscOutputPort` for each.
 
 For both the input and output ports we create a description string which
 shows up in `ola_dev_info` and on the web UI. For the input port this is the
@@ -623,11 +623,11 @@ targets it's sending to.
 ---------
 
 Since there isn't much code for the `Port` classes I put it all in
-`OSCPort.h` rather than splitting over two files.
+`OscPort.h` rather than splitting over two files.
 
-The `OSCInputPort` is the more complex of the two. Firstly the
+The `OscInputPort` is the more complex of the two. Firstly the
 `PreSetUniverse()` method is called, which is where we register a callback
-with the `OSCNode` (if needed). If the registration fails (say another port
+with the `OscNode` (if needed). If the registration fails (say another port
 has the same address) we return false, and OLA informs the user that
 patching failed.
 
@@ -641,8 +641,8 @@ calls `DmxChanged()`. This notifies the universe that the port is bound to
 that new data has arrived. The universe then calls `ReadDMX()` to collect
 the new data.
 
-`OSCOutputPort` is much more simple, when the `WriteDMX()` method is called
-we call `SendData()` on the `OSCNode` object. Note that our simple DMX over
+`OscOutputPort` is much more simple, when the `WriteDMX()` method is called
+we call `SendData()` on the `OscNode` object. Note that our simple DMX over
 OSC format has no notion of priority, so we ignore the priority argument.
 
 

--- a/plugins/spi/FakeSpiWriter.cpp
+++ b/plugins/spi/FakeSpiWriter.cpp
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * FakeSPIWriter.cpp
- * The SPIWriter used for testing.
+ * FakeSpiWriter.cpp
+ * The SpiWriter used for testing.
  * Copyright (C) 2013 Simon Newton
  */
 
@@ -23,7 +23,7 @@
 #include <string>
 #include "ola/Logging.h"
 #include "ola/testing/TestUtils.h"
-#include "plugins/spi/FakeSPIWriter.h"
+#include "plugins/spi/FakeSpiWriter.h"
 
 namespace ola {
 namespace plugin {
@@ -31,7 +31,7 @@ namespace spi {
 
 using ola::thread::MutexLocker;
 
-bool FakeSPIWriter::WriteSPIData(const uint8_t *data, unsigned int length) {
+bool FakeSpiWriter::WriteSpiData(const uint8_t *data, unsigned int length) {
   {
     MutexLocker lock(&m_mutex);
 
@@ -51,37 +51,37 @@ bool FakeSPIWriter::WriteSPIData(const uint8_t *data, unsigned int length) {
   return true;
 }
 
-void FakeSPIWriter::BlockWriter() {
+void FakeSpiWriter::BlockWriter() {
   m_write_lock.Lock();
 }
 
-void FakeSPIWriter::UnblockWriter() {
+void FakeSpiWriter::UnblockWriter() {
   m_write_lock.Unlock();
 }
 
-void FakeSPIWriter::ResetWrite() {
+void FakeSpiWriter::ResetWrite() {
   MutexLocker lock(&m_mutex);
   m_write_pending = false;
 }
 
-void FakeSPIWriter::WaitForWrite() {
+void FakeSpiWriter::WaitForWrite() {
   MutexLocker lock(&m_mutex);
   if (m_write_pending)
     return;
   m_cond_var.Wait(&m_mutex);
 }
 
-unsigned int FakeSPIWriter::WriteCount() const {
+unsigned int FakeSpiWriter::WriteCount() const {
   MutexLocker lock(&m_mutex);
   return m_writes;
 }
 
-unsigned int FakeSPIWriter::LastWriteSize() const {
+unsigned int FakeSpiWriter::LastWriteSize() const {
   MutexLocker lock(&m_mutex);
   return m_last_write_size;
 }
 
-void FakeSPIWriter::CheckDataMatches(
+void FakeSpiWriter::CheckDataMatches(
     const ola::testing::SourceLine &source_line,
     const uint8_t *expected,
     unsigned int length) {

--- a/plugins/spi/FakeSpiWriter.h
+++ b/plugins/spi/FakeSpiWriter.h
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * FakeSPIWriter.h
- * The SPIWriter used for testing.
+ * FakeSpiWriter.h
+ * The SpiWriter used for testing.
  * Copyright (C) 2013 Simon Newton
  */
 
@@ -25,7 +25,7 @@
 #include <ola/thread/Mutex.h>
 #include <stdint.h>
 #include <string>
-#include "plugins/spi/SPIWriter.h"
+#include "plugins/spi/SpiWriter.h"
 
 namespace ola {
 namespace plugin {
@@ -34,9 +34,9 @@ namespace spi {
 /**
  * A Fake SPI Writer used for testing
  */
-class FakeSPIWriter : public SPIWriterInterface {
+class FakeSpiWriter : public SpiWriterInterface {
  public:
-  explicit FakeSPIWriter(const std::string &device_path)
+  explicit FakeSpiWriter(const std::string &device_path)
     : m_device_path(device_path),
       m_write_pending(0),
       m_writes(0),
@@ -44,7 +44,7 @@ class FakeSPIWriter : public SPIWriterInterface {
       m_data(NULL) {
   }
 
-  ~FakeSPIWriter() {
+  ~FakeSpiWriter() {
     delete[] m_data;
   }
 
@@ -52,7 +52,7 @@ class FakeSPIWriter : public SPIWriterInterface {
 
   std::string DevicePath() const { return m_device_path; }
 
-  bool WriteSPIData(const uint8_t *data, unsigned int length);
+  bool WriteSpiData(const uint8_t *data, unsigned int length);
 
   // Methods used for testing
   void BlockWriter();

--- a/plugins/spi/Makefile.mk
+++ b/plugins/spi/Makefile.mk
@@ -4,28 +4,28 @@ if USE_SPI
 # This is a library which isn't coupled to olad
 lib_LTLIBRARIES += plugins/spi/libolaspicore.la plugins/spi/libolaspi.la
 plugins_spi_libolaspicore_la_SOURCES = \
-    plugins/spi/SPIBackend.cpp \
-    plugins/spi/SPIBackend.h \
-    plugins/spi/SPIOutput.cpp \
-    plugins/spi/SPIOutput.h \
-    plugins/spi/SPIWriter.cpp \
-    plugins/spi/SPIWriter.h
+    plugins/spi/SpiBackend.cpp \
+    plugins/spi/SpiBackend.h \
+    plugins/spi/SpiOutput.cpp \
+    plugins/spi/SpiOutput.h \
+    plugins/spi/SpiWriter.cpp \
+    plugins/spi/SpiWriter.h
 plugins_spi_libolaspicore_la_LIBADD = common/libolacommon.la
 
 # Plugin description is generated from README.md
-built_sources += plugins/spi/SPIPluginDescription.h
+built_sources += plugins/spi/SpiPluginDescription.h
 nodist_plugins_spi_libolaspi_la_SOURCES = \
-    plugins/spi/SPIPluginDescription.h
-plugins/spi/SPIPluginDescription.h: plugins/spi/README.md plugins/spi/Makefile.mk plugins/convert_README_to_header.sh
-	sh $(top_srcdir)/plugins/convert_README_to_header.sh $(top_srcdir)/plugins/spi $(top_builddir)/plugins/spi/SPIPluginDescription.h
+    plugins/spi/SpiPluginDescription.h
+plugins/spi/SpiPluginDescription.h: plugins/spi/README.md plugins/spi/Makefile.mk plugins/convert_README_to_header.sh
+	sh $(top_srcdir)/plugins/convert_README_to_header.sh $(top_srcdir)/plugins/spi $(top_builddir)/plugins/spi/SpiPluginDescription.h
 
 plugins_spi_libolaspi_la_SOURCES = \
-    plugins/spi/SPIDevice.cpp \
-    plugins/spi/SPIDevice.h \
-    plugins/spi/SPIPlugin.cpp \
-    plugins/spi/SPIPlugin.h \
-    plugins/spi/SPIPort.cpp \
-    plugins/spi/SPIPort.h
+    plugins/spi/SpiDevice.cpp \
+    plugins/spi/SpiDevice.h \
+    plugins/spi/SpiPlugin.cpp \
+    plugins/spi/SpiPlugin.h \
+    plugins/spi/SpiPort.cpp \
+    plugins/spi/SpiPort.h
 plugins_spi_libolaspi_la_LIBADD = \
     common/libolacommon.la \
     olad/plugin_api/libolaserverplugininterface.la \
@@ -33,15 +33,15 @@ plugins_spi_libolaspi_la_LIBADD = \
 
 # TESTS
 ##################################################
-test_programs += plugins/spi/SPITester
+test_programs += plugins/spi/SpiTester
 
-plugins_spi_SPITester_SOURCES = \
-    plugins/spi/SPIBackendTest.cpp \
-    plugins/spi/SPIOutputTest.cpp \
-    plugins/spi/FakeSPIWriter.cpp \
-    plugins/spi/FakeSPIWriter.h
-plugins_spi_SPITester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
-plugins_spi_SPITester_LDADD = $(COMMON_TESTING_LIBS) \
+plugins_spi_SpiTester_SOURCES = \
+    plugins/spi/SpiBackendTest.cpp \
+    plugins/spi/SpiOutputTest.cpp \
+    plugins/spi/FakeSpiWriter.cpp \
+    plugins/spi/FakeSpiWriter.h
+plugins_spi_SpiTester_CXXFLAGS = $(COMMON_TESTING_FLAGS)
+plugins_spi_SpiTester_LDADD = $(COMMON_TESTING_LIBS) \
                               plugins/spi/libolaspicore.la \
                               common/libolacommon.la
 

--- a/plugins/spi/SpiBackend.cpp
+++ b/plugins/spi/SpiBackend.cpp
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIBackend.cpp
+ * SpiBackend.cpp
  * The backend for SPI output. These are the classes which write the data to
  * the SPI bus.
  * Copyright (C) 2013 Simon Newton
@@ -35,7 +35,7 @@
 #include "ola/io/IOUtils.h"
 #include "ola/network/SocketCloser.h"
 #include "ola/stl/STLUtils.h"
-#include "plugins/spi/SPIBackend.h"
+#include "plugins/spi/SpiBackend.h"
 
 namespace ola {
 namespace plugin {
@@ -45,8 +45,8 @@ using ola::thread::MutexLocker;
 using std::string;
 using std::vector;
 
-const char SPIBackendInterface::SPI_DROP_VAR[] = "spi-drops";
-const char SPIBackendInterface::SPI_DROP_VAR_KEY[] = "device";
+const char SpiBackendInterface::SPI_DROP_VAR[] = "spi-drops";
+const char SpiBackendInterface::SPI_DROP_VAR_KEY[] = "device";
 
 uint8_t *HardwareBackend::OutputData::Resize(unsigned int length) {
   if (length < m_size) {
@@ -95,7 +95,7 @@ HardwareBackend::OutputData& HardwareBackend::OutputData::operator=(
 }
 
 HardwareBackend::HardwareBackend(const Options &options,
-                                 SPIWriterInterface *writer,
+                                 SpiWriterInterface *writer,
                                  ExportMap *export_map)
     : m_spi_writer(writer),
       m_drop_map(NULL),
@@ -247,7 +247,7 @@ void HardwareBackend::WriteOutput(uint8_t output_id, OutputData *output) {
     }
   }
 
-  m_spi_writer->WriteSPIData(output->GetData(), output->Size());
+  m_spi_writer->WriteSpiData(output->GetData(), output->Size());
 }
 
 bool HardwareBackend::SetupGPIO() {
@@ -301,7 +301,7 @@ void HardwareBackend::CloseGPIOFDs() {
 }
 
 SoftwareBackend::SoftwareBackend(const Options &options,
-                                 SPIWriterInterface *writer,
+                                 SpiWriterInterface *writer,
                                  ExportMap *export_map)
     : m_spi_writer(writer),
       m_drop_map(NULL),
@@ -442,22 +442,22 @@ void *SoftwareBackend::Run() {
     m_mutex.Unlock();
 
     if (write_pending) {
-      m_spi_writer->WriteSPIData(output_data, length);
+      m_spi_writer->WriteSpiData(output_data, length);
     }
   }
 }
 
-FakeSPIBackend::FakeSPIBackend(unsigned int outputs) {
+FakeSpiBackend::FakeSpiBackend(unsigned int outputs) {
   for (unsigned int i = 0; i < outputs; i++) {
     m_outputs.push_back(new Output());
   }
 }
 
-FakeSPIBackend::~FakeSPIBackend() {
+FakeSpiBackend::~FakeSpiBackend() {
   STLDeleteElements(&m_outputs);
 }
 
-uint8_t *FakeSPIBackend::Checkout(uint8_t output_id,
+uint8_t *FakeSpiBackend::Checkout(uint8_t output_id,
                                   unsigned int length,
                                   unsigned int latch_bytes) {
   if (output_id >= m_outputs.size()) {
@@ -475,14 +475,14 @@ uint8_t *FakeSPIBackend::Checkout(uint8_t output_id,
   return output->data;
 }
 
-void FakeSPIBackend::Commit(uint8_t output) {
+void FakeSpiBackend::Commit(uint8_t output) {
   if (output >= m_outputs.size()) {
     return;
   }
   m_outputs[output]->writes++;
 }
 
-const uint8_t *FakeSPIBackend::GetData(uint8_t output_id,
+const uint8_t *FakeSpiBackend::GetData(uint8_t output_id,
                                        unsigned int *length) {
   if (output_id >= m_outputs.size()) {
     return NULL;
@@ -493,7 +493,7 @@ const uint8_t *FakeSPIBackend::GetData(uint8_t output_id,
 }
 
 
-unsigned int FakeSPIBackend::Writes(uint8_t output) const {
+unsigned int FakeSpiBackend::Writes(uint8_t output) const {
   if (output >= m_outputs.size()) {
     return 0;
   }

--- a/plugins/spi/SpiBackend.h
+++ b/plugins/spi/SpiBackend.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIBackend.h
+ * SpiBackend.h
  * The backend for SPI output. These are the classes which write the data to
  * the SPI bus.
  * Copyright (C) 2013 Simon Newton
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 
-#include "plugins/spi/SPIWriter.h"
+#include "plugins/spi/SpiWriter.h"
 
 namespace ola {
 namespace plugin {
@@ -37,9 +37,9 @@ namespace spi {
 /**
  * The interface for all SPI Backends.
  */
-class SPIBackendInterface {
+class SpiBackendInterface {
  public:
-  virtual ~SPIBackendInterface() {}
+  virtual ~SpiBackendInterface() {}
 
   virtual uint8_t *Checkout(uint8_t output, unsigned int length) = 0;
   virtual uint8_t *Checkout(uint8_t output,
@@ -61,7 +61,7 @@ class SPIBackendInterface {
  * A HardwareBackend which uses GPIO pins and an external de-multiplexer
  */
 class HardwareBackend : public ola::thread::Thread,
-                        public SPIBackendInterface {
+                        public SpiBackendInterface {
  public:
   struct Options {
     // Which GPIO bits to use to select the output. The number of outputs
@@ -70,7 +70,7 @@ class HardwareBackend : public ola::thread::Thread,
   };
 
   HardwareBackend(const Options &options,
-                  SPIWriterInterface *writer,
+                  SpiWriterInterface *writer,
                   ExportMap *export_map);
   ~HardwareBackend();
 
@@ -126,7 +126,7 @@ class HardwareBackend : public ola::thread::Thread,
   typedef std::vector<int> GPIOFds;
   typedef std::vector<OutputData*> Outputs;
 
-  SPIWriterInterface *m_spi_writer;
+  SpiWriterInterface *m_spi_writer;
   UIntMap *m_drop_map;
   const uint8_t m_output_count;
   ola::thread::Mutex m_mutex;
@@ -151,7 +151,7 @@ class HardwareBackend : public ola::thread::Thread,
  * An SPI Backend which uses a software multipliexer. This accumulates all data
  * into a single buffer and then writes it to the SPI bus.
  */
-class SoftwareBackend : public SPIBackendInterface,
+class SoftwareBackend : public SpiBackendInterface,
                         public ola::thread::Thread {
  public:
   struct Options {
@@ -170,7 +170,7 @@ class SoftwareBackend : public SPIBackendInterface,
   };
 
   SoftwareBackend(const Options &options,
-                  SPIWriterInterface *writer,
+                  SpiWriterInterface *writer,
                   ExportMap *export_map);
   ~SoftwareBackend();
 
@@ -191,7 +191,7 @@ class SoftwareBackend : public SPIBackendInterface,
   void* Run();
 
  private:
-  SPIWriterInterface *m_spi_writer;
+  SpiWriterInterface *m_spi_writer;
   UIntMap *m_drop_map;
   ola::thread::Mutex m_mutex;
   ola::thread::ConditionVariable m_cond_var;
@@ -210,10 +210,10 @@ class SoftwareBackend : public SPIBackendInterface,
  * A fake backend used for testing. If we had gmock this would be much
  * easier...
  */
-class FakeSPIBackend : public SPIBackendInterface {
+class FakeSpiBackend : public SpiBackendInterface {
  public:
-  explicit FakeSPIBackend(unsigned int outputs);
-  ~FakeSPIBackend();
+  explicit FakeSpiBackend(unsigned int outputs);
+  ~FakeSpiBackend();
 
   uint8_t *Checkout(uint8_t output, unsigned int length) {
     return Checkout(output, length, 0);

--- a/plugins/spi/SpiBackendTest.cpp
+++ b/plugins/spi/SpiBackendTest.cpp
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIBackendTest.cpp
- * Test fixture for the SPIBackendTests.
+ * SpiBackendTest.cpp
+ * Test fixture for the SpiBackendTests.
  * Copyright (C) 2013 Simon Newton
  */
 
@@ -26,19 +26,19 @@
 #include "ola/ExportMap.h"
 #include "ola/Logging.h"
 #include "ola/testing/TestUtils.h"
-#include "plugins/spi/FakeSPIWriter.h"
-#include "plugins/spi/SPIBackend.h"
+#include "plugins/spi/FakeSpiWriter.h"
+#include "plugins/spi/SpiBackend.h"
 
 using ola::DmxBuffer;
 using ola::ExportMap;
-using ola::plugin::spi::FakeSPIWriter;
+using ola::plugin::spi::FakeSpiWriter;
 using ola::plugin::spi::HardwareBackend;
 using ola::plugin::spi::SoftwareBackend;
-using ola::plugin::spi::SPIBackendInterface;
+using ola::plugin::spi::SpiBackendInterface;
 using ola::UIntMap;
 
-class SPIBackendTest: public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(SPIBackendTest);
+class SpiBackendTest: public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(SpiBackendTest);
   CPPUNIT_TEST(testHardwareDrops);
   CPPUNIT_TEST(testHardwareVariousFrameLengths);
   CPPUNIT_TEST(testInvalidOutputs);
@@ -47,11 +47,11 @@ class SPIBackendTest: public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE_END();
 
  public:
-  SPIBackendTest();
+  SpiBackendTest();
 
   void setUp();
   unsigned int DropCount();
-  bool SendSomeData(SPIBackendInterface *backend,
+  bool SendSomeData(SpiBackendInterface *backend,
                     uint8_t output,
                     const uint8_t *data,
                     unsigned int length,
@@ -66,7 +66,7 @@ class SPIBackendTest: public CppUnit::TestFixture {
 
  private:
   ExportMap m_export_map;
-  FakeSPIWriter m_writer;
+  FakeSpiWriter m_writer;
   unsigned int m_total_size;
 
   static const uint8_t DATA1[];
@@ -81,61 +81,61 @@ class SPIBackendTest: public CppUnit::TestFixture {
   static const char SPI_DROP_VAR_KEY[];
 };
 
-const uint8_t SPIBackendTest::DATA1[] = {
+const uint8_t SpiBackendTest::DATA1[] = {
   1, 2, 3, 4, 5, 6, 7, 8, 9, 0
 };
 
-const uint8_t SPIBackendTest::DATA2[] = {
+const uint8_t SpiBackendTest::DATA2[] = {
   0xa, 0xb, 0xc, 0xd, 0xe, 0xf
 };
 
-const uint8_t SPIBackendTest::DATA3[] = {
+const uint8_t SpiBackendTest::DATA3[] = {
   1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
   0xa, 0xb, 0xc, 0xd, 0xe, 0xf
 };
 
-const uint8_t SPIBackendTest::EXPECTED1[] = {
+const uint8_t SpiBackendTest::EXPECTED1[] = {
   1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0
 };
 
-const uint8_t SPIBackendTest::EXPECTED2[] = {
+const uint8_t SpiBackendTest::EXPECTED2[] = {
   0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0
 };
 
-const uint8_t SPIBackendTest::EXPECTED3[] = {
+const uint8_t SpiBackendTest::EXPECTED3[] = {
   1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf,
   0, 0, 0, 0,
 };
 
-const uint8_t SPIBackendTest::EXPECTED4[] = {
+const uint8_t SpiBackendTest::EXPECTED4[] = {
   1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0
 };
 
-const char SPIBackendTest::DEVICE_NAME[] = "Fake Device";
-const char SPIBackendTest::SPI_DROP_VAR[] = "spi-drops";
-const char SPIBackendTest::SPI_DROP_VAR_KEY[] = "device";
+const char SpiBackendTest::DEVICE_NAME[] = "Fake Device";
+const char SpiBackendTest::SPI_DROP_VAR[] = "spi-drops";
+const char SpiBackendTest::SPI_DROP_VAR_KEY[] = "device";
 
 
-CPPUNIT_TEST_SUITE_REGISTRATION(SPIBackendTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(SpiBackendTest);
 
-SPIBackendTest::SPIBackendTest()
+SpiBackendTest::SpiBackendTest()
     : CppUnit::TestFixture(),
       m_writer(DEVICE_NAME) {
   m_total_size = arraysize(DATA3);
 }
 
-void SPIBackendTest::setUp() {
+void SpiBackendTest::setUp() {
   ola::InitLogging(ola::OLA_LOG_INFO, ola::OLA_LOG_STDERR);
 }
 
-unsigned int SPIBackendTest::DropCount() {
+unsigned int SpiBackendTest::DropCount() {
   UIntMap *drop_map = m_export_map.GetUIntMapVar(SPI_DROP_VAR,
                                                  SPI_DROP_VAR_KEY);
   return (*drop_map)[DEVICE_NAME];
 }
 
-bool SPIBackendTest::SendSomeData(SPIBackendInterface *backend,
+bool SpiBackendTest::SendSomeData(SpiBackendInterface *backend,
                                   uint8_t output,
                                   const uint8_t *data,
                                   unsigned int length,
@@ -152,7 +152,7 @@ bool SPIBackendTest::SendSomeData(SPIBackendInterface *backend,
 /**
  * Check that we increment the exported variable when we drop frames.
  */
-void SPIBackendTest::testHardwareDrops() {
+void SpiBackendTest::testHardwareDrops() {
   HardwareBackend backend(HardwareBackend::Options(), &m_writer,
                           &m_export_map);
   OLA_ASSERT(backend.Init());
@@ -175,7 +175,7 @@ void SPIBackendTest::testHardwareDrops() {
 /**
  * Check that we handle the case of frame lengths changing.
  */
-void SPIBackendTest::testHardwareVariousFrameLengths() {
+void SpiBackendTest::testHardwareVariousFrameLengths() {
   HardwareBackend backend(HardwareBackend::Options(), &m_writer,
                           &m_export_map);
   OLA_ASSERT(backend.Init());
@@ -229,7 +229,7 @@ void SPIBackendTest::testHardwareVariousFrameLengths() {
 /**
  * Check we can't send to invalid outputs.
  */
-void SPIBackendTest::testInvalidOutputs() {
+void SpiBackendTest::testInvalidOutputs() {
   // HardwareBackend
   HardwareBackend hw_backend(HardwareBackend::Options(), &m_writer,
                              &m_export_map);
@@ -251,7 +251,7 @@ void SPIBackendTest::testInvalidOutputs() {
 /**
  * Check that we increment the exported variable when we drop frames.
  */
-void SPIBackendTest::testSoftwareDrops() {
+void SpiBackendTest::testSoftwareDrops() {
   SoftwareBackend backend(SoftwareBackend::Options(), &m_writer,
                           &m_export_map);
   OLA_ASSERT(backend.Init());
@@ -274,7 +274,7 @@ void SPIBackendTest::testSoftwareDrops() {
 /**
  * Check that we handle the case of frame lengths changing.
  */
-void SPIBackendTest::testSoftwareVariousFrameLengths() {
+void SpiBackendTest::testSoftwareVariousFrameLengths() {
   SoftwareBackend backend(SoftwareBackend::Options(), &m_writer,
                           &m_export_map);
   OLA_ASSERT(backend.Init());

--- a/plugins/spi/SpiDevice.cpp
+++ b/plugins/spi/SpiDevice.cpp
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIDevice.cpp
+ * SpiDevice.cpp
  * SPI device
  * Copyright (C) 2013 Simon Newton
  */
@@ -30,9 +30,9 @@
 #include "olad/PluginAdaptor.h"
 #include "olad/Preferences.h"
 #include "olad/Universe.h"
-#include "plugins/spi/SPIDevice.h"
-#include "plugins/spi/SPIPort.h"
-#include "plugins/spi/SPIPlugin.h"
+#include "plugins/spi/SpiDevice.h"
+#include "plugins/spi/SpiPort.h"
+#include "plugins/spi/SpiPlugin.h"
 
 namespace ola {
 namespace plugin {
@@ -45,14 +45,14 @@ using std::set;
 using std::string;
 using std::vector;
 
-const char SPIDevice::SPI_DEVICE_NAME[] = "SPI Device";
-const char SPIDevice::HARDWARE_BACKEND[] = "hardware";
-const char SPIDevice::SOFTWARE_BACKEND[] = "software";
+const char SpiDevice::SPI_DEVICE_NAME[] = "SPI Device";
+const char SpiDevice::HARDWARE_BACKEND[] = "hardware";
+const char SpiDevice::SOFTWARE_BACKEND[] = "software";
 
 /*
  * Create a new device
  */
-SPIDevice::SPIDevice(SPIPlugin *owner,
+SpiDevice::SpiDevice(SpiPlugin *owner,
                      Preferences *prefs,
                      PluginAdaptor *plugin_adaptor,
                      const string &spi_device,
@@ -70,10 +70,10 @@ SPIDevice::SPIDevice(SPIPlugin *owner,
   SetDefaults();
   unsigned int port_count = 0;
 
-  string backend_type = m_preferences->GetValue(SPIBackendKey());
-  SPIWriter::Options writer_options;
+  string backend_type = m_preferences->GetValue(SpiBackendKey());
+  SpiWriter::Options writer_options;
   PopulateWriterOptions(&writer_options);
-  m_writer.reset(new SPIWriter(spi_device, writer_options,
+  m_writer.reset(new SpiWriter(spi_device, writer_options,
                                plugin_adaptor->GetExportMap()));
 
 
@@ -103,7 +103,7 @@ SPIDevice::SPIDevice(SPIPlugin *owner,
   }
 
   for (uint8_t i = 0; i < port_count; i++) {
-    SPIOutput::Options spi_output_options(i, m_spi_device_name);
+    SpiOutput::Options spi_output_options(i, m_spi_device_name);
 
     if (m_preferences->HasKey(DeviceLabelKey(i))) {
       spi_output_options.device_label =
@@ -123,13 +123,13 @@ SPIDevice::SPIDevice(SPIPlugin *owner,
     }
 
     m_spi_ports.push_back(
-        new SPIOutputPort(this, m_backend.get(), *uid.get(),
+        new SpiOutputPort(this, m_backend.get(), *uid.get(),
                           spi_output_options));
   }
 }
 
 
-string SPIDevice::DeviceId() const {
+string SpiDevice::DeviceId() const {
   return m_spi_device_name;
 }
 
@@ -137,13 +137,13 @@ string SPIDevice::DeviceId() const {
 /*
  * Start this device
  */
-bool SPIDevice::StartHook() {
+bool SpiDevice::StartHook() {
   if (!m_backend->Init()) {
     STLDeleteElements(&m_spi_ports);
     return false;
   }
 
-  SPIPorts::iterator iter = m_spi_ports.begin();
+  SpiPorts::iterator iter = m_spi_ports.begin();
   for (uint8_t i = 0; iter != m_spi_ports.end(); iter++, i++) {
     uint8_t personality;
     if (StringToInt(m_preferences->GetValue(PersonalityKey(i)),
@@ -163,8 +163,8 @@ bool SPIDevice::StartHook() {
 }
 
 
-void SPIDevice::PrePortStop() {
-  SPIPorts::iterator iter = m_spi_ports.begin();
+void SpiDevice::PrePortStop() {
+  SpiPorts::iterator iter = m_spi_ports.begin();
   for (uint8_t i = 0; iter != m_spi_ports.end(); iter++, i++) {
     ostringstream str;
     m_preferences->SetValue(DeviceLabelKey(i), (*iter)->GetDeviceLabel());
@@ -180,69 +180,69 @@ void SPIDevice::PrePortStop() {
   m_preferences->Save();
 }
 
-string SPIDevice::SPIBackendKey() const {
+string SpiDevice::SpiBackendKey() const {
   return m_spi_device_name + "-backend";
 }
 
-string SPIDevice::SPISpeedKey() const {
+string SpiDevice::SpiSpeedKey() const {
   return m_spi_device_name + "-spi-speed";
 }
 
-string SPIDevice::SPICEKey() const {
+string SpiDevice::SpiCEKey() const {
   return m_spi_device_name + "-spi-ce-high";
 }
 
-string SPIDevice::PortCountKey() const {
+string SpiDevice::PortCountKey() const {
   return m_spi_device_name + "-ports";
 }
 
-string SPIDevice::SyncPortKey() const {
+string SpiDevice::SyncPortKey() const {
   return m_spi_device_name + "-sync-port";
 }
 
-string SPIDevice::GPIOPinKey() const {
+string SpiDevice::GPIOPinKey() const {
   return m_spi_device_name + "-gpio-pin";
 }
 
-string SPIDevice::DeviceLabelKey(uint8_t port) const {
+string SpiDevice::DeviceLabelKey(uint8_t port) const {
   return GetPortKey("device-label", port);
 }
 
-string SPIDevice::PersonalityKey(uint8_t port) const {
+string SpiDevice::PersonalityKey(uint8_t port) const {
   return GetPortKey("personality", port);
 }
 
-string SPIDevice::StartAddressKey(uint8_t port) const {
+string SpiDevice::StartAddressKey(uint8_t port) const {
   return GetPortKey("dmx-address", port);
 }
 
-string SPIDevice::PixelCountKey(uint8_t port) const {
+string SpiDevice::PixelCountKey(uint8_t port) const {
   return GetPortKey("pixel-count", port);
 }
 
-string SPIDevice::GetPortKey(const string &suffix, uint8_t port) const {
+string SpiDevice::GetPortKey(const string &suffix, uint8_t port) const {
   std::ostringstream str;
   str << m_spi_device_name << "-" << static_cast<int>(port) << "-" << suffix;
   return str.str();
 }
 
-void SPIDevice::SetDefaults() {
+void SpiDevice::SetDefaults() {
   // Set device options
   set<string> valid_backends;
   valid_backends.insert(HARDWARE_BACKEND);
   valid_backends.insert(SOFTWARE_BACKEND);
-  m_preferences->SetDefaultValue(SPIBackendKey(),
+  m_preferences->SetDefaultValue(SpiBackendKey(),
                                  SetValidator<string>(valid_backends),
                                  SOFTWARE_BACKEND);
-  m_preferences->SetDefaultValue(SPISpeedKey(), UIntValidator(0, 32000000),
+  m_preferences->SetDefaultValue(SpiSpeedKey(), UIntValidator(0, 32000000),
                                  1000000);
-  m_preferences->SetDefaultValue(SPICEKey(), BoolValidator(), false);
+  m_preferences->SetDefaultValue(SpiCEKey(), BoolValidator(), false);
   m_preferences->SetDefaultValue(PortCountKey(), UIntValidator(1, 8), 1);
   m_preferences->SetDefaultValue(SyncPortKey(), IntValidator(-2, 8), 0);
   m_preferences->Save();
 }
 
-void SPIDevice::PopulateHardwareBackendOptions(
+void SpiDevice::PopulateHardwareBackendOptions(
     HardwareBackend::Options *options) {
   vector<string> pins = m_preferences->GetMultipleValue(GPIOPinKey());
   vector<string>::const_iterator iter = pins.begin();
@@ -263,7 +263,7 @@ void SPIDevice::PopulateHardwareBackendOptions(
   }
 }
 
-void SPIDevice::PopulateSoftwareBackendOptions(
+void SpiDevice::PopulateSoftwareBackendOptions(
     SoftwareBackend::Options *options) {
   if (!StringToInt(m_preferences->GetValue(PortCountKey()),
                                            &options->outputs)) {
@@ -279,13 +279,13 @@ void SPIDevice::PopulateSoftwareBackendOptions(
   }
 }
 
-void SPIDevice::PopulateWriterOptions(SPIWriter::Options *options) {
+void SpiDevice::PopulateWriterOptions(SpiWriter::Options *options) {
   uint32_t spi_speed;
-  if (StringToInt(m_preferences->GetValue(SPISpeedKey()), &spi_speed)) {
+  if (StringToInt(m_preferences->GetValue(SpiSpeedKey()), &spi_speed)) {
     options->spi_speed = spi_speed;
   }
   bool ce_high;
-  if (StringToBool(m_preferences->GetValue(SPICEKey()), &ce_high)) {
+  if (StringToBool(m_preferences->GetValue(SpiCEKey()), &ce_high)) {
     options->cs_enable_high = ce_high;
   }
 }

--- a/plugins/spi/SpiDevice.h
+++ b/plugins/spi/SpiDevice.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIDevice.h
+ * SpiDevice.h
  * The SPI Device class
  * Copyright (C) 2013 Simon Newton
  */
@@ -29,17 +29,17 @@
 #include "ola/io/SelectServer.h"
 #include "ola/rdm/UIDAllocator.h"
 #include "ola/rdm/UID.h"
-#include "plugins/spi/SPIBackend.h"
-#include "plugins/spi/SPIWriter.h"
+#include "plugins/spi/SpiBackend.h"
+#include "plugins/spi/SpiWriter.h"
 
 namespace ola {
 namespace plugin {
 namespace spi {
 
 
-class SPIDevice: public ola::Device {
+class SpiDevice: public ola::Device {
  public:
-  SPIDevice(class SPIPlugin *owner,
+  SpiDevice(class SpiPlugin *owner,
             class Preferences *preferences,
             class PluginAdaptor *plugin_adaptor,
             const std::string &spi_device,
@@ -54,19 +54,19 @@ class SPIDevice: public ola::Device {
   void PrePortStop();
 
  private:
-  typedef std::vector<class SPIOutputPort*> SPIPorts;
+  typedef std::vector<class SpiOutputPort*> SpiPorts;
 
-  std::auto_ptr<SPIWriterInterface> m_writer;
-  std::auto_ptr<SPIBackendInterface> m_backend;
+  std::auto_ptr<SpiWriterInterface> m_writer;
+  std::auto_ptr<SpiBackendInterface> m_backend;
   class Preferences *m_preferences;
   class PluginAdaptor *m_plugin_adaptor;
-  SPIPorts m_spi_ports;
+  SpiPorts m_spi_ports;
   std::string m_spi_device_name;
 
   // Per device options
-  std::string SPIBackendKey() const;
-  std::string SPISpeedKey() const;
-  std::string SPICEKey() const;
+  std::string SpiBackendKey() const;
+  std::string SpiSpeedKey() const;
+  std::string SpiCEKey() const;
   std::string PortCountKey() const;
   std::string SyncPortKey() const;
   std::string GPIOPinKey() const;
@@ -81,7 +81,7 @@ class SPIDevice: public ola::Device {
   void SetDefaults();
   void PopulateHardwareBackendOptions(HardwareBackend::Options *options);
   void PopulateSoftwareBackendOptions(SoftwareBackend::Options *options);
-  void PopulateWriterOptions(SPIWriter::Options *options);
+  void PopulateWriterOptions(SpiWriter::Options *options);
 
   static const char SPI_DEVICE_NAME[];
   static const char HARDWARE_BACKEND[];

--- a/plugins/spi/SpiOutput.h
+++ b/plugins/spi/SpiOutput.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIOutput.h
+ * SpiOutput.h
  * An RDM-controllable SPI device. Takes up to one universe of DMX.
  * Copyright (C) 2013 Simon Newton
  */
@@ -36,7 +36,7 @@ namespace ola {
 namespace plugin {
 namespace spi {
 
-class SPIOutput: public ola::rdm::DiscoverableRDMControllerInterface {
+class SpiOutput: public ola::rdm::DiscoverableRDMControllerInterface {
  public:
   struct Options {
     std::string device_label;
@@ -50,10 +50,10 @@ class SPIOutput: public ola::rdm::DiscoverableRDMControllerInterface {
     }
   };
 
-  SPIOutput(const ola::rdm::UID &uid,
-            class SPIBackendInterface *backend,
+  SpiOutput(const ola::rdm::UID &uid,
+            class SpiBackendInterface *backend,
             const Options &options);
-  ~SPIOutput();
+  ~SpiOutput();
 
   std::string GetDeviceLabel() const;
   bool SetDeviceLabel(const std::string &device_label);
@@ -75,7 +75,7 @@ class SPIOutput: public ola::rdm::DiscoverableRDMControllerInterface {
   /**
    * The RDM Operations for the MovingLightResponder.
    */
-  class RDMOps : public ola::rdm::ResponderOps<SPIOutput> {
+  class RDMOps : public ola::rdm::ResponderOps<SpiOutput> {
    public:
     static RDMOps *Instance() {
       if (!instance)
@@ -84,12 +84,12 @@ class SPIOutput: public ola::rdm::DiscoverableRDMControllerInterface {
     }
 
    private:
-    RDMOps() : ola::rdm::ResponderOps<SPIOutput>(PARAM_HANDLERS) {}
+    RDMOps() : ola::rdm::ResponderOps<SpiOutput>(PARAM_HANDLERS) {}
 
     static RDMOps *instance;
   };
 
-  class SPIBackendInterface *m_backend;
+  class SpiBackendInterface *m_backend;
   const uint8_t m_output_number;
   std::string m_spi_device_name;
   const ola::rdm::UID m_uid;
@@ -115,7 +115,7 @@ class SPIOutput: public ola::rdm::DiscoverableRDMControllerInterface {
   void CombinedAPA102Control(const DmxBuffer &buffer);
 
   unsigned int LPD8806BufferSize() const;
-  void WriteSPIData(const uint8_t *data, unsigned int length);
+  void WriteSpiData(const uint8_t *data, unsigned int length);
 
   // RDM methods
   ola::rdm::RDMResponse *GetDeviceInfo(
@@ -187,7 +187,7 @@ class SPIOutput: public ola::rdm::DiscoverableRDMControllerInterface {
   static const uint16_t APA102_SPI_BYTES_PER_PIXEL;
   static const uint16_t APA102_START_FRAME_BYTES;
 
-  static const ola::rdm::ResponderOps<SPIOutput>::ParamHandler
+  static const ola::rdm::ResponderOps<SpiOutput>::ParamHandler
       PARAM_HANDLERS[];
 };
 }  // namespace spi

--- a/plugins/spi/SpiOutputTest.cpp
+++ b/plugins/spi/SpiOutputTest.cpp
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIOutputTest.cpp
- * Test fixture for SPIOutput.
+ * SpiOutputTest.cpp
+ * Test fixture for SpiOutput.
  * Copyright (C) 2013 Simon Newton
  */
 
@@ -26,18 +26,18 @@
 #include "ola/Logging.h"
 #include "ola/rdm/UID.h"
 #include "ola/testing/TestUtils.h"
-#include "plugins/spi/SPIBackend.h"
-#include "plugins/spi/SPIOutput.h"
+#include "plugins/spi/SpiBackend.h"
+#include "plugins/spi/SpiOutput.h"
 
 using ola::DmxBuffer;
-using ola::plugin::spi::FakeSPIBackend;
-using ola::plugin::spi::SPIBackendInterface;
-using ola::plugin::spi::SPIOutput;
+using ola::plugin::spi::FakeSpiBackend;
+using ola::plugin::spi::SpiBackendInterface;
+using ola::plugin::spi::SpiOutput;
 using ola::rdm::UID;
 using std::string;
 
-class SPIOutputTest: public CppUnit::TestFixture {
-  CPPUNIT_TEST_SUITE(SPIOutputTest);
+class SpiOutputTest: public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(SpiOutputTest);
   CPPUNIT_TEST(testDescription);
   CPPUNIT_TEST(testIndividualWS2801Control);
   CPPUNIT_TEST(testCombinedWS2801Control);
@@ -50,7 +50,7 @@ class SPIOutputTest: public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE_END();
 
  public:
-  SPIOutputTest()
+  SpiOutputTest()
       : CppUnit::TestFixture(),
         m_uid(0x707a, 0) {
   }
@@ -71,21 +71,21 @@ class SPIOutputTest: public CppUnit::TestFixture {
 };
 
 
-CPPUNIT_TEST_SUITE_REGISTRATION(SPIOutputTest);
+CPPUNIT_TEST_SUITE_REGISTRATION(SpiOutputTest);
 
-void SPIOutputTest::setUp() {
+void SpiOutputTest::setUp() {
   ola::InitLogging(ola::OLA_LOG_INFO, ola::OLA_LOG_STDERR);
 }
 
 /**
  * Check the descrption, start address & personality.
  */
-void SPIOutputTest::testDescription() {
-  FakeSPIBackend backend(2);
-  SPIOutput output1(m_uid, &backend, SPIOutput::Options(0, "Test SPI Device"));
-  SPIOutput::Options options(1, "Test SPI Device");
+void SpiOutputTest::testDescription() {
+  FakeSpiBackend backend(2);
+  SpiOutput output1(m_uid, &backend, SpiOutput::Options(0, "Test SPI Device"));
+  SpiOutput::Options options(1, "Test SPI Device");
   options.pixel_count = 32;
-  SPIOutput output2(m_uid, &backend, options);
+  SpiOutput output2(m_uid, &backend, options);
 
   OLA_ASSERT_EQ(
       string("Output 0, WS2801 Individual Control, 75 slots @ 1."
@@ -113,11 +113,11 @@ void SPIOutputTest::testDescription() {
 /**
  * Test DMX writes in the individual WS2801 mode.
  */
-void SPIOutputTest::testIndividualWS2801Control() {
-  FakeSPIBackend backend(2);
-  SPIOutput::Options options(0, "Test SPI Device");
+void SpiOutputTest::testIndividualWS2801Control() {
+  FakeSpiBackend backend(2);
+  SpiOutput::Options options(0, "Test SPI Device");
   options.pixel_count = 2;
-  SPIOutput output(m_uid, &backend, options);
+  SpiOutput output(m_uid, &backend, options);
 
   DmxBuffer buffer;
   unsigned int length = 0;
@@ -169,11 +169,11 @@ void SPIOutputTest::testIndividualWS2801Control() {
 /**
  * Test DMX writes in the combined WS2801 mode.
  */
-void SPIOutputTest::testCombinedWS2801Control() {
-  FakeSPIBackend backend(2);
-  SPIOutput::Options options(0, "Test SPI Device");
+void SpiOutputTest::testCombinedWS2801Control() {
+  FakeSpiBackend backend(2);
+  SpiOutput::Options options(0, "Test SPI Device");
   options.pixel_count = 2;
-  SPIOutput output(m_uid, &backend, options);
+  SpiOutput output(m_uid, &backend, options);
   output.SetPersonality(2);
 
   DmxBuffer buffer;
@@ -218,11 +218,11 @@ void SPIOutputTest::testCombinedWS2801Control() {
 /**
  * Test DMX writes in the individual LPD8806 mode.
  */
-void SPIOutputTest::testIndividualLPD8806Control() {
-  FakeSPIBackend backend(2);
-  SPIOutput::Options options(0, "Test SPI Device");
+void SpiOutputTest::testIndividualLPD8806Control() {
+  FakeSpiBackend backend(2);
+  SpiOutput::Options options(0, "Test SPI Device");
   options.pixel_count = 2;
-  SPIOutput output(m_uid, &backend, options);
+  SpiOutput output(m_uid, &backend, options);
   output.SetPersonality(3);
 
   DmxBuffer buffer;
@@ -273,11 +273,11 @@ void SPIOutputTest::testIndividualLPD8806Control() {
 /**
  * Test DMX writes in the combined LPD8806 mode.
  */
-void SPIOutputTest::testCombinedLPD8806Control() {
-  FakeSPIBackend backend(2);
-  SPIOutput::Options options(0, "Test SPI Device");
+void SpiOutputTest::testCombinedLPD8806Control() {
+  FakeSpiBackend backend(2);
+  SpiOutput::Options options(0, "Test SPI Device");
   options.pixel_count = 2;
-  SPIOutput output(m_uid, &backend, options);
+  SpiOutput output(m_uid, &backend, options);
   output.SetPersonality(4);
 
   DmxBuffer buffer;
@@ -320,11 +320,11 @@ void SPIOutputTest::testCombinedLPD8806Control() {
 /**
  * Test DMX writes in the individual P9813 mode.
  */
-void SPIOutputTest::testIndividualP9813Control() {
-  FakeSPIBackend backend(2);
-  SPIOutput::Options options(0, "Test SPI Device");
+void SpiOutputTest::testIndividualP9813Control() {
+  FakeSpiBackend backend(2);
+  SpiOutput::Options options(0, "Test SPI Device");
   options.pixel_count = 2;
-  SPIOutput output(m_uid, &backend, options);
+  SpiOutput output(m_uid, &backend, options);
   output.SetPersonality(5);
 
   DmxBuffer buffer;
@@ -379,11 +379,11 @@ void SPIOutputTest::testIndividualP9813Control() {
 /**
  * Test DMX writes in the combined P9813 mode.
  */
-void SPIOutputTest::testCombinedP9813Control() {
-  FakeSPIBackend backend(2);
-  SPIOutput::Options options(0, "Test SPI Device");
+void SpiOutputTest::testCombinedP9813Control() {
+  FakeSpiBackend backend(2);
+  SpiOutput::Options options(0, "Test SPI Device");
   options.pixel_count = 2;
-  SPIOutput output(m_uid, &backend, options);
+  SpiOutput output(m_uid, &backend, options);
   output.SetPersonality(6);
 
   DmxBuffer buffer;
@@ -429,16 +429,16 @@ void SPIOutputTest::testCombinedP9813Control() {
 /**
  * Test DMX writes in the individual APA102 mode.
  */
-void SPIOutputTest::testIndividualAPA102Control() {
+void SpiOutputTest::testIndividualAPA102Control() {
   // personality 7= Individual APA102
   const uint16_t this_test_personality = 7;
   // setup Backend
-  FakeSPIBackend backend(2);
-  SPIOutput::Options options(0, "Test SPI Device");
+  FakeSpiBackend backend(2);
+  SpiOutput::Options options(0, "Test SPI Device");
   // setup pixel_count to 2 (enough to test all cases)
   options.pixel_count = 2;
-  // setup SPIOutput
-  SPIOutput output(m_uid, &backend, options);
+  // setup SpiOutput
+  SpiOutput output(m_uid, &backend, options);
   // set personality
   output.SetPersonality(this_test_personality);
 
@@ -524,11 +524,11 @@ void SPIOutputTest::testIndividualAPA102Control() {
   // test7
   // test for multiple ports
   // StartFrame is only allowed on first port.
-  SPIOutput::Options options1(1, "second SPI Device");
+  SpiOutput::Options options1(1, "second SPI Device");
   // setup pixel_count to 2 (enough to test all cases)
   options1.pixel_count = 2;
-  // setup SPIOutput
-  SPIOutput output1(m_uid, &backend, options1);
+  // setup SpiOutput
+  SpiOutput output1(m_uid, &backend, options1);
   // set personality
   output1.SetPersonality(this_test_personality);
   // setup some 'DMX' data
@@ -552,8 +552,8 @@ void SPIOutputTest::testIndividualAPA102Control() {
   // create new output with pixel_count=16 and check data length
   // setup pixel_count to 16
   options.pixel_count = 16;
-  // setup SPIOutput
-  SPIOutput output2(m_uid, &backend, options);
+  // setup SpiOutput
+  SpiOutput output2(m_uid, &backend, options);
   // set personality
   output2.SetPersonality(this_test_personality);
   buffer.SetFromString(
@@ -586,8 +586,8 @@ void SPIOutputTest::testIndividualAPA102Control() {
   // create new output with pixel_count=17 and check data length
   // setup pixel_count to 17
   options.pixel_count = 17;
-  // setup SPIOutput
-  SPIOutput output3(m_uid, &backend, options);
+  // setup SpiOutput
+  SpiOutput output3(m_uid, &backend, options);
   // set personality
   output3.SetPersonality(this_test_personality);
   // generate dmx data
@@ -623,16 +623,16 @@ void SPIOutputTest::testIndividualAPA102Control() {
 /**
  * Test DMX writes in the combined APA102 mode.
  */
-void SPIOutputTest::testCombinedAPA102Control() {
+void SpiOutputTest::testCombinedAPA102Control() {
   // personality 8= Combined APA102
   const uint16_t this_test_personality = 8;
   // setup Backend
-  FakeSPIBackend backend(2);
-  SPIOutput::Options options(0, "Test SPI Device");
+  FakeSpiBackend backend(2);
+  SpiOutput::Options options(0, "Test SPI Device");
   // setup pixel_count to 2 (enough to test all cases)
   options.pixel_count = 2;
-  // setup SPIOutput
-  SPIOutput output(m_uid, &backend, options);
+  // setup SpiOutput
+  SpiOutput output(m_uid, &backend, options);
   // set personality to 8= Combined APA102
   output.SetPersonality(this_test_personality);
 
@@ -714,11 +714,11 @@ void SPIOutputTest::testCombinedAPA102Control() {
   // test7
   // test for multiple ports
   // StartFrame is only allowed on first port.
-  SPIOutput::Options option1(1, "second SPI Device");
+  SpiOutput::Options option1(1, "second SPI Device");
   // setup pixel_count to 2 (enough to test all cases)
   option1.pixel_count = 2;
-  // setup SPIOutput
-  SPIOutput output1(m_uid, &backend, option1);
+  // setup SpiOutput
+  SpiOutput output1(m_uid, &backend, option1);
   // set personality
   output1.SetPersonality(this_test_personality);
   // setup some 'DMX' data

--- a/plugins/spi/SpiPlugin.cpp
+++ b/plugins/spi/SpiPlugin.cpp
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIPlugin.cpp
+ * SpiPlugin.cpp
  * The SPI plugin for ola
  * Copyright (C) 2013 Simon Newton
  */
@@ -28,9 +28,9 @@
 #include "ola/rdm/UIDAllocator.h"
 #include "olad/PluginAdaptor.h"
 #include "olad/Preferences.h"
-#include "plugins/spi/SPIDevice.h"
-#include "plugins/spi/SPIPlugin.h"
-#include "plugins/spi/SPIPluginDescription.h"
+#include "plugins/spi/SpiDevice.h"
+#include "plugins/spi/SpiPlugin.h"
+#include "plugins/spi/SpiPluginDescription.h"
 
 
 namespace ola {
@@ -42,18 +42,18 @@ using std::auto_ptr;
 using std::string;
 using std::vector;
 
-const char SPIPlugin::DEFAULT_BASE_UID[] = "7a70:00000100";
-const char SPIPlugin::DEFAULT_SPI_DEVICE_PREFIX[] = "spidev";
-const char SPIPlugin::PLUGIN_NAME[] = "SPI";
-const char SPIPlugin::PLUGIN_PREFIX[] = "spi";
-const char SPIPlugin::SPI_BASE_UID_KEY[] = "base_uid";
-const char SPIPlugin::SPI_DEVICE_PREFIX_KEY[] = "device_prefix";
+const char SpiPlugin::DEFAULT_BASE_UID[] = "7a70:00000100";
+const char SpiPlugin::DEFAULT_SPI_DEVICE_PREFIX[] = "spidev";
+const char SpiPlugin::PLUGIN_NAME[] = "SPI";
+const char SpiPlugin::PLUGIN_PREFIX[] = "spi";
+const char SpiPlugin::SPI_BASE_UID_KEY[] = "base_uid";
+const char SpiPlugin::SPI_DEVICE_PREFIX_KEY[] = "device_prefix";
 
 /*
  * Start the plugin
  * For now we just have one device.
  */
-bool SPIPlugin::StartHook() {
+bool SpiPlugin::StartHook() {
   const string uid_str = m_preferences->GetValue(SPI_BASE_UID_KEY);
   auto_ptr<UID> base_uid(UID::FromString(uid_str));
   if (!base_uid.get()) {
@@ -76,7 +76,7 @@ bool SPIPlugin::StartHook() {
   ola::rdm::UIDAllocator uid_allocator(*base_uid);
   vector<string>::const_iterator iter = spi_files.begin();
   for (; iter != spi_files.end(); ++iter) {
-    SPIDevice *device = new SPIDevice(this, m_preferences, m_plugin_adaptor,
+    SpiDevice *device = new SpiDevice(this, m_preferences, m_plugin_adaptor,
                                       *iter, &uid_allocator);
 
     if (!device) {
@@ -98,8 +98,8 @@ bool SPIPlugin::StartHook() {
  * Stop the plugin
  * @return true on success, false on failure
  */
-bool SPIPlugin::StopHook() {
-  vector<SPIDevice*>::iterator iter = m_devices.begin();
+bool SpiPlugin::StopHook() {
+  vector<SpiDevice*>::iterator iter = m_devices.begin();
   bool ok = true;
   for (; iter != m_devices.end(); ++iter) {
     m_plugin_adaptor->UnregisterDevice(*iter);
@@ -113,7 +113,7 @@ bool SPIPlugin::StopHook() {
 /*
  * Return the description for this plugin
  */
-string SPIPlugin::Description() const {
+string SpiPlugin::Description() const {
   return plugin_description;
 }
 
@@ -121,7 +121,7 @@ string SPIPlugin::Description() const {
 /*
  * Load the plugin prefs and default to sensible values
  */
-bool SPIPlugin::SetDefaultPreferences() {
+bool SpiPlugin::SetDefaultPreferences() {
   bool save = false;
 
   if (!m_preferences) {

--- a/plugins/spi/SpiPlugin.h
+++ b/plugins/spi/SpiPlugin.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIPlugin.h
+ * SpiPlugin.h
  * An SPI plugin.
  * Copyright (C) 2013 Simon Newton
  */
@@ -30,9 +30,9 @@ namespace ola {
 namespace plugin {
 namespace spi {
 
-class SPIPlugin: public ola::Plugin {
+class SpiPlugin: public ola::Plugin {
  public:
-  explicit SPIPlugin(class ola::PluginAdaptor *plugin_adaptor)
+  explicit SpiPlugin(class ola::PluginAdaptor *plugin_adaptor)
       : Plugin(plugin_adaptor) {}
 
   std::string Name() const { return PLUGIN_NAME; }
@@ -41,7 +41,7 @@ class SPIPlugin: public ola::Plugin {
   std::string PluginPrefix() const { return PLUGIN_PREFIX; }
 
  private:
-  std::vector<class SPIDevice*> m_devices;
+  std::vector<class SpiDevice*> m_devices;
 
   bool StartHook();
   bool StopHook();

--- a/plugins/spi/SpiPort.cpp
+++ b/plugins/spi/SpiPort.cpp
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIPort.cpp
+ * SpiPort.cpp
  * The SPI plugin for ola
  * Copyright (C) 2013 Simon Newton
  */
@@ -23,8 +23,8 @@
 #include "ola/rdm/RDMCommand.h"
 #include "ola/rdm/UID.h"
 
-#include "plugins/spi/SPIBackend.h"
-#include "plugins/spi/SPIPort.h"
+#include "plugins/spi/SpiBackend.h"
+#include "plugins/spi/SpiPort.h"
 
 namespace ola {
 namespace plugin {
@@ -36,59 +36,59 @@ using ola::rdm::RDMRequest;
 using ola::rdm::UID;
 using std::string;
 
-SPIOutputPort::SPIOutputPort(SPIDevice *parent, SPIBackendInterface *backend,
+SpiOutputPort::SpiOutputPort(SpiDevice *parent, SpiBackendInterface *backend,
                              const UID &uid,
-                             const SPIOutput::Options &options)
+                             const SpiOutput::Options &options)
     : BasicOutputPort(parent, options.output_number, true),
       m_spi_output(uid, backend, options) {
 }
 
 
-string SPIOutputPort::GetDeviceLabel() const {
+string SpiOutputPort::GetDeviceLabel() const {
   return m_spi_output.GetDeviceLabel();
 }
 
-bool SPIOutputPort::SetDeviceLabel(const string &device_label) {
+bool SpiOutputPort::SetDeviceLabel(const string &device_label) {
   return m_spi_output.SetDeviceLabel(device_label);
 }
 
-uint8_t SPIOutputPort::GetPersonality() const {
+uint8_t SpiOutputPort::GetPersonality() const {
   return m_spi_output.GetPersonality();
 }
 
-bool SPIOutputPort::SetPersonality(uint16_t personality) {
+bool SpiOutputPort::SetPersonality(uint16_t personality) {
   return m_spi_output.SetPersonality(personality);
 }
 
-uint16_t SPIOutputPort::GetStartAddress() const {
+uint16_t SpiOutputPort::GetStartAddress() const {
   return m_spi_output.GetStartAddress();
 }
 
-bool SPIOutputPort::SetStartAddress(uint16_t address) {
+bool SpiOutputPort::SetStartAddress(uint16_t address) {
   return m_spi_output.SetStartAddress(address);
 }
 
-unsigned int SPIOutputPort::PixelCount() const {
+unsigned int SpiOutputPort::PixelCount() const {
   return m_spi_output.PixelCount();
 }
 
-string SPIOutputPort::Description() const {
+string SpiOutputPort::Description() const {
   return m_spi_output.Description();
 }
 
-bool SPIOutputPort::WriteDMX(const DmxBuffer &buffer, uint8_t) {
+bool SpiOutputPort::WriteDMX(const DmxBuffer &buffer, uint8_t) {
   return m_spi_output.WriteDMX(buffer);
 }
 
-void SPIOutputPort::RunFullDiscovery(RDMDiscoveryCallback *callback) {
+void SpiOutputPort::RunFullDiscovery(RDMDiscoveryCallback *callback) {
   return m_spi_output.RunFullDiscovery(callback);
 }
 
-void SPIOutputPort::RunIncrementalDiscovery(RDMDiscoveryCallback *callback) {
+void SpiOutputPort::RunIncrementalDiscovery(RDMDiscoveryCallback *callback) {
   return m_spi_output.RunIncrementalDiscovery(callback);
 }
 
-void SPIOutputPort::SendRDMRequest(ola::rdm::RDMRequest *request,
+void SpiOutputPort::SendRDMRequest(ola::rdm::RDMRequest *request,
                                    ola::rdm::RDMCallback *callback) {
   return m_spi_output.SendRDMRequest(request, callback);
 }

--- a/plugins/spi/SpiPort.h
+++ b/plugins/spi/SpiPort.h
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIPort.h
- * An OLA SPI Port. This simply wraps the SPIOutput.
+ * SpiPort.h
+ * An OLA SPI Port. This simply wraps the SpiOutput.
  * Copyright (C) 2013 Simon Newton
  */
 
@@ -24,18 +24,18 @@
 #include <string>
 #include "ola/DmxBuffer.h"
 #include "olad/Port.h"
-#include "plugins/spi/SPIDevice.h"
-#include "plugins/spi/SPIOutput.h"
+#include "plugins/spi/SpiDevice.h"
+#include "plugins/spi/SpiOutput.h"
 
 namespace ola {
 namespace plugin {
 namespace spi {
 
-class SPIOutputPort: public BasicOutputPort {
+class SpiOutputPort: public BasicOutputPort {
  public:
-  SPIOutputPort(SPIDevice *parent, class SPIBackendInterface *backend,
-                const ola::rdm::UID &uid, const SPIOutput::Options &options);
-  ~SPIOutputPort() {}
+  SpiOutputPort(SpiDevice *parent, class SpiBackendInterface *backend,
+                const ola::rdm::UID &uid, const SpiOutput::Options &options);
+  ~SpiOutputPort() {}
 
   std::string GetDeviceLabel() const;
   bool SetDeviceLabel(const std::string &device_label);
@@ -54,7 +54,7 @@ class SPIOutputPort: public BasicOutputPort {
                       ola::rdm::RDMCallback *callback);
 
  private:
-  SPIOutput m_spi_output;
+  SpiOutput m_spi_output;
 };
 }  // namespace spi
 }  // namespace plugin

--- a/plugins/spi/SpiWriter.cpp
+++ b/plugins/spi/SpiWriter.cpp
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIWriter.cpp
+ * SpiWriter.cpp
  * This writes data to a SPI device.
  * Copyright (C) 2013 Simon Newton
  */
@@ -32,7 +32,7 @@
 #include "ola/io/IOUtils.h"
 #include "ola/Logging.h"
 #include "ola/network/SocketCloser.h"
-#include "plugins/spi/SPIWriter.h"
+#include "plugins/spi/SpiWriter.h"
 
 namespace ola {
 namespace plugin {
@@ -41,13 +41,13 @@ namespace spi {
 using ola::thread::MutexLocker;
 using std::string;
 
-const uint8_t SPIWriter::SPI_BITS_PER_WORD = 8;
-const uint8_t SPIWriter::SPI_MODE = 0;
-const char SPIWriter::SPI_DEVICE_KEY[] = "device";
-const char SPIWriter::SPI_ERROR_VAR[] = "spi-write-errors";
-const char SPIWriter::SPI_WRITE_VAR[] = "spi-writes";
+const uint8_t SpiWriter::SPI_BITS_PER_WORD = 8;
+const uint8_t SpiWriter::SPI_MODE = 0;
+const char SpiWriter::SPI_DEVICE_KEY[] = "device";
+const char SpiWriter::SPI_ERROR_VAR[] = "spi-write-errors";
+const char SpiWriter::SPI_WRITE_VAR[] = "spi-writes";
 
-SPIWriter::SPIWriter(const string &spi_device,
+SpiWriter::SpiWriter(const string &spi_device,
                      const Options &options,
                      ExportMap *export_map)
     : m_device_path(spi_device),
@@ -68,12 +68,12 @@ SPIWriter::SPIWriter(const string &spi_device,
   }
 }
 
-SPIWriter::~SPIWriter() {
+SpiWriter::~SpiWriter() {
   if (m_fd >= 0)
     close(m_fd);
 }
 
-bool SPIWriter::Init() {
+bool SpiWriter::Init() {
   int fd;
   if (!ola::io::Open(m_device_path, O_RDWR, &fd)) {
     return false;
@@ -104,7 +104,7 @@ bool SPIWriter::Init() {
   return true;
 }
 
-bool SPIWriter::WriteSPIData(const uint8_t *data, unsigned int length) {
+bool SpiWriter::WriteSpiData(const uint8_t *data, unsigned int length) {
   struct spi_ioc_transfer spi;
   memset(&spi, 0, sizeof(spi));
   spi.tx_buf = reinterpret_cast<__u64>(data);

--- a/plugins/spi/SpiWriter.h
+++ b/plugins/spi/SpiWriter.h
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * SPIWriter.h
+ * SpiWriter.h
  * This writes data to a SPI device.
  * Copyright (C) 2013 Simon Newton
  */
@@ -33,22 +33,22 @@ namespace spi {
 /**
  * The interface for the SPI Writer
  */
-class SPIWriterInterface {
+class SpiWriterInterface {
  public:
-  virtual ~SPIWriterInterface() {}
+  virtual ~SpiWriterInterface() {}
 
   virtual std::string DevicePath() const = 0;
   virtual bool Init() = 0;
-  virtual bool WriteSPIData(const uint8_t *data, unsigned int length) = 0;
+  virtual bool WriteSpiData(const uint8_t *data, unsigned int length) = 0;
 };
 
 /**
  * The SPI Writer, this writes data to a SPI device
  */
-class SPIWriter : public SPIWriterInterface {
+class SpiWriter : public SpiWriterInterface {
  public:
   /**
-   * SPIWriter Options
+   * SpiWriter Options
    */
   struct Options {
     uint32_t spi_speed;
@@ -57,19 +57,19 @@ class SPIWriter : public SPIWriterInterface {
     Options() : spi_speed(1000000), cs_enable_high(false) {}
   };
 
-  SPIWriter(const std::string &spi_device, const Options &options,
+  SpiWriter(const std::string &spi_device, const Options &options,
             ExportMap *export_map);
-  ~SPIWriter();
+  ~SpiWriter();
 
   std::string DevicePath() const { return m_device_path; }
 
   /**
-   * Init the SPIWriter
+   * Init the SpiWriter
    * @returns false if initialization failed.
    */
   bool Init();
 
-  bool WriteSPIData(const uint8_t *data, unsigned int length);
+  bool WriteSpiData(const uint8_t *data, unsigned int length);
 
  private:
   const std::string m_device_path;

--- a/plugins/uartdmx/README.md
+++ b/plugins/uartdmx/README.md
@@ -7,23 +7,23 @@ there is no external microcontroller.
 
 This is tested with the on-board UART of the Raspberry Pi. See here for a
 possible schematic:
-http://eastertrail.blogspot.co.uk/2014/04/command-and-control-ii.html
+<http://eastertrail.blogspot.co.uk/2014/04/command-and-control-ii.html>
 
 
 ## Config file: `ola-uartdmx.conf`
 
-`enabled = true` 
+`enabled = true`  
 Enable this plugin (DISABLED by default).
 
-`device = /dev/ttyACM0` 
+`device = /dev/ttyACM0`  
 The device to use for DMX output (optional). Multiple devices are supported
 if the hardware exists. Using USB-serial adapters is not supported (try the
 *ftdidmx* plugin instead).
 
 ### Per Device Settings (using above device name)
 
-`<device>-break = 100` 
+`<device>-break = 100`  
 The DMX break time in microseconds for this device (optional).
 
-`<device>-malf = 100` 
+`<device>-malf = 100`  
 The Mark After Last Frame time in microseconds for this device (optional).

--- a/tools/e133/e133-receiver.cpp
+++ b/tools/e133/e133-receiver.cpp
@@ -48,12 +48,12 @@
 #include <vector>
 
 #ifdef USE_SPI
-#include "plugins/spi/SPIBackend.h"
-#include "plugins/spi/SPIOutput.h"
-#include "plugins/spi/SPIWriter.h"
+#include "plugins/spi/SpiBackend.h"
+#include "plugins/spi/SpiOutput.h"
+#include "plugins/spi/SpiWriter.h"
 using ola::plugin::spi::SoftwareBackend;
-using ola::plugin::spi::SPIOutput;
-using ola::plugin::spi::SPIWriter;
+using ola::plugin::spi::SpiOutput;
+using ola::plugin::spi::SpiWriter;
 DEFINE_string(spi_device, "", "Path to the SPI device to use.");
 #endif  // USE_SPI
 
@@ -98,7 +98,7 @@ void HandleTriDMX(DmxBuffer *buffer, DmxTriWidget *widget) {
 
 
 #ifdef USE_SPI
-void HandleSpiDMX(DmxBuffer *buffer, SPIOutput *output) {
+void HandleSpiDMX(DmxBuffer *buffer, SpiOutput *output) {
   output->WriteDMX(*buffer);
 }
 #endif  // USE_SPI
@@ -207,9 +207,9 @@ int main(int argc, char *argv[]) {
   // uber hack for now.
   // TODO(simon): fix this
 #ifdef USE_SPI
-  auto_ptr<SPIWriter> spi_writer;
+  auto_ptr<SpiWriter> spi_writer;
   auto_ptr<SoftwareBackend> spi_backend;
-  auto_ptr<SPIOutput> spi_output;
+  auto_ptr<SpiOutput> spi_output;
   DmxBuffer spi_buffer;
 
   if (FLAGS_spi_device.present() && !FLAGS_spi_device.str().empty()) {
@@ -220,7 +220,7 @@ int main(int argc, char *argv[]) {
     }
 
     spi_writer.reset(
-        new SPIWriter(FLAGS_spi_device, SPIWriter::Options(), NULL));
+        new SpiWriter(FLAGS_spi_device, SpiWriter::Options(), NULL));
 
     SoftwareBackend::Options options;
     spi_backend.reset(new SoftwareBackend(options, spi_writer.get(), NULL));
@@ -229,10 +229,10 @@ int main(int argc, char *argv[]) {
       exit(ola::EXIT_USAGE);
     }
 
-    spi_output.reset(new SPIOutput(
+    spi_output.reset(new SpiOutput(
         *spi_uid,
         spi_backend.get(),
-        SPIOutput::Options(0, FLAGS_spi_device.str())));
+        SpiOutput::Options(0, FLAGS_spi_device.str())));
     E133Endpoint::EndpointProperties properties;
     properties.is_physical = true;
     endpoints.push_back(new E133Endpoint(spi_output.get(), properties));


### PR DESCRIPTION
As discussed in #1285, I refactored the SPI plugin to change the C++ name prefix to `Spi`. To standardize all plugins, I did the same for the GPIO, OPC and OSC plugins.

Unfortunately, I get the following errors when `make`ing, although I cannot find references to the old names in the code anymore:

```
olad/.libs/libolaserver.so: undefined reference to `vtable for ola::plugin::osc::OscPlugin'
olad/.libs/libolaserver.so: undefined reference to `vtable for ola::plugin::spi::SpiPlugin'
olad/.libs/libolaserver.so: undefined reference to `vtable for ola::plugin::gpio::GpioPlugin'
olad/.libs/libolaserver.so: undefined reference to `vtable for ola::plugin::openpixelcontrol::OpcPlugin'
```

Am I missing something or are these old build artefacts and I just have to rebuild completely (I have already run `make clean`)?