### PR TITLE
Fixed oddity in mockendpoint

### DIFF
--- a/plugins/usbpro/MockEndpoint.cpp
+++ b/plugins/usbpro/MockEndpoint.cpp
@@ -360,7 +360,7 @@ uint8_t *MockEndpoint::BuildRobeMessage(uint8_t label,
   frame[0] = 0xa5;  // som
   frame[1] = label;
   frame[2] = data_size & 0xff;  // len
-  frame[3] = (data_size + 1) >> 8;  // len hi
+  frame[3] = data_size >> 8;  // len hi
 
   // header crc
   uint8_t crc = 0;


### PR DESCRIPTION
The "+1" in the length is probably due to when XX bytes of DMX data is sent, there is also an error/status byte. This leads to 
```
  packet->len = (data_len+1) & 0xff;
  packet->len_hi = (data_len+1) >> 8;

```
Probably this code was partially copied/half-fixed from code that worked like this. 