### PR TITLE
Switch to using the full GCE image by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
-sudo: false
+# Default to the fully visualised "sudo" GCE environments, as they are faster for longer running jobs. We don't actually need sudo
+sudo: required
+# Use the latest Travis images since they are more up to date than the stable release.
 group: edge
 script:
  - "bash -ex .travis-ci.sh"
@@ -108,6 +110,8 @@ matrix:
            - ubuntu-toolchain-r-test
     - os: linux
       dist: trusty
+      # Short duration job, use the container/without sudo image as it boots faster
+      sudo: false
       env: TASK='doxygen'
       addons:
         apt:
@@ -119,6 +123,8 @@ matrix:
            - ubuntu-toolchain-r-test
     - os: linux
       dist: trusty
+      # Short duration job, use the container/without sudo image as it boots faster
+      sudo: false
       env: TASK='lint'
       addons:
         apt:
@@ -126,6 +132,8 @@ matrix:
            - *core_build
     - os: linux
       dist: trusty
+      # Short duration job, use the container/without sudo image as it boots faster
+      sudo: false
       env: TASK='check-licences'
       addons:
         apt:
@@ -133,12 +141,16 @@ matrix:
            - *core_build
     - os: linux
       dist: trusty
+      # Short duration job, use the container/without sudo image as it boots faster
+      sudo: false
       env: TASK='jshint'
       addons:
         apt:
           packages:
     - os: linux
       dist: trusty
+      # Short duration job, use the container/without sudo image as it boots faster
+      sudo: false
       env: TASK='flake8'
       addons:
         apt:


### PR DESCRIPTION
Just use the containers for the shorter jobs, as recommended in #1317

This should give us the fastest overall run time.