### PR TITLE
Fix for Python 3 error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,7 +11,8 @@ x/y/2018 ola-0.10.7
  Bugs:
  * Fix the build on Windows
  * Entire codebase now passes codespell testing
- * 
+ * Fix a Python 3 bug in the API
+ *
 
  Internal:
  *

--- a/python/ola/ClientWrapper.py
+++ b/python/ola/ClientWrapper.py
@@ -103,7 +103,7 @@ class SelectServer(object):
     self._function_list_lock.acquire()
     self._functions.append(f)
     # can write anything here, this wakes up the select() call
-    os.write(self._local_socket[1], 'a')
+    os.write(self._local_socket[1], b'a')
     self._function_list_lock.release()
 
   def Terminate(self):


### PR DESCRIPTION
Just a small patch for an error in a place where Python 3 expected a byte-like object and instead got a `str`.