### PR TITLE
Add link to my Bachelor's Thesis in SPI DMX Plugin's README

### DIFF
--- a/plugins/spidmx/README.md
+++ b/plugins/spidmx/README.md
@@ -13,6 +13,10 @@ set a larger block size if you want a higher refresh rate for the high
 channels (which results in more stuttering in all channels, as the time
 between two SPI read operation increases).
 
+A detailed description of the development process and the used techniques
+can be found in Flo Edelmann's Bachelors Thesis:
+http://mnm-team.org/pub/Fopras/edel17/PDF-Version/edel17.pdf
+
 
 ## Raspberry Pi configuration
 

--- a/plugins/spidmx/README.md
+++ b/plugins/spidmx/README.md
@@ -13,7 +13,7 @@ set a larger block size if you want a higher refresh rate for the high
 channels (which results in more stuttering in all channels, as the time
 between two SPI read operation increases).
 
-A detailed description of the development process and the used techniques
+A detailed description of the development process and the techniques used
 can be found in Flo Edelmann's Bachelors Thesis:
 http://mnm-team.org/pub/Fopras/edel17/PDF-Version/edel17.pdf
 


### PR DESCRIPTION
The online version of my [Bachelor's Thesis](http://mnm-team.org/pub/Fopras/edel17/PDF-Version/edel17.pdf) is finally available!

I've documented the whole development process of a PC-DMX interface using OLA, including my implementation of the SPI DMX Plugin and a corresponding electrical schematic. Thus, I think it will be a useful resource to add to the plugin's README.

Maybe you want to look into it @peternewman and @nomis52 :)