### PR TITLE
Avoid use of root logger and fix close callback in python3

### DIFF
--- a/python/ola/ClientWrapper.py
+++ b/python/ola/ClientWrapper.py
@@ -19,12 +19,12 @@ import array
 import datetime
 import fcntl
 import heapq
-import logging
 import os
 import select
 import termios
 import threading
 import traceback
+from ola import ola_logger
 from ola.OlaClient import OlaClient
 
 """A simple client wrapper for the OlaClient."""
@@ -173,7 +173,7 @@ class SelectServer(object):
       False if the calling thread isn't the one that created the select server.
     """
     if self._ss_thread_id != self._GetThreadID():
-      logging.critical(
+      ola_logger.critical(
          'SelectServer called in a thread other than the owner. '
          'Owner %d, caller %d' % (self._ss_thread_id, self._GetThreadID()))
       traceback.print_stack()

--- a/python/ola/__init__.py
+++ b/python/ola/__init__.py
@@ -1,0 +1,29 @@
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# __init__.py
+# Copyright (C) 2018 Shenghao Yang
+
+import logging
+
+"""Initialization code for the ola python library"""
+
+__author__ = 'me@shenghaoyang.info (Shenghao Yang)'
+
+
+ola_handler = logging.StreamHandler()
+ola_handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
+ola_logger = logging.getLogger(__name__)
+ola_logger.addHandler(ola_handler)
+ola_logger.propagate = False

--- a/python/ola/__init__.py
+++ b/python/ola/__init__.py
@@ -15,9 +15,11 @@
 # __init__.py
 # Copyright (C) 2018 Shenghao Yang
 
-import logging
+"""
+Initialization code for the ola python library
+"""
 
-"""Initialization code for the ola python library"""
+import logging
 
 __author__ = 'me@shenghaoyang.info (Shenghao Yang)'
 

--- a/python/ola/rpc/StreamRpcChannel.py
+++ b/python/ola/rpc/StreamRpcChannel.py
@@ -15,9 +15,9 @@
 # StreamRpcChannel.py
 # Copyright (C) 2005 Simon Newton
 
-import logging
 import struct
 from google.protobuf import service
+from ola import ola_logger
 from ola.rpc import Rpc_pb2
 from ola.rpc.SimpleRpcController import SimpleRpcController
 
@@ -75,7 +75,7 @@ class StreamRpcChannel(service.RpcChannel):
     """
     data = self._socket.recv(self.RECEIVE_BUFFER_SIZE)
     if data == '':
-      logging.info('OLAD Server Socket closed')
+      ola_logger.info('OLAD Server Socket closed')
       if self._close_callback is not None:
         self._close_callback()
       return False
@@ -107,7 +107,7 @@ class StreamRpcChannel(service.RpcChannel):
     if message.id in self._outstanding_responses:
       # fail any outstanding response with the same id, not the best approach
       # but it'll do for now.
-      logging.warning('Response %d already pending, failing now', message.id)
+      ola_logger.warning('Response %d already pending, failing now', message.id)
       response = self._outstanding_responses[message.id]
       response.controller.SetFailed('Duplicate request found')
       self._InvokeCallback(response)
@@ -173,7 +173,7 @@ class StreamRpcChannel(service.RpcChannel):
 
     sent_bytes = self._socket.send(data)
     if sent_bytes != len(data):
-      logging.warning('Failed to send full datagram')
+      ola_logger.warning('Failed to send full datagram')
       return False
     return True
 
@@ -244,8 +244,8 @@ class StreamRpcChannel(service.RpcChannel):
         version, size = self._DecodeHeader(header)
 
         if version != self.PROTOCOL_VERSION:
-          logging.warning('Protocol mismatch: %d != %d', version,
-                          self.PROTOCOL_VERSION)
+          ola_logger.warning('Protocol mismatch: %d != %d', version,
+                             self.PROTOCOL_VERSION)
           self._skip_message = True
         self._expected_size = size
 
@@ -271,7 +271,7 @@ class StreamRpcChannel(service.RpcChannel):
     if message.type in self.MESSAGE_HANDLERS:
       self.MESSAGE_HANDLERS[message.type](self, message)
     else:
-      logging.warning('Not sure of message type %d', message.type())
+      ola_logger.warning('Not sure of message type %d', message.type())
 
   def _HandleRequest(self, message):
     """Handle a Request message.
@@ -280,13 +280,13 @@ class StreamRpcChannel(service.RpcChannel):
       message: The RpcMessage object.
     """
     if not self._service:
-      logging.warning('No service registered')
+      ola_logger.warning('No service registered')
       return
 
     descriptor = self._service.GetDescriptor()
     method = descriptor.FindMethodByName(message.name)
     if not method:
-      logging.warning('Failed to get method descriptor for %s', message.name)
+      ola_logger.warning('Failed to get method descriptor for %s', message.name)
       self._SendNotImplemented(message.id)
       return
 
@@ -296,7 +296,7 @@ class StreamRpcChannel(service.RpcChannel):
     request = OutstandingRequest(message.id, controller)
 
     if message.id in self._outstanding_requests:
-      logging.warning('Duplicate request for %d', message.id)
+      ola_logger.warning('Duplicate request for %d', message.id)
       self._SendRequestFailed(message.id)
 
     self._outstanding_requests[message.id] = request
@@ -321,7 +321,7 @@ class StreamRpcChannel(service.RpcChannel):
     Args:
       message: The RpcMessage object.
     """
-    logging.warning('Received a canceled response')
+    ola_logger.warning('Received a canceled response')
     response = self._outstanding_responses.get(message.id, None)
     if response:
       response.controller.SetFailed(message.buffer)
@@ -344,7 +344,7 @@ class StreamRpcChannel(service.RpcChannel):
     Args:
       message: The RpcMessage object.
     """
-    logging.warning('Received a non-implemented response')
+    ola_logger.warning('Received a non-implemented response')
     response = self._outstanding_responses.get(message.id, None)
     if response:
       response.controller.SetFailed('Not Implemented')

--- a/python/ola/rpc/StreamRpcChannel.py
+++ b/python/ola/rpc/StreamRpcChannel.py
@@ -74,7 +74,7 @@ class StreamRpcChannel(service.RpcChannel):
       True if the socket remains connected, False if it was closed.
     """
     data = self._socket.recv(self.RECEIVE_BUFFER_SIZE)
-    if data == '':
+    if not data:
       ola_logger.info('OLAD Server Socket closed')
       if self._close_callback is not None:
         self._close_callback()


### PR DESCRIPTION
- Using the root logger makes it non-obvious for users of the library
  to control the log messages from the library.

- By setting up a logger for ola and using it for all the logging
  calls, users of the library can simply do logging.getLogger('ola')
  and control the output of the logger.

- Note that any tools / tests depending on log output might need to 
  be changed due to the reasons above. Those changes can be done, 
  but I want to put this commit out first so we can discuss this approach, 
  or we could skip emulating past behavior and simply adopt 
  the convention for python libraries.

- Empty string object is no longer returned by ``recv()`` in python3 
  on connection close, but an empty bytes object is returned instead. 
  Comparing the return value to an empty string is insufficient. 
  Since both objects evaluate to false, check for that condition and 
  invoke close actions accordingly. 