### PR TITLE
Add functionality to notify systemd on olad startup and config reload

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -387,6 +387,13 @@ esac
 have_libftd2xx="no"
 AM_CONDITIONAL([HAVE_LIBFTD2XX], [test "x$have_libftd2xx" = xyes])
 
+# libsystemd
+AC_SEARCH_LIBS([sd_notify], [systemd], [have_libsystemd="yes"])
+AC_CHECK_HEADER([systemd/sd-daemon.h], [], [have_libsystemd="no"])
+
+AS_IF([test "x$have_libsystemd" = xyes],
+      [AC_DEFINE([HAVE_LIBSYSTEMD], [1], [define if libsystemd is installed])])
+
 # ncurses
 AC_CHECK_LIB([ncurses], [initscr], [have_ncurses="yes"])
 AM_CONDITIONAL([HAVE_NCURSES], [test "x$have_ncurses" = xyes])

--- a/olad/OlaServer.cpp
+++ b/olad/OlaServer.cpp
@@ -22,6 +22,10 @@
 #include <config.h>
 #endif  // HAVE_CONFIG_H
 
+#ifdef HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif  // HAVE_LIBSYSTEMD
+
 #include <errno.h>
 #include <signal.h>
 #include <stdio.h>
@@ -472,9 +476,17 @@ bool OlaServer::InternalNewConnection(
 }
 
 void OlaServer::ReloadPluginsInternal() {
+#ifdef HAVE_LIBSYSTEMD
+  // Return value is intentionally not checked for both calls.
+  // See return value section under sd_notify(3).
+  sd_notify(0, "RELOADING=1\nSTATUS=Reloading plugins\n");
+#endif  // HAVE_LIBSYSTEMD
   OLA_INFO << "Reloading plugins";
   StopPlugins();
   m_plugin_manager->LoadAll();
+#ifdef HAVE_LIBSYSTEMD
+  sd_notify(0, "READY=1\nSTATUS=Plugin reload complete\n");
+#endif  // HAVE_LIBSYSTEMD
 }
 
 void OlaServer::UpdatePidStore(const RootPidStore *pid_store) {

--- a/olad/Olad.cpp
+++ b/olad/Olad.cpp
@@ -24,6 +24,10 @@
 #include <config.h>
 #endif  // HAVE_CONFIG_H
 
+#if HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif  // HAVE_LIBSYSTEMD
+
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -171,6 +175,11 @@ int main(int argc, char *argv[]) {
       ola::NewCallback(olad->GetOlaServer(), &ola::OlaServer::ReloadPlugins));
 #endif  // _WIN32
 
+#if HAVE_LIBSYSTEMD
+  // Return value is intentionally not checked. See return value section
+  // under sd_notify(3).
+  sd_notify(0, "READY=1\nSTATUS=Startup complete\n");
+#endif  // HAVE_LIBSYSTEMD
   olad->Run();
   return ola::EXIT_OK;
 }


### PR DESCRIPTION
- This helps users who run olad under the management of systemd to
  order their services after olad startup, (i.e. starting up a daemon
  that depends on the olad RPC socket being available), avoiding
  the need for a manual delay.

- If anyone's versed in autotools magic, please help check the
  changes to `configure.ac`. I've only dabbled with autotools one
  other time in my life, and I'm sure if what I did was exactly correct.

- Tested on my local machine with a unit file running the olad binary
  as a notifying service. Reload messages tested as well. And I do
  see the systemd generated reload notifications bounding the
  output from olad during the reload process. 

- Not sure how we go about writing test cases for this, though. 
  Seems a  bit pathological to formally test something like this, 
  but if the CI environment has `systemd` and `libsystemd` installed, 
  we could cook up a test for the notification functionality using 
  `systemd-run` - if the notification didn't go through, then
  `systemd-run` should notify on an error starting the service.

Thanks for reviewing.

Shenghao