### PR TITLE
Detach kernel driver to allow claiming of USB interface

### DIFF
--- a/libs/usb/LibUsbAdaptor.cpp
+++ b/libs/usb/LibUsbAdaptor.cpp
@@ -80,10 +80,22 @@ bool OpenHandleAndClaimInterface(libusb_device *usb_device,
   }
 
   int r = libusb_claim_interface(*usb_handle, interface);
-  if (r) {
+  if (r == LIBUSB_ERROR_BUSY) {
+	int error = libusb_detach_kernel_driver(*usb_handle, interface);
+	if (error) {
+		OLA_WARN << "Failed to detach kernel driver " << interface
+				 << " on device: " << usb_device;
+	} else {
+	  r = libusb_claim_interface(*usb_handle, interface);
+	}
+  }
+
+  if (r)
+  {
     OLA_WARN << "Failed to claim interface " << interface
              << " on device: " << usb_device << ": "
              << LibUsbAdaptor::ErrorCodeToString(r);
+
     libusb_close(*usb_handle);
     *usb_handle = NULL;
     return false;

--- a/libs/usb/LibUsbAdaptor.cpp
+++ b/libs/usb/LibUsbAdaptor.cpp
@@ -83,8 +83,8 @@ bool OpenHandleAndClaimInterface(libusb_device *usb_device,
   if (r == LIBUSB_ERROR_BUSY) {
     int error = libusb_detach_kernel_driver(*usb_handle, interface);
     if (error) {
-         OLA_WARN << "Failed to detach kernel driver for interface " << interface
-                  << " on device: " << usb_device;
+      OLA_WARN << "Failed to detach kernel driver for interface " << interface
+               << " on device: " << usb_device;
     } else {
       r = libusb_claim_interface(*usb_handle, interface);
     }

--- a/libs/usb/LibUsbAdaptor.cpp
+++ b/libs/usb/LibUsbAdaptor.cpp
@@ -81,21 +81,18 @@ bool OpenHandleAndClaimInterface(libusb_device *usb_device,
 
   int r = libusb_claim_interface(*usb_handle, interface);
   if (r == LIBUSB_ERROR_BUSY) {
-	int error = libusb_detach_kernel_driver(*usb_handle, interface);
-	if (error) {
-		OLA_WARN << "Failed to detach kernel driver " << interface
-				 << " on device: " << usb_device;
-	} else {
-	  r = libusb_claim_interface(*usb_handle, interface);
-	}
+    int error = libusb_detach_kernel_driver(*usb_handle, interface);
+    if (error) {
+         OLA_WARN << "Failed to detach kernel driver for interface " << interface
+                  << " on device: " << usb_device;
+    } else {
+      r = libusb_claim_interface(*usb_handle, interface);
+    }
   }
-
-  if (r)
-  {
+  if (r) {
     OLA_WARN << "Failed to claim interface " << interface
              << " on device: " << usb_device << ": "
              << LibUsbAdaptor::ErrorCodeToString(r);
-
     libusb_close(*usb_handle);
     *usb_handle = NULL;
     return false;


### PR DESCRIPTION
Hi I'm using a eurolite USB-DMX512-PRO Interface on Ubuntu 18.04 and ran into several problems.

First I had to create a new udev rule so that libusb_open wouldn't fail in LibUsbAdaptor.cpp. It looks like this:

SUBSYSTEM=="usb", ATTR{idVendor}=="04d8", ATTR{idProduct}=="fa63", MODE="0660", GROUP="dialout"

After creating this rule and rebooting /dev/ttyACM0 was created. So some kind of kernel driver was loaded for the eurolite interface.

This however caused libusb_claim_interface to fail. In this pull request I suggest to detach the kernel driver in case of an error and to retry claiming the USB interface.

Ideally the kernel driver should be reattached after closing olad. But that's not done yet. I thought maybe I'm missing something here.
