### PR TITLE
Extend configure so we switch to C++11 if necessary for Protobuf 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,22 @@ matrix:
       compiler: clang
       env:
       - TASK='compile'
+      - CPPUNIT='1.13'
+      - PROTOBUF='3.6'
+      - LIBFTDI='1'
+    - os: osx
+      osx_image: xcode9.3
+      compiler: gcc
+      env:
+      - TASK='compile'
+      - CPPUNIT='1.13'
+      - PROTOBUF='3.6'
+      - LIBFTDI='1'
+    - os: osx
+      osx_image: xcode9.3
+      compiler: clang
+      env:
+      - TASK='compile'
       - CPPUNIT='1.14'
       - PROTOBUF='3.6'
       - LIBFTDI='1'

--- a/configure.ac
+++ b/configure.ac
@@ -66,21 +66,26 @@ AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_11], [test "x$ac_cv_gnu_plus_plus_11" = x
 
 # force us into gnu++98 mode if necessary
 # If gnu++11 and gnu++98 then
-#   If no unit tests, force to gnu++98
-#   If unittests and cppunit < 1.14.0, force to gnu++98
+#   If protobuf < 3.6
+#     If no unit tests, force to gnu++98
+#     Else we have unit tests
+#       If cppunit < 1.14.0, force to gnu++98
+#       Else turn off deprecation messages for std::auto_ptr and run gnu++11
 #   Else turn off deprecation messages for std::auto_ptr and run gnu++11
 require_gnu_plus_plus_11="no"
 AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
       [AS_IF([test "x$ac_cv_gnu_plus_plus_98" = xyes],
-             [AS_IF([test "x$enable_unittests" = xno],
-                    [CXXFLAGS="$CXXFLAGS -std=gnu++98"],
-                    [PKG_CHECK_MODULES([CPPUNIT1], [cppunit < 1.14.0],
+             [PKG_CHECK_MODULES([PROTOBUF1], [protobuf < 3.6],
+                                [AS_IF([test "x$enable_unittests" = xno],
                                        [CXXFLAGS="$CXXFLAGS -std=gnu++98"],
-                                       [PKG_CHECK_MODULES([CPPUNIT2], [cppunit >= 1.14.0],
-                                                          [require_gnu_plus_plus_11="yes"],
-                                                          [AC_MSG_WARN([OLA requires std::auto_ptr support.])])
+                                       [PKG_CHECK_MODULES([CPPUNIT1], [cppunit < 1.14.0],
+                                                          [CXXFLAGS="$CXXFLAGS -std=gnu++98"],
+                                                          [PKG_CHECK_MODULES([CPPUNIT2], [cppunit >= 1.14.0],
+                                                                             [require_gnu_plus_plus_11="yes"],
+                                                                             [AC_MSG_WARN([OLA requires std::auto_ptr support.])])
+                                                          ])
                                        ])
-                    ])
+                                ])
              ])
       ])
 AS_IF([test "x$require_gnu_plus_plus_11" = xyes],

--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,7 @@ AM_CONDITIONAL([SUPPORTS_GNU_PLUS_PLUS_11], [test "x$ac_cv_gnu_plus_plus_11" = x
 #     Else we have unit tests
 #       If cppunit < 1.14.0, force to gnu++98
 #       Else turn off deprecation messages for std::auto_ptr and run gnu++11
-#   Else turn off deprecation messages for std::auto_ptr and run gnu++11
+#   Else assume we have protobuf >= 3.6 (later checks will confirm that for certain), turn off deprecation messages for std::auto_ptr and run gnu++11
 require_gnu_plus_plus_11="no"
 AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
       [AS_IF([test "x$ac_cv_gnu_plus_plus_98" = xyes],
@@ -85,7 +85,7 @@ AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
                                                                              [AC_MSG_WARN([OLA requires std::auto_ptr support.])])
                                                           ])
                                        ])
-                                ])
+                                [require_gnu_plus_plus_11="yes"]])
              ])
       ])
 AS_IF([test "x$require_gnu_plus_plus_11" = xyes],

--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,8 @@ AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
                                                                              [AC_MSG_WARN([OLA requires std::auto_ptr support.])])
                                                           ])
                                        ])
-                                [require_gnu_plus_plus_11="yes"]])
+                                ],
+                                [require_gnu_plus_plus_11="yes"])
              ])
       ])
 AS_IF([test "x$require_gnu_plus_plus_11" = xyes],

--- a/man/generate-html.sh
+++ b/man/generate-html.sh
@@ -43,3 +43,5 @@ cat << 'EOF' >> $index_file
 </body>
 </html>
 EOF
+
+chmod a+r $index_file;

--- a/plugins/generate-html.sh
+++ b/plugins/generate-html.sh
@@ -54,3 +54,5 @@ cat << 'EOF' >> $index_file
 </body>
 </html>
 EOF
+
+chmod a+r $index_file;


### PR DESCRIPTION
Closes https://github.com/OpenLightingProject/ola/issues/1463