### PR TITLE
Fix typo and dead link in developer readme

### DIFF
--- a/README.developer
+++ b/README.developer
@@ -101,7 +101,7 @@ Structure packing syntax differs between platforms and compilers. If you declare
 a struct or class that needs to be packed, use the PACK() macro from
 ola/base/Macro.h . See below for an example of PACK() usage.
 
-Not that this macro doesn't work for enums. See plugins/espnet/EspNetPackets.h
+Note that this macro doesn't work for enums. See plugins/espnet/EspNetPackets.h
 for an example of how to pack an enum.
 
 Non x86 platforms
@@ -122,7 +122,7 @@ uint16_t *ptr = &foo.value2;
 // Bug! Will not be true on all platforms.
 if (*ptr == 2)
 
-http://www.aleph1.co.uk/chapter-10-arm-structured-alignment-faq has a good
+http://netwinder.osuosl.org/users/b/brianbr/public_html/alignment.html has a good
 explanation.
 
 


### PR DESCRIPTION
http://www.aleph1.co.uk/chapter-10-arm-structured-alignment-faq has been hijacked and no longer sends the user to the desired destination. I believe the replaced link might work as a replacement.