### PR TITLE
Properly close socket on destruction of OlaClient

### DIFF
--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -721,6 +721,9 @@ class OlaClient(Ola_pb2.OlaClientService):
     self._stub = Ola_pb2.OlaServerService_Stub(self._channel)
     self._universe_callbacks = {}
 
+  def __del__(self):
+    self._SocketClosed()
+
   def GetSocket(self):
     """Returns the socket used to communicate with the server."""
     return self._socket


### PR DESCRIPTION
If a program using `ola.ClientWrapper` is run with `python -Wall` on Python 3, the interpreter prints a `ResourceWarning` complaining about an unclosed socket.
This PR fixes that warning.

For example, if you run:
```bash
cd python
python3 -Wall examples/ola_send_dmx.py
```

You will get:
```
examples/ola_send_dmx.py:56: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
  client.SendDmx(universe, data, DmxSent)
Success!
sys:1: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 52925), raddr=('127.0.0.1', 9010)>
```

With the proposed fix, the `ResourceWarning` disappears.