### PR TITLE
Use array.tobytes() instead of array.tostring() for Pyton 3.2 and higher

### DIFF
--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -18,6 +18,7 @@
 import array
 import socket
 import struct
+import sys
 from ola.rpc.StreamRpcChannel import StreamRpcChannel
 from ola.rpc.SimpleRpcController import SimpleRpcController
 from ola import Ola_pb2
@@ -879,7 +880,10 @@ class OlaClient(Ola_pb2.OlaClientService):
     controller = SimpleRpcController()
     request = Ola_pb2.DmxData()
     request.universe = universe
-    request.data = data.tostring()
+    if sys.version >= '3.2':
+      request.data = data.tobytes()
+    else:
+      request.data = data.tostring()
     try:
       self._stub.UpdateDmxData(
           controller, request,


### PR DESCRIPTION
According to https://docs.python.org/3/library/array.html#array.array.tostring, `array.tostring()` is a deprecated alias for `array.tobytes()`, which was introduced in Python 3.2. With this change, `array.tobytes()` is used for Python 3.2 and higher.