### PR TITLE
Backport some Debian changes and add another Debian test

### DIFF
--- a/debian/Makefile.mk
+++ b/debian/Makefile.mk
@@ -31,4 +31,5 @@ EXTRA_DIST += \
     debian/source/lintian-overrides \
     debian/source/local-options \
     debian/tests/control \
+    debian/tests/hw.cc \
     debian/watch

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: ola
 Priority: optional
 Maintainer: Wouter Verhelst <wouter@debian.org>
 Uploaders: RenZO <renzo@imaginux.com>
-Build-Depends: debhelper (>= 9), autotools-dev, dh-autoreconf, bash-completion, libcppunit-dev, bison, flex, pkg-config, uuid-dev, python, python-protobuf, libprotobuf-dev, protobuf-compiler, libprotoc-dev, libusb-1.0-0-dev, libftdi-dev, liblo-dev, libmicrohttpd-dev, libncurses5-dev, libavahi-client-dev, python-numpy
+Build-Depends: debhelper (>= 9), autotools-dev, dh-autoreconf, bash-completion, libcppunit-dev, bison, flex, pkg-config, uuid-dev, python, python-protobuf, libprotobuf-dev, protobuf-compiler, libprotoc-dev, libusb-1.0-0-dev, libftdi1-dev, liblo-dev, libmicrohttpd-dev, libncurses5-dev, libavahi-client-dev, python-numpy
 Standards-Version: 3.9.8
 Section: libs
 Vcs-Git: https://github.com/OpenLightingProject/ola.git

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Package: libola-dev
 Section: libdevel
 Architecture: any
 Multi-Arch: same
-Depends: ola (= ${binary:Version}), libprotobuf-dev, ${misc:Depends}
+Depends: ola (= ${binary:Version}), ${misc:Depends}, libprotobuf-dev
 Description: Open Lighting Architecture - development libraries
  The DMX512 standard for Digital MultipleX is used for digital
  communication networks commonly used to control stage lighting and

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,8 +1,11 @@
 Test-Command: olad --help
 Depends: ola
 
+Test-Command: ola_rdm_get --list-pids
+Depends: ola
+
 Test-Command: rdm_responder_test.py --help
-Depends: ola, ola-rdm-tests
+Depends: ola-rdm-tests
 
 Test-Command: set -e ; for py in $(pyversions -s 2>/dev/null) ; do cd "$ADTTMP" ; echo "Testing with $py:" ; $py -c "from ola.ClientWrapper import ClientWrapper; print(ClientWrapper)" ; done
 Depends: python-all, ola, ola-python

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -10,5 +10,6 @@ Depends: python-all, ola, ola-python
 Test-Command: pkg-config --cflags --libs libola
 Depends: libola-dev, pkg-config
 
-Test-Command: set -e; gcc -o linktest $(pkg-config --cflags --libs libola) debian/tests/hw.c; ./linktest
-Depends: libola-dev, gcc, libc6-dev, pkg-config
+Test-Command: set -e; g++ -o linktest $(pkg-config --cflags --libs libola) debian/tests/hw.cc; ./linktest
+Depends: libola-dev, g++, pkg-config
+Restrictions: rw-build-tree

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -6,3 +6,9 @@ Depends: ola, ola-rdm-tests
 
 Test-Command: set -e ; for py in $(pyversions -s 2>/dev/null) ; do cd "$ADTTMP" ; echo "Testing with $py:" ; $py -c "from ola.ClientWrapper import ClientWrapper; print(ClientWrapper)" ; done
 Depends: python-all, ola, ola-python
+
+Test-Command: pkg-config --cflags --libs libola
+Depends: libola-dev, pkg-config
+
+Test-Command: set -e; gcc -o linktest $(pkg-config --cflags --libs libola) debian/tests/hw.c; ./linktest
+Depends: libola-dev, gcc, libc6-dev, pkg-config

--- a/debian/tests/hw.cc
+++ b/debian/tests/hw.cc
@@ -1,0 +1,13 @@
+#include <iostream>
+#include <ola/client/OlaClient.h>
+
+int main(void) {
+	ola::io::LoopbackDescriptor d;
+	ola::client::OlaClient c(&d);
+
+	bool success = c.Setup();
+
+	std::cout << "Hello World!" << std::endl << "success: " << (success ? "t" : "f") << std::endl;
+
+	return success ? 0 : 1;
+}


### PR DESCRIPTION
A mix of old stuff and a little new.

@yoe I notice your order is different here:
https://github.com/OpenLightingProject/ola/compare/0.10...yoe:master?expand=1#diff-d837a1c17de0268bcea321239ddbed47L16

Is yours preferred by policy, I'd assumed real stuff, then variable substitution would be best? I thought it would be nice to standardise to simplify future merges, but happy to go either way.