### PR TITLE
Backport a fix to add a label to GetOutOfRangePersonalityDescription, also ensure a non-existant UID exits with a non-zero exit code

### DIFF
--- a/tools/rdm/TestDefinitions.py
+++ b/tools/rdm/TestDefinitions.py
@@ -1756,6 +1756,7 @@ class GetOutOfRangePersonalityDescription(TestMixins.GetOutOfRangeByteMixin,
   """GET the personality description for the N + 1 personality."""
   PID = 'DMX_PERSONALITY_DESCRIPTION'
   REQUIRES = ['personality_count']
+  LABEL = 'personality descriptions'
 
 
 class AllSubDevicesGetPersonalityDescription(TestMixins.AllSubDevicesGetMixin,

--- a/tools/rdm/rdm_responder_test.py
+++ b/tools/rdm/rdm_responder_test.py
@@ -289,7 +289,7 @@ def main():
   wrapper.Reset()
 
   if not uid_ok:
-    sys.exit()
+    sys.exit(1)
 
   test_filter = None
   if options.tests is not None:

--- a/tools/rdm/rdm_test_server.py
+++ b/tools/rdm/rdm_test_server.py
@@ -958,7 +958,7 @@ def BuildApplication(ola_thread, test_thread):
   app.RegisterHandler('/RunTests', run_tests_handler.HandleRequest)
   app.RegisterHandler('/StatCollector', run_tests_handler.HandleRequest)
   app.RegisterHandler('/StatTests', run_tests_handler.HandleRequest)
-  app.RegisterRegex('/static/.*',
+  app.RegisterRegex(r'/static/.*',
                     StaticFileHandler(settings['www_dir']).HandleRequest)
   return app
 


### PR DESCRIPTION
So it works with fixtures with 255 personalities