### PR TITLE
Ensure _close_callback is assigned before we might need to run it

### DIFF
--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -708,6 +708,7 @@ class OlaClient(Ola_pb2.OlaClientService):
         created.
       close_callback: A callable to run if the socket is closed
     """
+    self._close_callback = close_callback
     self._socket = our_socket
 
     if self._socket is None:
@@ -717,7 +718,6 @@ class OlaClient(Ola_pb2.OlaClientService):
       except socket.error:
         raise OLADNotRunningException('Failed to connect to olad')
 
-    self._close_callback = close_callback
     self._channel = StreamRpcChannel(self._socket, self, self._SocketClosed)
     self._stub = Ola_pb2.OlaServerService_Stub(self._channel)
     self._universe_callbacks = {}


### PR DESCRIPTION
Otherwise we also get an AttributeError:
`Exception AttributeError: "'OlaClient' object has no attribute '_close_callback'" in <bound method OlaClient.__del__ of <ola.OlaClient.OlaClient object at 0x7f00789e6290>> ignored`