### PR TITLE
Fix comparison methods for python3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Contributors:
   Masaki Muranaka, various patches
   Nicolas, for the win32 port of libartnet
   Nicolas Bertrand, added ShowJockey DMX-U1 support
+  Nils Van Zuijlen, typos and python lib small update
   Peter Newman, MilInst Plugin, Scanlime Fadecandy support and numerous fixes
   Ravindra Nath Kakarla, RDM Test Server (Google Summer of Code 2012)
   Rowan Maclachlan (hippy) for various changes

--- a/python/ola/ClientWrapper.py
+++ b/python/ola/ClientWrapper.py
@@ -32,7 +32,8 @@ from ola.OlaClient import OlaClient
 
 __author__ = 'nomis52@gmail.com (Simon Newton)'
 
-@functools.total_ordering()
+
+@functools.total_ordering
 class _Event(object):
   """An _Event represents a timer scheduled to expire in the future.
 
@@ -50,6 +51,7 @@ class _Event(object):
 
   def __eq__(self, other):
     return self._run_at == other._run_at and self._callback == other._callback
+
   def __lt__(self, other):
     return self._run_at < other._run_at
 

--- a/python/ola/ClientWrapper.py
+++ b/python/ola/ClientWrapper.py
@@ -18,6 +18,7 @@
 import array
 import datetime
 import fcntl
+import functools
 import heapq
 import os
 import select
@@ -31,7 +32,7 @@ from ola.OlaClient import OlaClient
 
 __author__ = 'nomis52@gmail.com (Simon Newton)'
 
-
+@functools.total_ordering()
 class _Event(object):
   """An _Event represents a timer scheduled to expire in the future.
 
@@ -46,6 +47,11 @@ class _Event(object):
 
   def __cmp__(self, other):
     return cmp(self._run_at, other._run_at)
+
+  def __eq__(self, other):
+    return self._run_at == other._run_at and self._callback == other._callback
+  def __lt__(self, other):
+    return self._run_at < other._run_at
 
   def TimeLeft(self, now):
     """Get the time remaining before this event triggers.

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -18,7 +18,6 @@
 
 from __future__ import print_function
 import binascii
-import functools
 import math
 import os
 import socket
@@ -68,7 +67,7 @@ class UnpackException(Error):
 class MissingPLASAPIDs(Error):
   """Raises if the files did not contain the ESTA (PLASA) PIDs."""
 
-@functools.total_ordering()
+
 class Pid(object):
   """A class that describes everything about a PID."""
   def __init__(self, name, value,
@@ -166,6 +165,15 @@ class Pid(object):
 
   def __lt__(self, other):
     return self._value < other._value
+
+  def __le__(self, other):
+    return self._value <= other._value
+
+  def __gt__(self, other):
+    return self._value > other._value
+
+  def __ge__(self, other):
+    return self._value >= other._value
 
   def __str__(self):
     return '%s (0x%04hx)' % (self.name, self.value)

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -18,6 +18,7 @@
 
 from __future__ import print_function
 import binascii
+import functools
 import math
 import os
 import socket
@@ -67,7 +68,7 @@ class UnpackException(Error):
 class MissingPLASAPIDs(Error):
   """Raises if the files did not contain the ESTA (PLASA) PIDs."""
 
-
+@functools.total_ordering()
 class Pid(object):
   """A class that describes everything about a PID."""
   def __init__(self, name, value,
@@ -159,6 +160,12 @@ class Pid(object):
 
   def __cmp__(self, other):
     return cmp(self._value, other._value)
+
+  def __eq__(self, other):
+    return self._value == other._value
+
+  def __lt__(self, other):
+    return self._value < other._value
 
   def __str__(self):
     return '%s (0x%04hx)' % (self.name, self.value)

--- a/tools/ola_mon/ola_mon.py
+++ b/tools/ola_mon/ola_mon.py
@@ -262,4 +262,4 @@ def main():
 
 
 if __name__ == "__main__":
-      main()
+  main()

--- a/tools/rdm/ResponderTest.py
+++ b/tools/rdm/ResponderTest.py
@@ -27,7 +27,6 @@
 #                                  result based on the output of
 #                                  SUPPORTED_PARAMETERS
 
-import functools
 import logging
 import time
 from ExpectedResults import (AckDiscoveryResult, AckGetResult, AckSetResult,
@@ -51,7 +50,6 @@ class UndeclaredPropertyException(Error):
   """Raised if a test attempts to get/set a property that it didn't declare."""
 
 
-@functools.total_ordering()
 class TestFixture(object):
   """The base responder test class, every test inherits from this."""
   PID = None
@@ -93,6 +91,15 @@ class TestFixture(object):
 
   def __lt__(self, other):
     return self.__class__.__name__ < other.__class__.__name__
+
+  def __le__(self, other):
+    return self.__class__.__name__ <= other.__class__.__name__
+
+  def __gt__(self, other):
+    return self.__class__.__name__ > other.__class__.__name__
+
+  def __ge__(self, other):
+    return self.__class__.__name__ >= other.__class__.__name__
 
   def PidRequired(self):
     """Whether a valid PID is required for this test"""

--- a/tools/rdm/ResponderTest.py
+++ b/tools/rdm/ResponderTest.py
@@ -27,6 +27,7 @@
 #                                  result based on the output of
 #                                  SUPPORTED_PARAMETERS
 
+import functools
 import logging
 import time
 from ExpectedResults import (AckDiscoveryResult, AckGetResult, AckSetResult,
@@ -50,6 +51,7 @@ class UndeclaredPropertyException(Error):
   """Raised if a test attempts to get/set a property that it didn't declare."""
 
 
+@functools.total_ordering()
 class TestFixture(object):
   """The base responder test class, every test inherits from this."""
   PID = None
@@ -85,6 +87,12 @@ class TestFixture(object):
 
   def __cmp__(self, other):
     return cmp(self.__class__.__name__, other.__class__.__name__)
+
+  def __eq__(self, other):
+    return self.__class__.__name__ == other.__class__.__name__
+
+  def __lt__(self, other):
+    return self.__class__.__name__ < other.__class__.__name__
 
   def PidRequired(self):
     """Whether a valid PID is required for this test"""

--- a/tools/rdm/TestDefinitions.py
+++ b/tools/rdm/TestDefinitions.py
@@ -6821,13 +6821,13 @@ class GetPresetStatus(OptionalParameterTestFixture):
 
   def CheckFieldIsBetween(self, fields, key, min_value, max_value):
     if fields[key] < min_value:
-          self.AddWarning(
-              '%s for scene %d (%d s) is less than the min of %s' %
-              (key, self.index, fields[key], min_value))
+      self.AddWarning(
+          '%s for scene %d (%d s) is less than the min of %s' %
+          (key, self.index, fields[key], min_value))
     if fields[key] > max_value:
-          self.AddWarning(
-              '%s for scene %d (%d s) is more than the min of %s' %
-              (key, self.index, fields[key], max_value))
+      self.AddWarning(
+          '%s for scene %d (%d s) is more than the min of %s' %
+          (key, self.index, fields[key], max_value))
 
 
 class GetPresetStatusWithNoData(TestMixins.GetWithNoDataMixin,

--- a/tools/rdm/TestState.py
+++ b/tools/rdm/TestState.py
@@ -15,12 +15,10 @@
 # TestState.py
 # Copyright (C) 2011 Simon Newton
 
-import functools
 
 __author__ = 'nomis52@gmail.com (Simon Newton)'
 
 
-@functools.total_ordering()
 class TestState(object):
   """Represents the state of a test."""
   def __init__(self, state):
@@ -37,6 +35,15 @@ class TestState(object):
 
   def __lt__(self, other):
     return self._state < other._state
+
+  def __le__(self, other):
+    return self._state <= other._state
+
+  def __gt__(self, other):
+    return self._state > other._state
+
+  def __ge__(self, other):
+    return self._state >= other._state
 
   def __hash__(self):
     return hash(self._state)

--- a/tools/rdm/TestState.py
+++ b/tools/rdm/TestState.py
@@ -15,9 +15,12 @@
 # TestState.py
 # Copyright (C) 2011 Simon Newton
 
+import functools
+
 __author__ = 'nomis52@gmail.com (Simon Newton)'
 
 
+@functools.total_ordering()
 class TestState(object):
   """Represents the state of a test."""
   def __init__(self, state):
@@ -28,6 +31,12 @@ class TestState(object):
 
   def __cmp__(self, other):
     return cmp(self._state, other._state)
+
+  def __eq__(self, other):
+    return self._state == other._state
+
+  def __lt__(self, other):
+    return self._state < other._state
 
   def __hash__(self):
     return hash(self._state)


### PR DESCRIPTION
See https://portingguide.readthedocs.io/en/latest/comparisons.html#rich-comparisons for an explaination of why it was broken.

In particular, I was stuck with a bug in the `_Event` class because heaps are ordered and I wanted to add multiple events to it, which failed because they had no suitable comparison functions.