### PR TITLE
Add user chosable base support to StringToInt()

### DIFF
--- a/common/utils/StringUtils.cpp
+++ b/common/utils/StringUtils.cpp
@@ -152,13 +152,16 @@ bool StringToBoolTolerant(const string &value, bool *output) {
   return false;
 }
 
-bool StringToInt(const string &value, unsigned int *output, bool strict) {
+bool StringToInt(const string &value,
+                 unsigned int *output,
+                 bool strict,
+                 uint8_t base) {
   if (value.empty()) {
     return false;
   }
   char *end_ptr;
   errno = 0;
-  long long l = strtoll(value.data(), &end_ptr, 10);  // NOLINT(runtime/int)
+  long long l = strtoll(value.data(), &end_ptr, base);  // NOLINT(runtime/int)
   if (l < 0 || (l == 0 && errno != 0)) {
     return false;
   }
@@ -175,9 +178,12 @@ bool StringToInt(const string &value, unsigned int *output, bool strict) {
   return true;
 }
 
-bool StringToInt(const string &value, uint16_t *output, bool strict) {
+bool StringToInt(const string &value,
+                 uint16_t *output,
+                 bool strict,
+                 uint8_t base) {
   unsigned int v;
-  if (!StringToInt(value, &v, strict)) {
+  if (!StringToInt(value, &v, strict, base)) {
     return false;
   }
   if (v > UINT16_MAX) {
@@ -187,9 +193,12 @@ bool StringToInt(const string &value, uint16_t *output, bool strict) {
   return true;
 }
 
-bool StringToInt(const string &value, uint8_t *output, bool strict) {
+bool StringToInt(const string &value,
+                 uint8_t *output,
+                 bool strict,
+                 uint8_t base) {
   unsigned int v;
-  if (!StringToInt(value, &v, strict)) {
+  if (!StringToInt(value, &v, strict, base)) {
     return false;
   }
   if (v > UINT8_MAX) {
@@ -199,13 +208,16 @@ bool StringToInt(const string &value, uint8_t *output, bool strict) {
   return true;
 }
 
-bool StringToInt(const string &value, int *output, bool strict) {
+bool StringToInt(const string &value,
+                 int *output,
+                 bool strict,
+                 uint8_t base) {
   if (value.empty()) {
     return false;
   }
   char *end_ptr;
   errno = 0;
-  long long l = strtoll(value.data(), &end_ptr, 10);  // NOLINT(runtime/int)
+  long long l = strtoll(value.data(), &end_ptr, base);  // NOLINT(runtime/int)
   if (l == 0 && errno != 0) {
     return false;
   }
@@ -222,9 +234,12 @@ bool StringToInt(const string &value, int *output, bool strict) {
   return true;
 }
 
-bool StringToInt(const string &value, int16_t *output, bool strict) {
+bool StringToInt(const string &value,
+                 int16_t *output,
+                 bool strict,
+                 uint8_t base) {
   int v;
-  if (!StringToInt(value, &v, strict)) {
+  if (!StringToInt(value, &v, strict, base)) {
     return false;
   }
   if (v < INT16_MIN || v > INT16_MAX) {
@@ -234,9 +249,12 @@ bool StringToInt(const string &value, int16_t *output, bool strict) {
   return true;
 }
 
-bool StringToInt(const string &value, int8_t *output, bool strict) {
+bool StringToInt(const string &value,
+                 int8_t *output,
+                 bool strict,
+                 uint8_t base) {
   int v;
-  if (!StringToInt(value, &v, strict)) {
+  if (!StringToInt(value, &v, strict, base)) {
     return false;
   }
   if (v < INT8_MIN || v > INT8_MAX) {

--- a/common/utils/StringUtilsTest.cpp
+++ b/common/utils/StringUtilsTest.cpp
@@ -539,7 +539,7 @@ void StringUtilsTest::testStringToBoolTolerant() {
 
 
 void StringUtilsTest::testStringToUInt() {
-  unsigned int value;
+  unsigned int value, value2;
   OLA_ASSERT_FALSE(StringToInt("", &value));
   OLA_ASSERT_FALSE(StringToInt("-1", &value));
   OLA_ASSERT_TRUE(StringToInt("0", &value));
@@ -561,6 +561,14 @@ void StringUtilsTest::testStringToUInt() {
   OLA_ASSERT_FALSE(StringToInt("1 bar baz", &value, true));
   OLA_ASSERT_FALSE(StringToInt("65537cat", &value, true));
   OLA_ASSERT_FALSE(StringToInt("4294967295bat bar", &value, true));
+
+  //Base36 test
+  OLA_ASSERT_TRUE(StringToInt("12FZ9A", &value, false, 36));
+  OLA_ASSERT_TRUE(StringToInt("12fz9a", &value2, false, 36));
+  OLA_ASSERT_EQ(value, value2);
+  OLA_ASSERT_TRUE(StringToInt("STRICT1", &value, true, 36));
+  OLA_ASSERT_TRUE(StringToInt("strict1", &value2, true, 36));
+  OLA_ASSERT_EQ(value, value2);
 }
 
 void StringUtilsTest::testStringToUIntOrDefault() {

--- a/include/ola/StringUtils.h
+++ b/include/ola/StringUtils.h
@@ -328,7 +328,8 @@ bool StringToInt(const std::string &value,
  */
 bool StringToInt(const std::string &value,
                  int16_t *output,
-                 bool strict = false);
+                 bool strict = false,
+                 uint8_t base = 10);
 
 /**
  * @brief Convert a string to a int8_t.
@@ -357,9 +358,10 @@ bool StringToInt(const std::string &value,
 template <typename int_type>
 int_type StringToIntOrDefault(const std::string &value,
                               int_type alternative,
-                              bool strict = false) {
+                              bool strict = false,
+                              uint8_t base = 10) {
   int_type output;
-  return (StringToInt(value, &output, strict)) ? output : alternative;
+  return (StringToInt(value, &output, strict, base)) ? output : alternative;
 }
 
 /**

--- a/include/ola/StringUtils.h
+++ b/include/ola/StringUtils.h
@@ -262,55 +262,66 @@ bool StringToBoolTolerant(const std::string &value, bool *output);
  * @param[in] value the string to convert
  * @param[out] output a pointer where the value will be stored.
  * @param[in] strict this controls if trailing characters produce an error.
+ * @param[in] base the base of the number being read
  * @returns true if the value was converted, false if the string was not an int
  * or the value was too large / small for the type.
  */
 bool StringToInt(const std::string &value,
                  unsigned int *output,
-                 bool strict = false);
+                 bool strict = false,
+                 uint8_t base = 10);
 
 /**
  * @brief Convert a string to a uint16_t.
  * @param[in] value the string to convert
  * @param[out] output a pointer where the value will be stored.
  * @param[in] strict this controls if trailing characters produce an error.
+ * @param[in] base the base of the number being read
  * @returns true if the value was converted, false if the string was not an int
  * or the value was too large / small for the type.
  * @sa StringToInt.
  */
 bool StringToInt(const std::string &value,
                  uint16_t *output,
-                 bool strict = false);
+                 bool strict = false,
+                 uint8_t base = 10);
 
 /**
  * @brief Convert a string to a uint8_t.
  * @param[in] value the string to convert
  * @param[out] output a pointer where the value will be stored.
  * @param[in] strict this controls if trailing characters produce an error.
+ * @param[in] base the base of the number being read
  * @returns true if the value was converted, false if the string was not an int
  * or the value was too large / small for the type.
  * @sa StringToInt.
  */
 bool StringToInt(const std::string &value,
                  uint8_t *output,
-                 bool strict = false);
+                 bool strict = false,
+                 uint8_t base = 10);
 
 /**
  * @brief Convert a string to a int.
  * @param[in] value the string to convert
  * @param[out] output a pointer where the value will be stored.
  * @param[in] strict this controls if trailing characters produce an error.
+ * @param[in] base the base of the number being read
  * @returns true if the value was converted, false if the string was not an int
  * or the value was too large / small for the type.
  * @sa StringToInt.
  */
-bool StringToInt(const std::string &value, int *output, bool strict = false);
+bool StringToInt(const std::string &value,
+                 int *output,
+                 bool strict = false,
+                 uint8_t base = 10);
 
 /**
  * @brief Convert a string to a int16_t.
  * @param[in] value the string to convert
  * @param[out] output a pointer where the value will be stored.
  * @param[in] strict this controls if trailing characters produce an error.
+ * @param[in] base the base of the number being read
  * @returns true if the value was converted, false if the string was not an int
  * or the value was too large / small for the type.
  * @sa StringToInt.
@@ -324,11 +335,15 @@ bool StringToInt(const std::string &value,
  * @param[in] value the string to convert
  * @param[out] output a pointer where the value will be stored.
  * @param[in] strict this controls if trailing characters produce an error.
+ * @param[in] base the base of the number being read
  * @returns true if the value was converted, false if the string was not an int
  * or the value was too large / small for the type.
  * @sa StringToInt.
  */
-bool StringToInt(const std::string &value, int8_t *output, bool strict = false);
+bool StringToInt(const std::string &value,
+                 int8_t *output,
+                 bool strict = false,
+                 uint8_t base = 10);
 
 /**
  * @brief Convert a string to an int type or return a default if it failed.


### PR DESCRIPTION
Needed for FTDI plugin to create a unique ID for RDM packets based on base36 serial stored in the EEPROM.