### PR TITLE
Usleep

### DIFF
--- a/common/utils/Clock.cpp
+++ b/common/utils/Clock.cpp
@@ -39,6 +39,8 @@
 #include <sstream>
 #include <string>
 
+#include "ola/Logging.h"
+
 namespace ola {
 
 using std::string;
@@ -127,6 +129,10 @@ void BaseTimeVal::AsTimeval(struct timeval *tv) const {
 int64_t BaseTimeVal::InMilliSeconds() const {
   return (m_tv.tv_sec * static_cast<int64_t>(ONE_THOUSAND) +
           m_tv.tv_usec / ONE_THOUSAND);
+}
+
+int64_t BaseTimeVal::InMicroSeconds() const {
+  return this->AsInt();
 }
 
 int64_t BaseTimeVal::AsInt() const {
@@ -272,4 +278,88 @@ void MockClock::CurrentTime(TimeStamp *timestamp) const {
   *timestamp = tv;
   *timestamp += m_offset;
 }
+
+Sleep::Sleep(std::string caller) :
+  m_caller(caller) {
+}
+
+/**
+ * @brief Set wanted granularity for usleep and check it.
+ * @note does not check at the nanosecond level,
+ * since internal sturtures use usecs.
+ *
+ * @param wanted wanted/needed granularity in usecs
+ * @param maxDeviation max deviation in usecs tolerated by calling thread.
+ *
+ * @attention the granularity of sleep is highly fluctuating depending on the
+ * load of the system, a prior GOOD state is no guarantee for future proper
+ * timing.
+ */
+bool Sleep::CheckTimeGranularity(uint64_t wanted, uint64_t maxDeviation) {
+  TimeStamp ts1, ts2;
+  Clock clock;
+
+  m_wanted_granularity = wanted;
+  m_max_granularity_deviation = maxDeviation;
+
+  timespec t;
+  t.tv_sec = wanted / USEC_IN_SECONDS;
+  t.tv_nsec = (wanted % USEC_IN_SECONDS) * ONE_THOUSAND;
+
+  clock.CurrentTime(&ts1);
+  this->usleep(1);
+  clock.CurrentTime(&ts2);
+  TimeInterval interval = ts2 - ts1;
+  m_clock_overhead = interval.InMicroSeconds();
+
+  clock.CurrentTime(&ts1);
+  this->usleep(t);
+  clock.CurrentTime(&ts2);
+
+  interval = ts2 - ts1;
+  m_granularity = (interval.InMicroSeconds() >
+                   (wanted + maxDeviation + m_clock_overhead)) ? BAD : GOOD;
+
+  OLA_INFO << "Granularity for OlaSleep in " << m_caller << " is "
+           << ((m_granularity == GOOD) ? "GOOD" : "BAD")
+           << " Requested: " << wanted << " Got: " << interval.InMicroSeconds()
+           << " Overhead: " << m_clock_overhead;
+  if (m_granularity == GOOD) {
+    return true;
+  }
+  return false;
+}
+
+void Sleep::usleep(TimeInterval requested) {
+  timespec req;
+  req.tv_sec = requested.Seconds();
+  req.tv_nsec = requested.MicroSeconds() * ONE_THOUSAND;
+
+  this->usleep(req);
+}
+
+void Sleep::usleep(uint32_t requested) {
+  timespec req;
+  req.tv_sec = requested / USEC_IN_SECONDS;
+  req.tv_nsec = (requested % USEC_IN_SECONDS) * ONE_THOUSAND;
+
+  this->usleep(req);
+}
+
+void Sleep::usleep(timespec requested) {
+  timespec rem;
+
+  if (nanosleep(&requested, &rem) < 0) {
+    if (errno == EINTR) {
+      while (rem.tv_nsec > 0 || rem.tv_sec > 0) {
+        requested.tv_nsec = rem.tv_nsec;
+        requested.tv_sec = rem.tv_sec;
+        nanosleep(&requested, &rem);
+      }
+    } else {
+      OLA_WARN << "nanosleep failed with state: " << errno;
+    }
+  }
+}
+
 }  // namespace ola

--- a/include/ola/Clock.h
+++ b/include/ola/Clock.h
@@ -41,8 +41,9 @@
 namespace ola {
 
 static const int USEC_IN_SECONDS = 1000000;
-static const int ONE_THOUSAND = 1000;
-
+static const int MSEC_IN_SEC = 1000;
+static const uint64_t NSEC_IN_SEC = 1000000000;
+static const int ONE_THOUSAND = MSEC_IN_SEC;
 /**
  * Don't use this class directly. It's an implementation detail of TimeInterval
  * and TimeStamp.
@@ -104,6 +105,12 @@ class BaseTimeVal {
    */
   int64_t AsInt() const;
 
+  /**
+   * @brief InMicroSeconds returns AsInt() for naming consistency
+   * @return returns AsInt()
+   */
+  int64_t InMicroSeconds() const;
+
   std::string ToString() const;
 
  private:
@@ -160,6 +167,7 @@ class TimeInterval {
   int32_t MicroSeconds() const { return m_interval.MicroSeconds(); }
 
   int64_t InMilliSeconds() const { return m_interval.InMilliSeconds(); }
+  int64_t InMicroSeconds() const { return m_interval.InMicroSeconds(); }
   int64_t AsInt() const { return m_interval.AsInt(); }
 
   std::string ToString() const { return m_interval.ToString(); }
@@ -256,6 +264,34 @@ class MockClock: public Clock {
 
  private:
   TimeInterval m_offset;
+};
+
+enum TimerGranularity { UNKNOWN, GOOD, BAD };
+
+/**
+ * @brief The Sleep class implements usleep with some granualtiry detection.
+ */
+class Sleep {
+ public:
+  explicit Sleep(std::string caller);
+
+  void setCaller(std::string caller) { m_caller = caller; }
+
+  void usleep(TimeInterval requested);
+  void usleep(uint32_t requested);
+  void usleep(timespec requested);
+
+  TimerGranularity getGranularity() { return m_granularity; }
+  bool CheckTimeGranularity(uint64_t wanted, uint64_t maxDeviation);
+ private:
+  std::string m_caller;
+  uint64_t m_wanted_granularity;
+  uint64_t m_max_granularity_deviation;
+  uint64_t m_clock_overhead;
+
+  static const uint32_t BAD_GRANULARITY_LIMIT = 10;
+
+  TimerGranularity m_granularity = UNKNOWN;
 };
 }  // namespace ola
 #endif  // INCLUDE_OLA_CLOCK_H_

--- a/plugins/convert_README_to_header.sh
+++ b/plugins/convert_README_to_header.sh
@@ -4,6 +4,8 @@
 # from the plugin's README.md
 # The output file then contains one variable 'plugin_description'.
 
+set -e
+
 if [ $# != 2 ]; then
   echo "Usage: convert_README_to_header.sh <plugin path> <outfile path>";
   echo "<plugin path>: path to plugin dir, e.g. plugins/artnet";

--- a/plugins/convert_README_to_header.sh
+++ b/plugins/convert_README_to_header.sh
@@ -30,12 +30,12 @@ outfilename=`basename $outfile`;
 # See http://stackoverflow.com/a/16576291
 # On Mac OS's sed, \n is not recognized as a newline character, but
 # \[actual newline] works
-desc=`sed -e ':a' -e 'N' -e '$!ba' -e 's/\\\/\\\\\\\/g' -e 's/\"/\\\"/g'\
- -e 's/\n/\\\\n\"\
+desc=`sed -e ':a' -e 'N' -e '$!ba' -e 's/\\\/\\\\\\\/g' -e 's/\"/\\\"/g' \
+ -e 's/\n/\\\\n\"\\
 \"/g' "$path/README.md"`;
 
 if (( $? != 0 )); then
-	echo 'Sed failed to generate $desc'
+	echo "sed failed to process $path/README.md"
 	exit 1
 fi
 

--- a/plugins/convert_README_to_header.sh
+++ b/plugins/convert_README_to_header.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # A simple script to build a C++ header file containing the plugin description
 # from the plugin's README.md
@@ -30,8 +30,14 @@ outfilename=`basename $outfile`;
 # See http://stackoverflow.com/a/16576291
 # On Mac OS's sed, \n is not recognized as a newline character, but
 # \[actual newline] works
-desc=`sed -e ':a' -e 'N' -e '$!ba' -e 's/\"/\\\"/g' -e 's/\n/\\\\n"\\
-"/g' "$path/README.md"`;
+desc=`sed -e ':a' -e 'N' -e '$!ba' -e 's/\\\/\\\\\\\/g' -e 's/\"/\\\"/g'\
+ -e 's/\n/\\\\n\"\
+\"/g' "$path/README.md"`;
+
+if (( $? != 0 )); then
+	echo 'Sed failed to generate $desc'
+	exit 1
+fi
 
 identifier=`echo "PLUGINS_${plugin}_${outfilename%.h}_H_" | tr '[:lower:]' '[:upper:]'`
 

--- a/plugins/convert_README_to_header.sh
+++ b/plugins/convert_README_to_header.sh
@@ -36,11 +36,6 @@ desc=`sed -e ':a' -e 'N' -e '$!ba' -e 's/\\\/\\\\\\\/g' -e 's/\"/\\\"/g' \
  -e 's/\n/\\\\n\"\\
 \"/g' "$path/README.md"`;
 
-if (( $? != 0 )); then
-	echo "sed failed to process $path/README.md"
-	exit 1
-fi
-
 identifier=`echo "PLUGINS_${plugin}_${outfilename%.h}_H_" | tr '[:lower:]' '[:upper:]'`
 
 cat <<EOM > $outfile


### PR DESCRIPTION
Adds a usleep implementation, also makes logic for timer granularity logic available for everyone (instead of just ftdi plugin).

Also adds a wrapper for AsInt() for naming consistency and clarity.