### PR TITLE
patches to OLA python, so library works in both python2 and python3

### DIFF
--- a/python/ola/ClientWrapper.py
+++ b/python/ola/ClientWrapper.py
@@ -47,6 +47,9 @@ class _Event(object):
   def __cmp__(self, other):
     return cmp(self._run_at, other._run_at)
 
+  def __lt__(self, other):
+    return self._run_at < other._run_at
+
   def TimeLeft(self, now):
     """Get the time remaining before this event triggers.
 

--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -1293,7 +1293,11 @@ class OlaClient(Ola_pb2.OlaClientService):
     request.uid.device_id = uid.device_id
     request.sub_device = sub_device
     request.param_id = param_id
-    request.data = data
+    if sys.version >= '3.2':
+      request.data = eval(data)[0] if data else bytes(data, 'utf-8')
+    else:
+      #request.data = eval(data)[0] if data else data # started breaking (MultiDim), 2019-10-31
+      request.data = data # works, 2019-10-31
     request.is_set = set
     request.include_raw_response = include_frames
     try:

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -429,7 +429,7 @@ class IntAtom(FixedSizeAtom):
         raise ArgsValidationError(
             'Conversion will lose data: %d -> %d' %
             (new_value, (new_value / multiplier * multiplier)))
-      new_value = new_value / multiplier
+      new_value = int(new_value / multiplier)
 
     else:
       try:
@@ -616,7 +616,10 @@ class String(Atom):
                                 (self.name, self.min))
 
     try:
-      data = struct.unpack('%ds' % arg_size, arg)
+      if sys.version >= '3.2':
+        data = struct.unpack('%ds' % arg_size, bytes(arg, 'utf8'))
+      else:
+        data = struct.unpack('%ds' % arg_size, arg)
     except struct.error as e:
       raise ArgsValidationError("Can't pack data: %s" % e)
     return data[0], 1
@@ -636,7 +639,10 @@ class String(Atom):
     except struct.error as e:
       raise UnpackException(e)
 
-    return value[0].rstrip('\x00')
+    if sys.version >= '3.2':
+      return value[0].rstrip(bytes('\x00', 'utf-8')).decode('utf-8')
+    else:
+      return value[0].rstrip('\x00')
 
   def GetDescription(self, indent=0):
     indent = ' ' * indent
@@ -778,7 +784,10 @@ class Group(Atom):
         raise ArgsValidationError('Too many arguments, expected %d, got %d' %
                                   (arg_offset, len(args)))
 
-      return ''.join(data), arg_offset
+      if sys.version >= '3.2':
+        return ''.join(str(data)), arg_offset
+      else:
+        return ''.join(data), arg_offset
 
     elif self._group_size == 0:
       return '', 0
@@ -794,7 +803,7 @@ class Group(Atom):
       if arg_offset < len(args):
         raise ArgsValidationError('Too many arguments, expected %d, got %d' %
                                   (arg_offset, len(args)))
-      return ''.join(data), arg_offset
+      return ''.join(str(data)), arg_offset
 
   def Unpack(self, data):
     """Unpack binary data.


### PR DESCRIPTION
Just wanted to submit my patches to OLA, so the Python API works also for python3.

Have been using this for a while in Raspbian GNU/Linux 9.11 (stretch), and has worked for me so far for both DMX and RDM. However, it has not been extensively tested with all possible edge cases.

Typically, what I do is just:

```
pi@raspberrypi:~ $ sudo ln -s /usr/lib/python2.7/dist-packages/ola /usr/lib/python3/dist-packages/
```
... and then just patch the files in `/usr/lib/python2.7/dist-packages/ola`; here I've done the same changes in the OLA source tree.
