### PR TITLE
Protobuf 3.11 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
       env:
       - TASK='compile'
       - CPPUNIT='1.13'
-      - PROTOBUF='3.6'
+      - PROTOBUF='latest'
       - LIBFTDI='1'
     - os: osx
       osx_image: xcode9.3
@@ -85,7 +85,7 @@ matrix:
       env:
       - TASK='compile'
       - CPPUNIT='1.13'
-      - PROTOBUF='3.6'
+      - PROTOBUF='latest'
       - LIBFTDI='1'
     - os: osx
       osx_image: xcode9.3
@@ -93,7 +93,7 @@ matrix:
       env:
       - TASK='compile'
       - CPPUNIT='1.14'
-      - PROTOBUF='3.6'
+      - PROTOBUF='latest'
       - LIBFTDI='1'
     - os: osx
       osx_image: xcode9.3
@@ -101,7 +101,7 @@ matrix:
       env:
       - TASK='compile'
       - CPPUNIT='1.14'
-      - PROTOBUF='3.6'
+      - PROTOBUF='latest'
       - LIBFTDI='1'
     - os: linux
       dist: xenial
@@ -310,8 +310,8 @@ before_cache:
 
 install:
 # Match the version of protobuf being installed via apt
-  - if [[ "$PROTOBUF" == "3.6" ]]; then pip install --user protobuf==3.6.0; fi
-  - if [[ "$PROTOBUF" != "3.6" ]]; then pip install --user protobuf==3.1.0; fi
+  - if [[ "$PROTOBUF" == "latest" ]]; then pip install --user protobuf; fi
+  - if [[ "$PROTOBUF" != "latest" ]]; then pip install --user protobuf==3.1.0; fi
 # We need to use pip rather than apt on Xenial
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pip install --user numpy; fi
   - if [ "$TASK" = "coverage" ]; then pip install --user cpp-coveralls; fi
@@ -333,10 +333,9 @@ before_install:
  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ccache bison flex liblo libmicrohttpd; fi # ossp-uuid, homebrew/python/numpy and libusb already present
  - if [ "$TRAVIS_OS_NAME" == "osx" -a "$LIBFTDI" != "1" ]; then brew install libftdi0; fi # install libftdi0
  - if [ "$TRAVIS_OS_NAME" == "osx" -a "$LIBFTDI" == "1" ]; then brew install libftdi; fi # install the latest libftdi
- - if [ "$TRAVIS_OS_NAME" == "osx" -a "$PROTOBUF" == "3.6" ]; then brew install protobuf@3.6; fi
- - if [ "$TRAVIS_OS_NAME" == "osx" -a "$PROTOBUF" == "3.6" ]; then brew link -f protobuf@3.6; export PKG_CONFIG_PATH=/usr/local/opt/protobuf@3.6/lib/pkgconfig; fi # When protobuf is not on the latest release
- - if [ "$TRAVIS_OS_NAME" == "osx" -a "$PROTOBUF" != "3.6" ]; then brew install protobuf@3.1; fi
- - if [ "$TRAVIS_OS_NAME" == "osx" -a "$PROTOBUF" != "3.6" ]; then brew link -f protobuf@3.1; export PKG_CONFIG_PATH=/usr/local/opt/protobuf@3.1/lib/pkgconfig; brew install --build-from-source --ignore-dependencies --env=std protobuf-c; fi # When protobuf is not on the latest release
+ - if [ "$TRAVIS_OS_NAME" == "osx" -a "$PROTOBUF" == "latest" ]; then brew install protobuf; fi
+ - if [ "$TRAVIS_OS_NAME" == "osx" -a "$PROTOBUF" != "latest" ]; then brew install protobuf@3.1; fi
+ - if [ "$TRAVIS_OS_NAME" == "osx" -a "$PROTOBUF" != "latest" ]; then brew link -f protobuf@3.1; export PKG_CONFIG_PATH=/usr/local/opt/protobuf@3.1/lib/pkgconfig; brew install --build-from-source --ignore-dependencies --env=std protobuf-c; fi # When protobuf is not on the latest release
  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p ${HOME}/Library/Python/2.7/lib/python/site-packages; echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >> ${HOME}/Library/Python/2.7/lib/python/site-packages/homebrew.pth; fi
  - if [ "$TRAVIS_OS_NAME" == "osx" -a "$CPPUNIT" != "1.14" ]; then brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/e6e43cf6a3%5E/Formula/cppunit.rb; fi # install a slightly older cppunit, as latest needs C++11 support
  - if [ "$TRAVIS_OS_NAME" == "osx" -a "$CPPUNIT" == "1.14" ]; then brew install cppunit; fi # install the latest cppunit, which needs C++11

--- a/configure.ac
+++ b/configure.ac
@@ -864,6 +864,9 @@ AS_IF([test "${enable_rdm_tests}" = "yes"],
 AS_IF([test "x$build_java_libs" = xyes],
       [PROTOBUF_SUPPORT([2.4.0])],
       [PROTOBUF_SUPPORT([2.3.0])])
+# Version 3.7 and above of protoc require some additional includes
+AC_CHECK_HEADERS([google/protobuf/io/strtod.h google/protobuf/stubs/logging.h \
+                  google/protobuf/stubs/stl_util.h])
 
 
 # Doxygen

--- a/protoc/CppFileGenerator.cpp
+++ b/protoc/CppFileGenerator.cpp
@@ -244,7 +244,7 @@ void FileGenerator::GenerateBuildDescriptors(Printer* printer) {
       "inline void protobuf_AssignDescriptorsOnce() {\n"
       "  static ::google::protobuf::internal::once_flag once;\n"
       "  ::google::protobuf::internal::call_once(once,\n"
-      "    $assigndescriptorsname$);\n"
+      "    &$assigndescriptorsname$);\n"
       "}\n"
       "\n",
       "assigndescriptorsname", GlobalAssignDescriptorsName(m_output_name));

--- a/protoc/CppFileGenerator.cpp
+++ b/protoc/CppFileGenerator.cpp
@@ -221,18 +221,12 @@ void FileGenerator::GenerateBuildDescriptors(Printer* printer) {
     // AssignDescriptors().  All later times, waits for the first call to
     // complete and then returns.
     printer->Print(
-      "namespace {\n"
-      "\n"
-      "GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_AssignDescriptors_once_);\n"
-      "inline void protobuf_AssignDescriptorsOnce() {\n"
-      "  ::google::protobuf::GoogleOnceInit(&protobuf_AssignDescriptors_once_,"
-      "\n"
-      "                 &$assigndescriptorsname$);\n"
+      "void protobuf_AssignDescriptorsOnce() {\n"
+      "  static ::google::protobuf::internal::once_flag once;\n"
+      "  ::google::protobuf::internal::call_once(once, $assigndescriptorsname$);\n"
       "}\n"
       "\n",
       "assigndescriptorsname", GlobalAssignDescriptorsName(m_output_name));
-
-    printer->Print("}  // namespace\n");
   }
 }
 

--- a/protoc/CppFileGenerator.cpp
+++ b/protoc/CppFileGenerator.cpp
@@ -239,13 +239,16 @@ void FileGenerator::GenerateBuildDescriptors(Printer* printer) {
     printer->Print("}  // namespace\n");
 #else
     printer->Print(
-      "void protobuf_AssignDescriptorsOnce() {\n"
+      "namespace {\n"
+      "\n"
+      "inline void protobuf_AssignDescriptorsOnce() {\n"
       "  static ::google::protobuf::internal::once_flag once;\n"
       "  ::google::protobuf::internal::call_once(once,\n"
       "    $assigndescriptorsname$);\n"
       "}\n"
       "\n",
       "assigndescriptorsname", GlobalAssignDescriptorsName(m_output_name));
+    printer->Print("}  // namespace\n");
 #endif
   }
 }

--- a/protoc/CppFileGenerator.cpp
+++ b/protoc/CppFileGenerator.cpp
@@ -223,7 +223,7 @@ void FileGenerator::GenerateBuildDescriptors(Printer* printer) {
 
     // We need to generate different code, depending on the version
     // of protobuf we compile against
-#if GOOGLE_PROTOBUF_VERSION < 3008000
+#if GOOGLE_PROTOBUF_VERSION < 3007000
     printer->Print(
       "namespace {\n"
       "\n"

--- a/protoc/CppFileGenerator.cpp
+++ b/protoc/CppFileGenerator.cpp
@@ -220,6 +220,24 @@ void FileGenerator::GenerateBuildDescriptors(Printer* printer) {
     // protobuf_AssignDescriptorsOnce():  The first time it is called, calls
     // AssignDescriptors().  All later times, waits for the first call to
     // complete and then returns.
+
+    // We need to generate different code, depending on the version
+    // of protobuf we compile against
+#if GOOGLE_PROTOBUF_VERSION < 3008000
+    printer->Print(
+      "namespace {\n"
+      "\n"
+      "GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_AssignDescriptors_once_);\n"
+      "inline void protobuf_AssignDescriptorsOnce() {\n"
+      "  ::google::protobuf::GoogleOnceInit(&protobuf_AssignDescriptors_once_,"
+      "\n"
+      "                 &$assigndescriptorsname$);\n"
+      "}\n"
+      "\n",
+      "assigndescriptorsname", GlobalAssignDescriptorsName(m_output_name));
+
+    printer->Print("}  // namespace\n");
+#else
     printer->Print(
       "void protobuf_AssignDescriptorsOnce() {\n"
       "  static ::google::protobuf::internal::once_flag once;\n"
@@ -227,6 +245,7 @@ void FileGenerator::GenerateBuildDescriptors(Printer* printer) {
       "}\n"
       "\n",
       "assigndescriptorsname", GlobalAssignDescriptorsName(m_output_name));
+#endif
   }
 }
 

--- a/protoc/CppFileGenerator.cpp
+++ b/protoc/CppFileGenerator.cpp
@@ -241,7 +241,8 @@ void FileGenerator::GenerateBuildDescriptors(Printer* printer) {
     printer->Print(
       "void protobuf_AssignDescriptorsOnce() {\n"
       "  static ::google::protobuf::internal::once_flag once;\n"
-      "  ::google::protobuf::internal::call_once(once, $assigndescriptorsname$);\n"
+      "  ::google::protobuf::internal::call_once(once,\n"
+      "    $assigndescriptorsname$);\n"
       "}\n"
       "\n",
       "assigndescriptorsname", GlobalAssignDescriptorsName(m_output_name));

--- a/protoc/StrUtil.cpp
+++ b/protoc/StrUtil.cpp
@@ -41,6 +41,16 @@
 
 #include "protoc/StrUtil.h"
 
+#ifdef HAVE_GOOGLE_PROTOBUF_IO_STRTOD_H
+#include <google/protobuf/io/strtod.h>
+#endif  // HAVE_GOOGLE_PROTOBUF_IO_STRTOD_H
+#ifdef HAVE_GOOGLE_PROTOBUF_STUBS_LOGGING_H
+#include <google/protobuf/stubs/logging.h>
+#endif  // HAVE_GOOGLE_PROTOBUF_STUBS_LOGGING_H
+#ifdef HAVE_GOOGLE_PROTOBUF_STUBS_STL_UTIL_H
+#include <google/protobuf/stubs/stl_util.h>
+#endif  // HAVE_GOOGLE_PROTOBUF_STUBS_STL_UTIL_H
+
 #ifdef _WIN32
 // MSVC has only _snprintf, not snprintf.
 //

--- a/protoc/StrUtil.cpp
+++ b/protoc/StrUtil.cpp
@@ -41,6 +41,11 @@
 
 #include "protoc/StrUtil.h"
 
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif  // HAVE_CONFIG_H
+
+// Required for Protobuf 3.7 onwards
 #ifdef HAVE_GOOGLE_PROTOBUF_IO_STRTOD_H
 #include <google/protobuf/io/strtod.h>
 #endif  // HAVE_GOOGLE_PROTOBUF_IO_STRTOD_H

--- a/tools/rdm/TestDefinitions.py
+++ b/tools/rdm/TestDefinitions.py
@@ -1176,7 +1176,7 @@ class GetParameterDescription(ParamDescriptionTestFixture):
     self.params = self.Property('manufacturer_parameters')[:]
     if len(self.params) == 0:
       self.SetNotRun('No manufacturer params found')
-      # This case is tested in GetParamDescriptionForNonManufacturerPid
+      # This case is tested in GetParameterDescriptionForNonManufacturerPid
       return
     self._GetParam()
 


### PR DESCRIPTION
As discussed in #1550: This PR changes the snippets of OLA's protoc-plugin to emit code that compiles and works fine with Protobuf 3.11.4.
`make check` passes 100%, the C++ and Python-based examples work.
However, we might want to update the Travis files so it tests with other, possibly multiple, versions of protobuf? Let's see what Travis gives as a result here ;)

See also #1192