### PR TITLE
Explicitely link against tinfo. Needed for ncurses 6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -443,6 +443,9 @@ AM_CONDITIONAL([HAVE_LIBFTD2XX], [test "x$have_libftd2xx" = xyes])
 AC_CHECK_HEADERS([curses.h ncurses/curses.h])
 AC_CHECK_LIB([ncurses], [initscr], [have_ncurses="yes"])
 AM_CONDITIONAL([HAVE_NCURSES], [test "x$have_ncurses" = xyes])
+# Defines libncurses_LIBS that we can use to link against ncurses
+# Needed since >=ncurses-6 where -ltinfo is needed in addition to -lncurses
+PKG_CHECK_MODULES(libncurses, [ncurses >= 5])
 
 # pthread
 ACX_PTHREAD([

--- a/configure.ac
+++ b/configure.ac
@@ -445,8 +445,10 @@ AC_CHECK_LIB([ncurses], [initscr], [have_ncurses="yes"])
 AM_CONDITIONAL([HAVE_NCURSES], [test "x$have_ncurses" = xyes])
 # Defines libncurses_LIBS that we can use to link against ncurses
 # Needed since >=ncurses-6 where -ltinfo is needed in addition to -lncurses
-PKG_CHECK_MODULES(libncurses, [ncurses >= 5])
-AM_CONDITIONAL([HAVE_NCURSES_PKGCONFIG], [test "$libncurses_LIBS" != ""])
+PKG_CHECK_MODULES(libncurses, [ncurses >= 5], [have_ncurses_pkgconfig="yes"],
+  [true])
+AM_CONDITIONAL([HAVE_NCURSES_PKGCONFIG],
+  [test "x$have_ncurses_pkgconfig" = xyes])
 
 # pthread
 ACX_PTHREAD([

--- a/configure.ac
+++ b/configure.ac
@@ -445,10 +445,14 @@ AC_CHECK_LIB([ncurses], [initscr], [have_ncurses="yes"])
 AM_CONDITIONAL([HAVE_NCURSES], [test "x$have_ncurses" = xyes])
 # Defines libncurses_LIBS that we can use to link against ncurses
 # Needed since >=ncurses-6 where -ltinfo is needed in addition to -lncurses
-PKG_CHECK_MODULES(libncurses, [ncurses >= 5], [have_ncurses_pkgconfig="yes"],
-  [true])
-AM_CONDITIONAL([HAVE_NCURSES_PKGCONFIG],
-  [test "x$have_ncurses_pkgconfig" = xyes])
+PKG_CHECK_MODULES(
+                  libncurses,
+                  [ncurses >= 5],
+                  [have_ncurses_pkgconfig="yes"],
+                  [have_ncurses_pkgconfig="no"])
+AM_CONDITIONAL(
+               [HAVE_NCURSES_PKGCONFIG],
+               [test "x$have_ncurses_pkgconfig" = xyes])
 
 # pthread
 ACX_PTHREAD([

--- a/configure.ac
+++ b/configure.ac
@@ -445,13 +445,11 @@ AC_CHECK_LIB([ncurses], [initscr], [have_ncurses="yes"])
 AM_CONDITIONAL([HAVE_NCURSES], [test "x$have_ncurses" = xyes])
 # Defines libncurses_LIBS that we can use to link against ncurses
 # Needed since >=ncurses-6 where -ltinfo is needed in addition to -lncurses
-PKG_CHECK_MODULES(
-                  libncurses,
+PKG_CHECK_MODULES(libncurses,
                   [ncurses >= 5],
                   [have_ncurses_pkgconfig="yes"],
                   [have_ncurses_pkgconfig="no"])
-AM_CONDITIONAL(
-               [HAVE_NCURSES_PKGCONFIG],
+AM_CONDITIONAL([HAVE_NCURSES_PKGCONFIG],
                [test "x$have_ncurses_pkgconfig" = xyes])
 
 # pthread

--- a/configure.ac
+++ b/configure.ac
@@ -446,6 +446,7 @@ AM_CONDITIONAL([HAVE_NCURSES], [test "x$have_ncurses" = xyes])
 # Defines libncurses_LIBS that we can use to link against ncurses
 # Needed since >=ncurses-6 where -ltinfo is needed in addition to -lncurses
 PKG_CHECK_MODULES(libncurses, [ncurses >= 5])
+AM_CONDITIONAL([HAVE_NCURSES_PKGCONFIG], [test "$libncurses_LIBS" != ""])
 
 # pthread
 ACX_PTHREAD([

--- a/examples/Makefile.mk
+++ b/examples/Makefile.mk
@@ -91,9 +91,15 @@ examples_ola_uni_stats_LDADD = $(EXAMPLE_COMMON_LIBS)
 if HAVE_NCURSES
 bin_PROGRAMS += examples/ola_dmxconsole examples/ola_dmxmonitor
 examples_ola_dmxconsole_SOURCES = examples/ola-dmxconsole.cpp
-examples_ola_dmxconsole_LDADD = $(EXAMPLE_COMMON_LIBS) $(libncurses_LIBS)
 examples_ola_dmxmonitor_SOURCES = examples/ola-dmxmonitor.cpp
+if HAVE_NCURSES_PKGCONFIG
+examples_ola_dmxconsole_LDADD = $(EXAMPLE_COMMON_LIBS) $(libncurses_LIBS)
 examples_ola_dmxmonitor_LDADD = $(EXAMPLE_COMMON_LIBS) $(libncurses_LIBS)
+else
+# Fallback when pkg-config didn't know about ncurses
+examples_ola_dmxconsole_LDADD = $(EXAMPLE_COMMON_LIBS) -lncurses
+examples_ola_dmxmonitor_LDADD = $(EXAMPLE_COMMON_LIBS) -lncurses
+endif
 endif
 
 noinst_PROGRAMS += examples/ola_throughput examples/ola_latency

--- a/examples/Makefile.mk
+++ b/examples/Makefile.mk
@@ -91,9 +91,9 @@ examples_ola_uni_stats_LDADD = $(EXAMPLE_COMMON_LIBS)
 if HAVE_NCURSES
 bin_PROGRAMS += examples/ola_dmxconsole examples/ola_dmxmonitor
 examples_ola_dmxconsole_SOURCES = examples/ola-dmxconsole.cpp
-examples_ola_dmxconsole_LDADD = $(EXAMPLE_COMMON_LIBS) -lncurses
+examples_ola_dmxconsole_LDADD = $(EXAMPLE_COMMON_LIBS) $(libncurses_LIBS)
 examples_ola_dmxmonitor_SOURCES = examples/ola-dmxmonitor.cpp
-examples_ola_dmxmonitor_LDADD = $(EXAMPLE_COMMON_LIBS) -lncurses
+examples_ola_dmxmonitor_LDADD = $(EXAMPLE_COMMON_LIBS) $(libncurses_LIBS)
 endif
 
 noinst_PROGRAMS += examples/ola_throughput examples/ola_latency


### PR DESCRIPTION
This fixes a compilation error when ncurses is installed in version 6 only:
```
libtool: link: x86_64-pc-linux-gnu-g++ -I./include -I./include -Wall -Wformat -W -fvisibility-inlines-hidden -pthread -march=native -O2 -pipe -fomit-frame-pointer -std=gnu++11 -Wno-error=deprecated-declarations -pthread -Wl,-O1 -o examples/.libs/ola_dmxmonitor examples/ola-dmxmonitor.o  -Wl,--as-needed common/.libs/libolacommon.so ola/.libs/libola.so /var/tmp/portage/app-misc/ola-9999/work/ola-9999/common/.libs/libolacommon.so -lresolv -lpthread -lprotobuf -lncurses -ldl -pthread
/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: examples/ola-dmxmonitor.o: undefined reference to symbol 'resetty'
/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /lib64/libtinfo.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
I'm unable to test if this also works with ncurses 5, so I'm sending this as a draft and Travis will tell us if it's okay for ncurses 5 as well.