### PR TITLE
Protobuf AddDescriptors should be removed for all versions of protobu…

### DIFF
--- a/protoc/CppFileGenerator.cpp
+++ b/protoc/CppFileGenerator.cpp
@@ -196,8 +196,8 @@ void FileGenerator::GenerateBuildDescriptors(Printer* printer) {
       "assigndescriptorsname", GlobalAssignDescriptorsName(m_output_name));
     printer->Indent();
 
-    // No longer needed since protobuf 3.7
-#if GOOGLE_PROTOBUF_VERSION < 3007000
+    // No longer needed since protobuf 3.2
+#if GOOGLE_PROTOBUF_VERSION < 3002000
     // Make sure the file has found its way into the pool.  If a descriptor
     // is requested *during* static init then AddDescriptors() may not have
     // been called yet, so we call it manually.  Note that it's fine if

--- a/protoc/GeneratorHelpers.cpp
+++ b/protoc/GeneratorHelpers.cpp
@@ -104,8 +104,8 @@ string FilenameIdentifier(const string& filename) {
   return result;
 }
 
-// No longer needed since protobuf 3.7
-#if GOOGLE_PROTOBUF_VERSION < 3007000
+// No longer needed since protobuf 3.2
+#if GOOGLE_PROTOBUF_VERSION < 3002000
 // Return the name of the AddDescriptors() function for a given file.
 string GlobalAddDescriptorsName(const string& filename) {
   return "protobuf_AddDesc_" + FilenameIdentifier(filename);

--- a/protoc/GeneratorHelpers.h
+++ b/protoc/GeneratorHelpers.h
@@ -67,8 +67,8 @@ string StripProto(const string& filename);
 // Convert a file name into a valid identifier.
 string FilenameIdentifier(const string& filename);
 
-// No longer needed since protobuf 3.7
-#if GOOGLE_PROTOBUF_VERSION < 3007000
+// No longer needed since protobuf 3.2
+#if GOOGLE_PROTOBUF_VERSION < 3002000
 // Return the name of the AddDescriptors() function for a given file.
 string GlobalAddDescriptorsName(const string& filename);
 #endif


### PR DESCRIPTION
…f since 3.2 instead of 3.7. See #1192 and #1336

#1630 fixed building against protobuf > 3.7. However, some things fixed were also required for versions from 3.2 on already. This PR changes the version numbers of protobuf in the conditionals so it also works with protobuf 3.2 to 3.6.

Tested with protobuf 3.11.4 and all tests PASSED.