### PR TITLE
Libmicrohttpd compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,6 @@ matrix:
     - os: linux
       dist: xenial
       env: TASK='codespell'
-      python: '3.7.1'
       addons:
         apt:
           packages:
@@ -313,7 +312,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pip install --user numpy; fi
   - if [ "$TASK" = "coverage" ]; then pip install --user cpp-coveralls; fi
   - if [ "$TASK" = "flake8" ]; then pip install --user flake8; fi
-  - if [ "$TASK" = "codespell" ]; then pip3 install --user git+https://github.com/codespell-project/codespell.git; fi
+  - if [ "$TASK" = "codespell" ]; then PATH=/opt/python/3.7.1/bin:$PATH; pip3 install --user git+https://github.com/codespell-project/codespell.git; fi
   - if [ "$TASK" = "jshint" ]; then npm install -g grunt-cli; fi
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,6 @@ matrix:
     - os: linux
       dist: xenial
       env: TASK='codespell'
-      python: '3.7.1'
       addons:
         apt:
           packages:
@@ -313,7 +312,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pip install --user numpy; fi
   - if [ "$TASK" = "coverage" ]; then pip install --user cpp-coveralls; fi
   - if [ "$TASK" = "flake8" ]; then pip install --user flake8; fi
-  - if [ "$TASK" = "codespell" ]; then pip install --user git+https://github.com/codespell-project/codespell.git; fi
+  - if [ "$TASK" = "codespell" ]; then pip3 install --user git+https://github.com/codespell-project/codespell.git; fi
   - if [ "$TASK" = "jshint" ]; then npm install -g grunt-cli; fi
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -176,7 +176,9 @@ matrix:
            - moreutils
     - os: linux
       dist: xenial
-      env: TASK='codespell'
+      env:
+       - TASK='codespell'
+       - PATH=/opt/python/3.8.1/bin:$PATH
       addons:
         apt:
           packages:
@@ -312,7 +314,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pip install --user numpy; fi
   - if [ "$TASK" = "coverage" ]; then pip install --user cpp-coveralls; fi
   - if [ "$TASK" = "flake8" ]; then pip install --user flake8; fi
-  - if [ "$TASK" = "codespell" ]; then PATH=/opt/python/3.7.1/bin:$PATH; pip3 install --user git+https://github.com/codespell-project/codespell.git; fi
+  - if [ "$TASK" = "codespell" ]; then pip3 install --user git+https://github.com/codespell-project/codespell.git; fi
   - if [ "$TASK" = "jshint" ]; then npm install -g grunt-cli; fi
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,6 +177,7 @@ matrix:
     - os: linux
       dist: xenial
       env: TASK='codespell'
+      python: '3.7.1'
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,7 @@ matrix:
       dist: xenial
       env:
        - TASK='codespell'
-       - PATH=/opt/python/3.8.1/bin:$PATH
+       - PATH=/opt/python/3.7.1/bin:$PATH
       addons:
         apt:
           packages:

--- a/NEWS
+++ b/NEWS
@@ -33,7 +33,7 @@ x/y/2019 ola-0.10.8
  * Renamed RESONSE_INVALID_DESTINATION(sic) to RESPONSE_INVALID_DESTINATION in
    the ArduinoWidget code
  * Fix compatibility with ncurses 6
- * Fix compatibility with Protobuf 3.7 and newer (tested with up to 3.11.4)
+ * Fix compatibility with Protobuf 3.7 and newer (tested with up to 3.12.2)
  * Rename CircularDepdendancyException(sic) to CircularDependencyException in
    the Python RDM Test code, also the relevant comments
 

--- a/common/http/HTTPServer.cpp
+++ b/common/http/HTTPServer.cpp
@@ -89,7 +89,7 @@ const char HTTPServer::CONTENT_TYPE_OCT[] = "application/octet-stream";
  * @param value the header value
  */
 static MHD_RESULT AddHeaders(void *cls, OLA_UNUSED enum MHD_ValueKind kind,
-                      const char *key, const char *value) {
+                             const char *key, const char *value) {
   HTTPRequest *request = static_cast<HTTPRequest*>(cls);
   string key_string = key;
   string value_string = value;
@@ -110,11 +110,12 @@ static MHD_RESULT AddHeaders(void *cls, OLA_UNUSED enum MHD_ValueKind kind,
  * @param off the offset of the data
  * @param size the number of bytes available
  */
-int IteratePost(void *request_cls, OLA_UNUSED enum MHD_ValueKind kind,
-                const char *key, OLA_UNUSED const char *filename,
-                OLA_UNUSED const char *content_type,
-                OLA_UNUSED const char *transfer_encoding, const char *data,
-                OLA_UNUSED uint64_t off, OLA_UNUSED size_t size) {
+MHD_RESULT IteratePost(void *request_cls, OLA_UNUSED enum MHD_ValueKind kind,
+                       const char *key, OLA_UNUSED const char *filename,
+                       OLA_UNUSED const char *content_type,
+                       OLA_UNUSED const char *transfer_encoding,
+                       const char *data,
+                       OLA_UNUSED uint64_t off, OLA_UNUSED size_t size) {
   // libmicrohttpd has a bug where the size isn't set correctly.
   HTTPRequest *request = static_cast<HTTPRequest*>(request_cls);
   string value(data);
@@ -129,14 +130,14 @@ int IteratePost(void *request_cls, OLA_UNUSED enum MHD_ValueKind kind,
  * This sets up HTTPRequest & HTTPResponse objects and then calls
  * DispatchRequest.
  */
-static int HandleRequest(void *http_server_ptr,
-                         struct MHD_Connection *connection,
-                         const char *url,
-                         const char *method,
-                         const char *version,
-                         const char *upload_data,
-                         size_t *upload_data_size,
-                         void **ptr) {
+static MHD_RESULT HandleRequest(void *http_server_ptr,
+                                struct MHD_Connection *connection,
+                                const char *url,
+                                const char *method,
+                                const char *version,
+                                const char *upload_data,
+                                size_t *upload_data_size,
+                                void **ptr) {
   HTTPServer *http_server = static_cast<HTTPServer*>(http_server_ptr);
   HTTPRequest *request;
 

--- a/common/http/HTTPServer.cpp
+++ b/common/http/HTTPServer.cpp
@@ -88,7 +88,7 @@ const char HTTPServer::CONTENT_TYPE_OCT[] = "application/octet-stream";
  * @param key the header name
  * @param value the header value
  */
-static int AddHeaders(void *cls, OLA_UNUSED enum MHD_ValueKind kind,
+static MHD_RESULT AddHeaders(void *cls, OLA_UNUSED enum MHD_ValueKind kind,
                       const char *key, const char *value) {
   HTTPRequest *request = static_cast<HTTPRequest*>(cls);
   string key_string = key;

--- a/common/http/HTTPServer.cpp
+++ b/common/http/HTTPServer.cpp
@@ -144,8 +144,9 @@ static MHD_RESULT HandleRequest(void *http_server_ptr,
   // on the first call ptr is null
   if (*ptr == NULL) {
     request = new HTTPRequest(url, method, version, connection);
-    if (!request)
+    if (!request) {
       return MHD_NO;
+    }
 
     if (!request->Init()) {
       delete request;
@@ -157,9 +158,10 @@ static MHD_RESULT HandleRequest(void *http_server_ptr,
 
   request = static_cast<HTTPRequest*>(*ptr);
 
-  if (request->InFlight())
+  if (request->InFlight()) {
     // don't dispatch more than once
     return MHD_YES;
+  }
 
   if (request->Method() == MHD_HTTP_METHOD_GET) {
     HTTPResponse *response = new HTTPResponse(connection);
@@ -193,8 +195,9 @@ void RequestCompleted(void*,
                       struct MHD_Connection*,
                       void **request_cls,
                       enum MHD_RequestTerminationCode) {
-  if (!request_cls)
+  if (!request_cls) {
     return;
+  }
 
   delete static_cast<HTTPRequest*>(*request_cls);
   *request_cls = NULL;
@@ -240,8 +243,9 @@ bool HTTPRequest::Init() {
  * @brief Cleanup this request object
  */
 HTTPRequest::~HTTPRequest() {
-  if (m_processor)
+  if (m_processor) {
     MHD_destroy_post_processor(m_processor);
+  }
 }
 
 
@@ -291,10 +295,11 @@ void HTTPRequest::ProcessPostData(const char *data, size_t *data_size) {
 const string HTTPRequest::GetHeader(const string &key) const {
   map<string, string>::const_iterator iter = m_headers.find(key);
 
-  if (iter == m_headers.end())
+  if (iter == m_headers.end()) {
     return "";
-  else
+  } else {
     return iter->second;
+  }
 }
 
 
@@ -307,10 +312,11 @@ const string HTTPRequest::GetParameter(const string &key) const {
   const char *value = MHD_lookup_connection_value(m_connection,
                                                   MHD_GET_ARGUMENT_KIND,
                                                   key.c_str());
-  if (value)
+  if (value) {
     return string(value);
-  else
+  } else {
     return string();
+  }
 }
 
 /**
@@ -344,10 +350,11 @@ bool HTTPRequest::CheckParameterExists(const string &key) const {
 const string HTTPRequest::GetPostParameter(const string &key) const {
   map<string, string>::const_iterator iter = m_post_params.find(key);
 
-  if (iter == m_post_params.end())
+  if (iter == m_post_params.end()) {
     return "";
-  else
+  } else {
     return iter->second;
+  }
 }
 
 
@@ -391,10 +398,11 @@ int HTTPResponse::SendJson(const JsonValue &json) {
       static_cast<void*>(const_cast<char*>(output.data())),
       output.length());
   HeadersMultiMap::const_iterator iter;
-  for (iter = m_headers.begin(); iter != m_headers.end(); ++iter)
+  for (iter = m_headers.begin(); iter != m_headers.end(); ++iter) {
     MHD_add_response_header(response,
                             iter->first.c_str(),
                             iter->second.c_str());
+  }
   int ret = MHD_queue_response(m_connection, m_status_code, response);
   MHD_destroy_response(response);
   return ret;
@@ -410,10 +418,11 @@ int HTTPResponse::Send() {
   struct MHD_Response *response = HTTPServer::BuildResponse(
       static_cast<void*>(const_cast<char*>(m_data.data())),
       m_data.length());
-  for (iter = m_headers.begin(); iter != m_headers.end(); ++iter)
+  for (iter = m_headers.begin(); iter != m_headers.end(); ++iter) {
     MHD_add_response_header(response,
                             iter->first.c_str(),
                             iter->second.c_str());
+  }
   int ret = MHD_queue_response(m_connection, m_status_code, response);
   MHD_destroy_response(response);
   return ret;
@@ -448,8 +457,9 @@ HTTPServer::~HTTPServer() {
     MHD_stop_daemon(m_httpd);
 
   map<string, BaseHTTPCallback*>::const_iterator iter;
-  for (iter = m_handlers.begin(); iter != m_handlers.end(); ++iter)
+  for (iter = m_handlers.begin(); iter != m_handlers.end(); ++iter) {
     delete iter->second;
+  }
 
   if (m_default_handler) {
     delete m_default_handler;
@@ -622,17 +632,20 @@ int HTTPServer::DispatchRequest(const HTTPRequest *request,
   map<string, BaseHTTPCallback*>::iterator iter =
     m_handlers.find(request->Url());
 
-  if (iter != m_handlers.end())
+  if (iter != m_handlers.end()) {
     return iter->second->Run(request, response);
+  }
 
   map<string, static_file_info>::iterator file_iter =
     m_static_content.find(request->Url());
 
-  if (file_iter != m_static_content.end())
+  if (file_iter != m_static_content.end()) {
     return ServeStaticContent(&(file_iter->second), response);
+  }
 
-  if (m_default_handler)
+  if (m_default_handler) {
     return m_default_handler->Run(request, response);
+  }
 
   return ServeNotFound(response);
 }
@@ -647,8 +660,9 @@ int HTTPServer::DispatchRequest(const HTTPRequest *request,
 bool HTTPServer::RegisterHandler(const string &path,
                                  BaseHTTPCallback *handler) {
   map<string, BaseHTTPCallback*>::const_iterator iter = m_handlers.find(path);
-  if (iter != m_handlers.end())
+  if (iter != m_handlers.end()) {
     return false;
+  }
   pair<string, BaseHTTPCallback*> pair(path, handler);
   m_handlers.insert(pair);
   return true;
@@ -683,8 +697,9 @@ bool HTTPServer::RegisterFile(const std::string &path,
   map<string, static_file_info>::const_iterator file_iter = (
       m_static_content.find(path));
 
-  if (file_iter != m_static_content.end())
+  if (file_iter != m_static_content.end()) {
     return false;
+  }
 
   static_file_info file_info;
   file_info.file_path = file;
@@ -711,13 +726,15 @@ void HTTPServer::RegisterDefaultHandler(BaseHTTPCallback *handler) {
  */
 void HTTPServer::Handlers(vector<string> *handlers) const {
   map<string, BaseHTTPCallback*>::const_iterator iter;
-  for (iter = m_handlers.begin(); iter != m_handlers.end(); ++iter)
+  for (iter = m_handlers.begin(); iter != m_handlers.end(); ++iter) {
     handlers->push_back(iter->first);
+  }
 
   map<string, static_file_info>::const_iterator file_iter;
   for (file_iter = m_static_content.begin();
-       file_iter != m_static_content.end(); ++file_iter)
+       file_iter != m_static_content.end(); ++file_iter) {
     handlers->push_back(file_iter->first);
+  }
 }
 
 /**
@@ -811,10 +828,11 @@ int HTTPServer::ServeStaticContent(static_file_info *file_info,
   struct MHD_Response *mhd_response = BuildResponse(static_cast<void*>(data),
                                                     length);
 
-  if (!file_info->content_type.empty())
+  if (!file_info->content_type.empty()) {
     MHD_add_response_header(mhd_response,
                             MHD_HTTP_HEADER_CONTENT_TYPE,
                             file_info->content_type.c_str());
+  }
 
   int ret = MHD_queue_response(response->Connection(),
                                MHD_HTTP_OK,

--- a/common/http/HTTPServer.cpp
+++ b/common/http/HTTPServer.cpp
@@ -167,8 +167,7 @@ static MHD_RESULT HandleRequest(void *http_server_ptr,
     HTTPResponse *response = new HTTPResponse(connection);
     request->SetInFlight();
     return static_cast<MHD_RESULT>(
-      http_server->DispatchRequest(request, response)
-    );
+      http_server->DispatchRequest(request, response));
 
   } else if (request->Method() == MHD_HTTP_METHOD_POST) {
     if (*upload_data_size != 0) {
@@ -179,8 +178,7 @@ static MHD_RESULT HandleRequest(void *http_server_ptr,
     request->SetInFlight();
     HTTPResponse *response = new HTTPResponse(connection);
     return static_cast<MHD_RESULT>(
-      http_server->DispatchRequest(request, response)
-    );
+      http_server->DispatchRequest(request, response));
   }
   return MHD_NO;
 }

--- a/common/http/HTTPServer.cpp
+++ b/common/http/HTTPServer.cpp
@@ -613,8 +613,8 @@ void HTTPServer::UpdateSockets() {
 /**
  * @brief Call the appropriate handler.
  */
-int HTTPServer::DispatchRequest(const HTTPRequest *request,
-                                HTTPResponse *response) {
+MHD_RESULT HTTPServer::DispatchRequest(const HTTPRequest *request,
+                                       HTTPResponse *response) {
   map<string, BaseHTTPCallback*>::iterator iter =
     m_handlers.find(request->Url());
 

--- a/common/http/HTTPServer.cpp
+++ b/common/http/HTTPServer.cpp
@@ -164,7 +164,9 @@ static MHD_RESULT HandleRequest(void *http_server_ptr,
   if (request->Method() == MHD_HTTP_METHOD_GET) {
     HTTPResponse *response = new HTTPResponse(connection);
     request->SetInFlight();
-    return http_server->DispatchRequest(request, response);
+    return static_cast<MHD_RESULT>(
+      http_server->DispatchRequest(request, response)
+    );
 
   } else if (request->Method() == MHD_HTTP_METHOD_POST) {
     if (*upload_data_size != 0) {
@@ -174,7 +176,9 @@ static MHD_RESULT HandleRequest(void *http_server_ptr,
     }
     request->SetInFlight();
     HTTPResponse *response = new HTTPResponse(connection);
-    return http_server->DispatchRequest(request, response);
+    return static_cast<MHD_RESULT>(
+      http_server->DispatchRequest(request, response)
+    );
   }
   return MHD_NO;
 }
@@ -613,8 +617,8 @@ void HTTPServer::UpdateSockets() {
 /**
  * @brief Call the appropriate handler.
  */
-MHD_RESULT HTTPServer::DispatchRequest(const HTTPRequest *request,
-                                       HTTPResponse *response) {
+int HTTPServer::DispatchRequest(const HTTPRequest *request,
+                                HTTPResponse *response) {
   map<string, BaseHTTPCallback*>::iterator iter =
     m_handlers.find(request->Url());
 

--- a/include/ola/Logging.h
+++ b/include/ola/Logging.h
@@ -73,7 +73,7 @@
 #define OLA_WARN OLA_LOG(ola::OLA_LOG_WARN)
 
 /**
- * Provide a stream to log an infomational message.
+ * Provide a stream to log an informational message.
  * @code
  *     OLA_INFO << "Reading configs from " << config_dir;
  * @endcode

--- a/include/ola/http/HTTPServer.h
+++ b/include/ola/http/HTTPServer.h
@@ -45,6 +45,17 @@
 #include <string>
 #include <vector>
 
+// Beginning with v0.9.71, libmicrohttpd changed the return type of most
+// functions from int to enum MHD_Result
+// https://git.gnunet.org/gnunet.git/tree/src/include/gnunet_mhd_compat.h
+// proposes to define a constant for the return type so it works well
+// with all versions of libmicrohttpd
+#if MHD_VERSION >= 0x00097002
+#define MHD_RESULT enum MHD_Result
+#else
+#define MHD_RESULT int
+#endif
+
 namespace ola {
 namespace http {
 


### PR DESCRIPTION
Fix for #1650 : Define a new constant for the return type of functions passed to libmicrohttpd. Also adds some curly braces for `if`s and `for`s that were missing them (code style)