### PR TITLE
python3 rdm compat work from sdbbs 1615

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,11 +185,13 @@ protoc/ola_protoc
 protoc/ola_protoc.exe
 protoc/ola_protoc_plugin
 protoc/ola_protoc_plugin.exe
+python/PyCompileTest.sh
 python/examples/ola_rdm_set.py
 python/ola/ClientWrapperTest.sh
 python/ola/OlaClientTest.sh
 python/ola/PidStoreLocation.py
 python/ola/PidStoreTest.sh
+python/ola/RDMTest.sh
 python/ola/Version.py
 python/ola/rpc/SimpleRpcControllerTest.sh
 slp/slp_client

--- a/.travis.yml
+++ b/.travis.yml
@@ -358,8 +358,8 @@ before_install:
 after_failure:
 # Disabled as otherwise the logfile is too big
 #  - if [ -f ${TRAVIS_BUILD_DIR}/config.log ]; then cat ${TRAVIS_BUILD_DIR}/config.log; fi
-#  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log; fi
-#  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log; fi
+  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log; fi
+  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log; fi
   - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/test-suite.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/test-suite.log; fi
   - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/test-suite.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/test-suite.log; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,9 @@ matrix:
     - os: linux
       dist: xenial
       compiler: clang
-      env: TASK='compile'
-      python: '3.8'
+      env:
+      - TASK='compile'
+      - PYTHON='python3'
       addons:
         apt:
           packages:
@@ -104,7 +105,6 @@ matrix:
       dist: xenial
       compiler: gcc
       env: TASK='compile'
-      python: '2.7'
       addons:
         apt:
           packages:
@@ -306,12 +306,12 @@ before_cache:
 
 install:
 # Match the version of protobuf being installed via apt
-  - if [[ "$PROTOBUF" == "latest" ]]; then pip install --user protobuf; fi
-  - if [[ "$PROTOBUF" != "latest" ]]; then pip install --user protobuf==3.1.0; fi
+  - if [[ "$PROTOBUF" == "latest" ]]; then pip install --user protobuf; pip3 install --user protobuf; fi
+  - if [[ "$PROTOBUF" != "latest" ]]; then pip install --user protobuf==3.1.0; pip3 install --user protobuf==3.1.0; fi
   # disable until can be added to all build variants
-  #- pip install --user timeout-decorator
+  #- pip install --user timeout-decorator; pip3 install --user timeout-decorator
 # We need to use pip rather than apt on Xenial
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pip install --user numpy; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pip install --user numpy; pip3 install --user numpy; fi
   - if [ "$TASK" = "coverage" ]; then pip install --user cpp-coveralls; fi
   - if [ "$TASK" = "flake8" ]; then pip install --user flake8; fi
   - if [ "$TASK" = "codespell" ]; then pip3 install --user git+https://github.com/codespell-project/codespell.git; fi
@@ -344,9 +344,10 @@ before_install:
  - if [ "$TRAVIS_OS_NAME" == "osx" -a "$CPPUNIT" == "1.14" ]; then brew install cppunit; fi # install the latest cppunit, which needs C++11
  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PATH=/usr/local/opt/ccache/libexec:$PATH; fi # Use ccache on Mac too
 #Put back the old pip numpy we need to work
- - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install --upgrade --no-deps --force-reinstall --user numpy; fi
+ - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install --upgrade --no-deps --force-reinstall --user numpy; pip3 install --upgrade --no-deps --force-reinstall --user numpy; fi
 #Coverity doesn't work with g++ 5 or 6, so only upgrade to g++ 4.9 for that
  - if [ "$TRAVIS_OS_NAME" == "linux" -a \( "$TASK" = "compile" -o "$TASK" = "coverage" -o "$TASK" = "doxygen" \) -a "$CXX" = "g++" ]; then export CXX="ccache g++-9" CC="ccache gcc-9"; fi
+ - if [ "$PYTHON" == "python3" ]; then export PYTHON="python3"; fi
  - if [ "$TASK" = "coverity" -a "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 #Use the latest clang if we're compiling with clang
  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$CXX" = "clang++" ]; then export CXX="clang++-6.0" CC="clang-6.0"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,7 @@ matrix:
       dist: xenial
       env:
        - TASK='codespell'
-       - PATH=/opt/python/3.7.1/bin:$PATH
+       - PYTHON='python3'
       addons:
         apt:
           packages:
@@ -314,7 +314,7 @@ install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pip install --user numpy; fi
   - if [ "$TASK" = "coverage" ]; then pip install --user cpp-coveralls; fi
   - if [ "$TASK" = "flake8" ]; then pip install --user flake8; fi
-  - if [ "$TASK" = "codespell" ]; then pip3 install --user git+https://github.com/codespell-project/codespell.git; fi
+  - if [ "$TASK" = "codespell" ]; then pip install --user git+https://github.com/codespell-project/codespell.git; fi
   - if [ "$TASK" = "jshint" ]; then npm install -g grunt-cli; fi
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
       dist: xenial
       compiler: clang
       env: TASK='compile'
-      python: '2.7'
+      python: '3.8'
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -353,8 +353,8 @@ before_install:
 after_failure:
 # Disabled as otherwise the logfile is too big
 #  - if [ -f ${TRAVIS_BUILD_DIR}/config.log ]; then cat ${TRAVIS_BUILD_DIR}/config.log; fi
-  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log; fi
-  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log; fi
+#  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log; fi
+#  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log; fi
   - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/test-suite.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/test-suite.log; fi
   - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/test-suite.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/test-suite.log; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -358,8 +358,7 @@ before_install:
 after_failure:
   - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/test-suite.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/test-suite.log; fi
   - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/test-suite.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/test-suite.log; fi
-# Disabled as otherwise the logfile is too big
-#  - if [ -f ${TRAVIS_BUILD_DIR}/config.log ]; then cat ${TRAVIS_BUILD_DIR}/config.log; fi
+  - if [ -f ${TRAVIS_BUILD_DIR}/config.log ]; then cat ${TRAVIS_BUILD_DIR}/config.log; fi
   - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log; fi
   - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -356,12 +356,12 @@ before_install:
  - if [ "$TASK" == "spellintian" -o "$TASK" == "spellintian-duplicates" ]; then wget "http://old-releases.ubuntu.com/ubuntu/pool/main/l/lintian/lintian_2.5.104_all.deb"; sudo dpkg -i lintian_*.deb; sudo apt-get install -f -y; fi # Install a later lintian
 
 after_failure:
+  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/test-suite.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/test-suite.log; fi
+  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/test-suite.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/test-suite.log; fi
 # Disabled as otherwise the logfile is too big
 #  - if [ -f ${TRAVIS_BUILD_DIR}/config.log ]; then cat ${TRAVIS_BUILD_DIR}/config.log; fi
   - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/config.log; fi
   - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/config.log; fi
-  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/test-suite.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/test-suite.log; fi
-  - if [ -f ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/test-suite.log ]; then cat ${TRAVIS_BUILD_DIR}/ola-*/_build/sub/test-suite.log; fi
 
 after_success:
   - if [ "$TASK" = "coverage" ]; then coveralls --gcov /usr/bin/gcov-8 -b . -E '.*Test\.cpp$' -E '.*\.pb\.cc$' -E '.*\.pb\.cpp$' -E '.*\.pb\.h$' -E '.*\.yy\.cpp$' -E '.*\.tab\.cpp$' -E '.*\.tab\.h$' -E '.*/doxygen/examples.*$' --gcov-options '\-lp' > /dev/null; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -306,18 +306,19 @@ before_cache:
 
 install:
 # Match the version of protobuf being installed via apt
-  - if [[ "$PROTOBUF" == "latest" ]]; then pip install --user protobuf; pip3 install --user protobuf; fi
-  - if [[ "$PROTOBUF" != "latest" ]]; then pip install --user protobuf==3.1.0; pip3 install --user protobuf==3.1.0; fi
+  - if [[ "$PROTOBUF" == "latest" ]]; then pip install --user protobuf; fi
+  - if [[ "$PROTOBUF" != "latest" ]]; then pip install --user protobuf==3.1.0; fi
   # disable until can be added to all build variants
-  #- pip install --user timeout-decorator; pip3 install --user timeout-decorator
+  #- pip install --user timeout-decorator
 # We need to use pip rather than apt on Xenial
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pip install --user numpy; pip3 install --user numpy; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then pip install --user numpy; fi
   - if [ "$TASK" = "coverage" ]; then pip install --user cpp-coveralls; fi
   - if [ "$TASK" = "flake8" ]; then pip install --user flake8; fi
   - if [ "$TASK" = "codespell" ]; then pip3 install --user git+https://github.com/codespell-project/codespell.git; fi
   - if [ "$TASK" = "jshint" ]; then npm install -g grunt-cli; fi
 
 before_install:
+ - if [ "$PYTHON" == "python3" ]; then pyenv global 3.7.1 ; fi
 #Fix permissions for unbound (and possibly others)
  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if [ ! -d /usr/local/sbin ]; then sudo mkdir -p /usr/local/sbin && sudo chown -R $(whoami) /usr/local/sbin; fi; fi
 #Add a missing gnupg folder
@@ -344,10 +345,9 @@ before_install:
  - if [ "$TRAVIS_OS_NAME" == "osx" -a "$CPPUNIT" == "1.14" ]; then brew install cppunit; fi # install the latest cppunit, which needs C++11
  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PATH=/usr/local/opt/ccache/libexec:$PATH; fi # Use ccache on Mac too
 #Put back the old pip numpy we need to work
- - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install --upgrade --no-deps --force-reinstall --user numpy; pip3 install --upgrade --no-deps --force-reinstall --user numpy; fi
+ - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip install --upgrade --no-deps --force-reinstall --user numpy; fi
 #Coverity doesn't work with g++ 5 or 6, so only upgrade to g++ 4.9 for that
  - if [ "$TRAVIS_OS_NAME" == "linux" -a \( "$TASK" = "compile" -o "$TASK" = "coverage" -o "$TASK" = "doxygen" \) -a "$CXX" = "g++" ]; then export CXX="ccache g++-9" CC="ccache gcc-9"; fi
- - if [ "$PYTHON" == "python3" ]; then export PYTHON="python3"; fi
  - if [ "$TASK" = "coverity" -a "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 #Use the latest clang if we're compiling with clang
  - if [ "$TRAVIS_OS_NAME" == "linux" -a "$CXX" = "clang++" ]; then export CXX="clang++-6.0" CC="clang-6.0"; fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -149,6 +149,9 @@ built_sources =
 # Test scripts are run if BUILD_TESTS is true.
 test_scripts =
 
+# directories with python code that should be test compiled during the build
+PYTHON_BUILD_DIRS =
+
 # The includes
 # -----------------------------------------------------------------------------
 
@@ -173,6 +176,7 @@ include olad/Makefile.mk
 include protoc/Makefile.mk
 include python/Makefile.mk
 include tools/Makefile.mk
+include scripts/Makefile.mk
 
 # -----------------------------------------------------------------------------
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -175,8 +175,8 @@ include plugins/Makefile.mk
 include olad/Makefile.mk
 include protoc/Makefile.mk
 include python/Makefile.mk
-include tools/Makefile.mk
 include scripts/Makefile.mk
+include tools/Makefile.mk
 
 # -----------------------------------------------------------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -955,6 +955,7 @@ AC_CONFIG_LINKS([python/ola/__init__.py:python/ola/__init__.py
                  python/ola/MACAddress.py:python/ola/MACAddress.py
                  python/ola/OlaClient.py:python/ola/OlaClient.py
                  python/ola/PidStore.py:python/ola/PidStore.py
+                 python/ola/RDMAPI.py:python/ola/RDMAPI.py
                  python/ola/RDMConstants.py:python/ola/RDMConstants.py
                  python/ola/TestUtils.py:python/ola/TestUtils.py
                  python/ola/UID.py:python/ola/UID.py

--- a/data/Makefile.mk
+++ b/data/Makefile.mk
@@ -1,1 +1,3 @@
 include data/rdm/Makefile.mk
+
+PYTHON_BUILD_DIRS += data

--- a/include/Makefile.mk
+++ b/include/Makefile.mk
@@ -1,2 +1,6 @@
 include include/ola/Makefile.mk
 include include/olad/Makefile.mk
+
+# uncomment when include is py3 compatible
+# PYTHON_BUILD_DIRS += include
+

--- a/python/Makefile.mk
+++ b/python/Makefile.mk
@@ -3,10 +3,10 @@ include python/ola/Makefile.mk
 
 python/PyCompileTest.sh: python/Makefile.mk
 	mkdir -p $(top_builddir)/python
-# 	restore this line when py3 compat is done for whole tree
-#	echo "$(PYTHON) -m compileall -f tools scripts python include data; exit \$$?" > $(top_builddir)/python/PyCompileTest.sh
-	echo "$(PYTHON) -m compileall python data; exit \$$?" > $(top_builddir)/python/PyCompileTest.sh
+	echo "$(PYTHON) -m compileall -f $(PYTHON_BUILD_DIRS); exit \$$?" > $(top_builddir)/python/PyCompileTest.sh
 	chmod +x $(top_builddir)/python/PyCompileTest.sh
+
+PYTHON_BUILD_DIRS += python
 
 if BUILD_PYTHON_LIBS
 test_scripts += \

--- a/python/Makefile.mk
+++ b/python/Makefile.mk
@@ -5,7 +5,7 @@ python/PyCompileTest.sh: python/Makefile.mk
 	mkdir -p $(top_builddir)/python
 # 	restore this line when py3 compat is done for whole tree
 #	echo "$(PYTHON) -m compileall -f tools scripts python include data; exit \$$?" > $(top_builddir)/python/PyCompileTest.sh
-	echo "$(PYTHON) -m compileall -f python data; exit \$$?" > $(top_builddir)/python/PyCompileTest.sh
+	echo "$(PYTHON) -m compileall python data; exit \$$?" > $(top_builddir)/python/PyCompileTest.sh
 	chmod +x $(top_builddir)/python/PyCompileTest.sh
 
 if BUILD_PYTHON_LIBS

--- a/python/Makefile.mk
+++ b/python/Makefile.mk
@@ -1,2 +1,17 @@
 include python/examples/Makefile.mk
 include python/ola/Makefile.mk
+
+python/PyCompileTest.sh: python/Makefile.mk
+	mkdir -p $(top_builddir)/python
+# 	restore this line when py3 compat is done for whole tree
+#	echo "$(PYTHON) -m compileall -f tools scripts python include data; exit \$$?" > $(top_builddir)/python/PyCompileTest.sh
+	echo "$(PYTHON) -m compileall -f python data; exit \$$?" > $(top_builddir)/python/PyCompileTest.sh
+	chmod +x $(top_builddir)/python/PyCompileTest.sh
+
+if BUILD_PYTHON_LIBS
+test_scripts += \
+    python/PyCompileTest.sh
+endif
+
+CLEANFILES += \
+    python/PyCompileTest.sh

--- a/python/Makefile.mk
+++ b/python/Makefile.mk
@@ -3,7 +3,7 @@ include python/ola/Makefile.mk
 
 python/PyCompileTest.sh: python/Makefile.mk
 	mkdir -p $(top_builddir)/python
-	echo "$(PYTHON) -m compileall -f $(PYTHON_BUILD_DIRS); exit \$$?" > $(top_builddir)/python/PyCompileTest.sh
+	echo "$(PYTHON) -m compileall $(PYTHON_BUILD_DIRS); exit \$$?" > $(top_builddir)/python/PyCompileTest.sh
 	chmod +x $(top_builddir)/python/PyCompileTest.sh
 
 PYTHON_BUILD_DIRS += python

--- a/python/examples/ola_rdm_get.py
+++ b/python/examples/ola_rdm_get.py
@@ -18,6 +18,7 @@
 
 '''Get a PID from a UID.'''
 
+from __future__ import print_function
 import cmd
 import getopt
 import os.path
@@ -459,7 +460,7 @@ def main():
   try:
     PidStore.GetStore(pid_location)
   except PidStore.MissingPLASAPIDs as e:
-    print e
+    print(e)
     sys.exit()
 
   controller = InteractiveModeController(universe,

--- a/python/ola/ClientWrapperTest.py
+++ b/python/ola/ClientWrapperTest.py
@@ -17,6 +17,7 @@
 # Copyright (C) 2019 Bruce Lowekamp
 
 import array
+import binascii
 import datetime
 import socket
 # import timeout_decorator
@@ -208,7 +209,13 @@ class ClientWrapperTest(unittest.TestCase):
 
     def DataCallback(self):
       data = sockets[1].recv(4096)
-      self.assertTrue(len(data) > 100)
+      expected = binascii.unhexlify(
+        "7d000010080110001a0d557064617465446d784461746122680801126400000"
+        "000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000"
+        "000000")
+      self.assertEqual(data, expected)
       results.gotdata = True
       wrapper.AddEvent(0, wrapper.Stop)
 

--- a/python/ola/ClientWrapperTest.py
+++ b/python/ola/ClientWrapperTest.py
@@ -215,7 +215,10 @@ class ClientWrapperTest(unittest.TestCase):
         "000000000000000000000000000000000000000000000000000000000000000"
         "000000000000000000000000000000000000000000000000000000000000000"
         "000000")
-      self.assertEqual(data, expected)
+      self.assertEqual(data, expected,
+                       msg="Regression check failed. If protocol change "
+                       "was intended set expected to: " +
+                       str(binascii.hexlify(data)))
       results.gotdata = True
       wrapper.AddEvent(0, wrapper.Stop)
 

--- a/python/ola/Makefile.mk
+++ b/python/ola/Makefile.mk
@@ -104,4 +104,5 @@ CLEANFILES += \
     python/ola/ClientWrapperTest.sh \
     python/ola/OlaClientTest.sh \
     python/ola/PidStoreTest.sh \
-    python/ola/RDMTest.sh
+    python/ola/RDMTest.sh \
+    python/ola/__pycache__/*

--- a/python/ola/Makefile.mk
+++ b/python/ola/Makefile.mk
@@ -79,6 +79,7 @@ dist_check_SCRIPTS += \
     python/ola/MACAddressTest.py \
     python/ola/OlaClientTest.py \
     python/ola/PidStoreTest.py \
+    python/ola/RDMTest.py \
     python/ola/TestUtils.py \
     python/ola/UIDTest.py
 
@@ -89,6 +90,7 @@ test_scripts += \
     python/ola/MACAddressTest.py \
     python/ola/OlaClientTest.sh \
     python/ola/PidStoreTest.sh \
+    python/ola/RDMTest.py \
     python/ola/UIDTest.py
 endif
 

--- a/python/ola/Makefile.mk
+++ b/python/ola/Makefile.mk
@@ -73,6 +73,11 @@ python/ola/PidStoreTest.sh: python/ola/Makefile.mk
 	echo "PYTHONPATH=${top_builddir}/python TESTDATADIR=$(srcdir)/common/rdm/testdata $(PYTHON) ${srcdir}/python/ola/PidStoreTest.py; exit \$$?" > $(top_builddir)/python/ola/PidStoreTest.sh
 	chmod +x $(top_builddir)/python/ola/PidStoreTest.sh
 
+python/ola/RDMTest.sh: python/ola/Makefile.mk
+	mkdir -p $(top_builddir)/python/ola
+	echo "PYTHONPATH=${top_builddir}/python PIDSTOREDIR=$(srcdir)/data/rdm $(PYTHON) ${srcdir}/python/ola/RDMTest.py; exit \$$?" > $(top_builddir)/python/ola/RDMTest.sh
+	chmod +x $(top_builddir)/python/ola/RDMTest.sh
+
 dist_check_SCRIPTS += \
     python/ola/DUBDecoderTest.py \
     python/ola/ClientWrapperTest.py \
@@ -90,7 +95,7 @@ test_scripts += \
     python/ola/MACAddressTest.py \
     python/ola/OlaClientTest.sh \
     python/ola/PidStoreTest.sh \
-    python/ola/RDMTest.py \
+    python/ola/RDMTest.sh \
     python/ola/UIDTest.py
 endif
 
@@ -98,4 +103,5 @@ CLEANFILES += \
     python/ola/*.pyc \
     python/ola/ClientWrapperTest.sh \
     python/ola/OlaClientTest.sh \
-    python/ola/PidStoreTest.sh
+    python/ola/PidStoreTest.sh \
+    python/ola/RDMTest.sh

--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -1360,8 +1360,7 @@ class OlaClient(Ola_pb2.OlaClientService):
     if sys.version >= '3.2':
       request.data = eval(data)[0] if data else bytes(data, 'utf-8')
     else:
-      # eval(data)[0] if data else data - broke (MultiDim), 2019-10-31
-      request.data = data  # works, 2019-10-31
+      request.data = data
     request.is_set = set
     request.include_raw_response = include_frames
     try:

--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -1224,7 +1224,7 @@ class OlaClient(Ola_pb2.OlaClientService):
       raise OLADNotRunningException()
     return True
 
-  def RDMGet(self, universe, uid, sub_device, param_id, callback, data='',
+  def RDMGet(self, universe, uid, sub_device, param_id, callback, data=b'',
              include_frames=False):
     """Send an RDM get command.
 
@@ -1246,7 +1246,7 @@ class OlaClient(Ola_pb2.OlaClientService):
     return self._RDMMessage(universe, uid, sub_device, param_id, callback,
                             data, include_frames)
 
-  def RDMSet(self, universe, uid, sub_device, param_id, callback, data='',
+  def RDMSet(self, universe, uid, sub_device, param_id, callback, data=b'',
              include_frames=False):
     """Send an RDM set command.
 
@@ -1274,7 +1274,7 @@ class OlaClient(Ola_pb2.OlaClientService):
                           sub_device,
                           param_id,
                           callback,
-                          data='',
+                          data=b'',
                           include_frames=False):
     """Send an RDM Discovery command. Unless you're writing RDM tests you
       shouldn't need to use this.
@@ -1357,10 +1357,7 @@ class OlaClient(Ola_pb2.OlaClientService):
     request.uid.device_id = uid.device_id
     request.sub_device = sub_device
     request.param_id = param_id
-    if sys.version >= '3.2':
-      request.data = eval(data)[0] if data else bytes(data, 'utf-8')
-    else:
-      request.data = data
+    request.data = data
     request.is_set = set
     request.include_raw_response = include_frames
     try:

--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -1357,7 +1357,11 @@ class OlaClient(Ola_pb2.OlaClientService):
     request.uid.device_id = uid.device_id
     request.sub_device = sub_device
     request.param_id = param_id
-    request.data = data
+    if sys.version >= '3.2':
+      request.data = eval(data)[0] if data else bytes(data, 'utf-8')
+    else:
+      # eval(data)[0] if data else data - broke (MultiDim), 2019-10-31
+      request.data = data  # works, 2019-10-31
     request.is_set = set
     request.include_raw_response = include_frames
     try:

--- a/python/ola/OlaClient.py
+++ b/python/ola/OlaClient.py
@@ -429,6 +429,12 @@ class RequestStatus(object):
 
 
 class RDMNack(object):
+  """Nack response to a request.
+
+      Individual NACK response reasons can be access as attrs, e.g.
+      RMDNack.NR_FORMAT_ERROR
+      """
+
   NACK_SYMBOLS_TO_VALUES = {
     'NR_UNKNOWN_PID': (0, 'Unknown PID'),
     'NR_FORMAT_ERROR': (1, 'Format Error'),

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -669,9 +669,9 @@ class String(Atom):
       raise UnpackException(e)
 
     if sys.version >= '3.2':
-      return value[0].rstrip(bytes('\x00', 'utf-8')).decode('utf-8')
+      return value[0].rstrip(b'\x00').decode('utf-8')
     else:
-      return value[0].rstrip('\x00')
+      return value[0].rstrip(b'\x00')
 
   def GetDescription(self, indent=0):
     indent = ' ' * indent

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -458,7 +458,7 @@ class IntAtom(FixedSizeAtom):
         raise ArgsValidationError(
             'Conversion will lose data: %d -> %d' %
             (new_value, (new_value / multiplier * multiplier)))
-      new_value = new_value / multiplier
+      new_value = int(new_value / multiplier)
 
     else:
       try:
@@ -645,7 +645,10 @@ class String(Atom):
                                 (self.name, self.min))
 
     try:
-      data = struct.unpack('%ds' % arg_size, arg)
+      if sys.version >= '3.2':
+        data = struct.unpack('%ds' % arg_size, bytes(arg, 'utf8'))
+      else:
+        data = struct.unpack('%ds' % arg_size, arg)
     except struct.error as e:
       raise ArgsValidationError("Can't pack data: %s" % e)
     return data[0], 1
@@ -665,7 +668,10 @@ class String(Atom):
     except struct.error as e:
       raise UnpackException(e)
 
-    return value[0].rstrip('\x00')
+    if sys.version >= '3.2':
+      return value[0].rstrip(bytes('\x00', 'utf-8')).decode('utf-8')
+    else:
+      return value[0].rstrip('\x00')
 
   def GetDescription(self, indent=0):
     indent = ' ' * indent
@@ -807,7 +813,10 @@ class Group(Atom):
         raise ArgsValidationError('Too many arguments, expected %d, got %d' %
                                   (arg_offset, len(args)))
 
-      return ''.join(data), arg_offset
+      if sys.version >= '3.2':
+        return ''.join(str(data)), arg_offset
+      else:
+        return ''.join(data), arg_offset
 
     elif self._group_size == 0:
       return '', 0
@@ -823,7 +832,7 @@ class Group(Atom):
       if arg_offset < len(args):
         raise ArgsValidationError('Too many arguments, expected %d, got %d' %
                                   (arg_offset, len(args)))
-      return ''.join(data), arg_offset
+      return ''.join(str(data)), arg_offset
 
   def Unpack(self, data):
     """Unpack binary data.

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -832,7 +832,10 @@ class Group(Atom):
       if arg_offset < len(args):
         raise ArgsValidationError('Too many arguments, expected %d, got %d' %
                                   (arg_offset, len(args)))
-      return ''.join(str(data)), arg_offset
+      if sys.version >= '3.2':
+        return ''.join(str(data)), arg_offset
+      else:
+        return ''.join(data), arg_offset
 
   def Unpack(self, data):
     """Unpack binary data.

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -813,13 +813,10 @@ class Group(Atom):
         raise ArgsValidationError('Too many arguments, expected %d, got %d' %
                                   (arg_offset, len(args)))
 
-      if sys.version >= '3.2':
-        return ''.join(str(data)), arg_offset
-      else:
-        return ''.join(data), arg_offset
+      return b''.join(data), arg_offset
 
     elif self._group_size == 0:
-      return '', 0
+      return b'', 0
     else:
       # this could be groups of fields, but we don't support that yet
       data = []
@@ -832,10 +829,7 @@ class Group(Atom):
       if arg_offset < len(args):
         raise ArgsValidationError('Too many arguments, expected %d, got %d' %
                                   (arg_offset, len(args)))
-      if sys.version >= '3.2':
-        return ''.join(str(data)), arg_offset
-      else:
-        return ''.join(data), arg_offset
+      return b''.join(data), arg_offset
 
   def Unpack(self, data):
     """Unpack binary data.

--- a/python/ola/PidStore.py
+++ b/python/ola/PidStore.py
@@ -53,7 +53,7 @@ class Error(Exception):
 
 
 class InvalidPidFormat(Error):
-  "Indicates the PID data file was invalid."""
+  """Indicates the PID data file was invalid."""
 
 
 class PidStructureException(Error):

--- a/python/ola/PidStoreTest.py
+++ b/python/ola/PidStoreTest.py
@@ -245,7 +245,7 @@ class PidStoreTest(unittest.TestCase):
 
     # invalid month > 255
     with self.assertRaises(PidStore.ArgsValidationError):
-      args = ["2020", "255", "20", "20", "20", "20"]
+      args = ["2020", "256", "20", "20", "20", "20"]
       blob = pid.Pack(args, PidStore.RDM_SET)
 
     # invalid negative month

--- a/python/ola/PidStoreTest.py
+++ b/python/ola/PidStoreTest.py
@@ -226,7 +226,10 @@ class PidStoreTest(unittest.TestCase):
 
     args = ["2020", "6", "20", "20", "20", "20"]
     blob = pid.Pack(args, PidStore.RDM_SET)
-    self.assertTrue(len(blob) > 1)
+    decoded = pid._requests.get(PidStore.RDM_SET).Unpack(blob)[0]
+    self.assertEqual(decoded, {'year': 2020, 'month': 6,
+                               'day': 20, 'hour': 20,
+                               'minute': 20, 'second': 20})
 
     # invalid year (2002 < 2003)
     with self.assertRaises(PidStore.ArgsValidationError):
@@ -257,7 +260,8 @@ class PidStoreTest(unittest.TestCase):
     pid = store.GetName("LANGUAGE_CAPABILITIES")
     args = ["en"]
     blob = pid._responses.get(PidStore.RDM_GET).Pack(args)[0]
-    self.assertTrue(len(blob) > 1)
+    decoded = pid.Unpack(blob, PidStore.RDM_GET)
+    self.assertEqual(decoded, {'languages': [{'language': 'en'}]})
 
     with self.assertRaises(PidStore.ArgsValidationError):
       args = ["e"]
@@ -271,6 +275,7 @@ class PidStoreTest(unittest.TestCase):
     pid = store.GetName("STATUS_ID_DESCRIPTION")
     args = [""]
     blob = pid._responses.get(PidStore.RDM_GET).Pack(args)[0]
+    self.assertEqual(len(blob), 0)
     decoded = pid.Unpack(blob, PidStore.RDM_GET)
     self.assertEqual(decoded['label'], "")
 

--- a/python/ola/PidStoreTest.py
+++ b/python/ola/PidStoreTest.py
@@ -16,6 +16,7 @@
 # PidStoreTest.py
 # Copyright (C) 2020 Bruce Lowekamp
 
+import binascii
 import os
 import unittest
 import ola.PidStore as PidStore
@@ -224,13 +225,16 @@ class PidStoreTest(unittest.TestCase):
 
     pid = store.GetName("REAL_TIME_CLOCK")
 
-    args = ["2020", "6", "20", "20", "20", "20"]
+    # first check encoding of valid RTC data
+    args = ["2020", "6", "20", "21", "22", "23"]
     blob = pid.Pack(args, PidStore.RDM_SET)
+    self.assertEqual(blob, binascii.unhexlify("07e40614151617"))
     decoded = pid._requests.get(PidStore.RDM_SET).Unpack(blob)[0]
     self.assertEqual(decoded, {'year': 2020, 'month': 6,
-                               'day': 20, 'hour': 20,
-                               'minute': 20, 'second': 20})
+                               'day': 20, 'hour': 21,
+                               'minute': 22, 'second': 23})
 
+    # next check that ranges are being enforced properly
     # invalid year (2002 < 2003)
     with self.assertRaises(PidStore.ArgsValidationError):
       args = ["2002", "6", "20", "20", "20", "20"]

--- a/python/ola/RDMTest.py
+++ b/python/ola/RDMTest.py
@@ -58,7 +58,10 @@ class RDMTest(unittest.TestCase):
       expected = binascii.unhexlify(
         "29000010080110001a0a52444d436f6d6d616e6422170801120908f0f4011500"
         "ffffff180020602a0030003800")
-      self.assertEqual(data, expected)
+      self.assertEqual(data, expected,
+                       msg="Regression check failed. If protocol change "
+                       "was intended set expected to: " +
+                       str(binascii.hexlify(data)))
       results.gotrequest = True
       response = binascii.unhexlify(
         "3f0000100802100022390800100018002213010000017fff0000000300050204"

--- a/python/ola/RDMTest.py
+++ b/python/ola/RDMTest.py
@@ -17,6 +17,7 @@
 # Copyright (C) 2019 Bruce Lowekamp
 
 import binascii
+import os
 import socket
 # import timeout_decorator
 import unittest
@@ -30,6 +31,7 @@ from ola.UID import UID
 
 __author__ = 'bruce@lowekamp.net (Bruce Lowekamp)'
 
+global pidStorePath
 
 class RDMTest(unittest.TestCase):
   # @timeout_decorator.timeout(2)
@@ -39,7 +41,7 @@ class RDMTest(unittest.TestCase):
     sends fixed response message."""
     sockets = socket.socketpair()
     wrapper = ClientWrapper(sockets[0])
-    pid_store = PidStore.GetStore()
+    pid_store = PidStore.GetStore(pidStorePath)
     client = wrapper.Client()
     rdm_api = RDMAPI(client, pid_store)
 
@@ -97,4 +99,5 @@ class RDMTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+  pidStorePath = (os.environ.get('PIDSTOREDIR', "../data/rdm"))
   unittest.main()

--- a/python/ola/RDMTest.py
+++ b/python/ola/RDMTest.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# ClientWrapperTest.py
+# Copyright (C) 2019 Bruce Lowekamp
+
+import binascii
+import socket
+# import timeout_decorator
+import unittest
+from ola import PidStore
+from ola.ClientWrapper import ClientWrapper
+from ola.RDMAPI import RDMAPI
+from ola.UID import UID
+
+
+"""Test cases for RDM device commands."""
+
+__author__ = 'bruce@lowekamp.net (Bruce Lowekamp)'
+
+
+class RDMTest(unittest.TestCase):
+  # @timeout_decorator.timeout(2)
+  def testGetWithResponse(self):
+    """uses client to send an RDM get with mocked olad.
+    Regression test that confirms sent message is correct and
+    sends fixed response message."""
+    sockets = socket.socketpair()
+    wrapper = ClientWrapper(sockets[0])
+    pid_store = PidStore.GetStore()
+    client = wrapper.Client()
+    rdm_api = RDMAPI(client, pid_store)
+
+    class results:
+      gotrequest = False
+      gotresponse = False
+
+    def DataCallback(self):
+      # request and response for
+      # ola_rdm_get.py -u 1 --uid 7a70:ffffff00 device_info
+      # against olad dummy plugin
+      data = sockets[1].recv(4096)
+      expected = binascii.unhexlify(
+        "29000010080110001a0a52444d436f6d6d616e6422170801120908f0f4011500"
+        "ffffff180020602a0030003800")
+      self.assertEqual(data, expected)
+      results.gotrequest = True
+      response = binascii.unhexlify(
+        "3f0000100802100022390800100018002213010000017fff0000000300050204"
+        "00010000032860300038004a0908f0f4011500ffffff520908f0f40115ac1100"
+        "02580a")
+      sent_bytes = sockets[1].send(response)
+      self.assertEqual(sent_bytes, len(response))
+
+    def ResponseCallback(self, response, data, unpack_exception):
+      results.gotresponse = True
+      self.assertEqual(response.response_type, client.RDM_ACK)
+      self.assertEqual(response.pid, 0x60)
+      self.assertEqual(data["dmx_footprint"], 5)
+      self.assertEqual(data["software_version"], 3)
+      self.assertEqual(data["personality_count"], 4)
+      self.assertEqual(data["device_model"], 1)
+      self.assertEqual(data["current_personality"], 2)
+      self.assertEqual(data["protocol_major"], 1)
+      self.assertEqual(data["protocol_minor"], 0)
+      self.assertEqual(data["product_category"], 32767)
+      self.assertEqual(data["dmx_start_address"], 1)
+      self.assertEqual(data["sub_device_count"], 0)
+      self.assertEqual(data["sensor_count"], 3)
+      wrapper.AddEvent(0, wrapper.Stop)
+
+    wrapper._ss.AddReadDescriptor(sockets[1], lambda: DataCallback(self))
+
+    uid = UID.FromString("7a70:ffffff00")
+    pid = pid_store.GetName("DEVICE_INFO", uid.manufacturer_id)
+    rdm_api.Get(1, uid, 0, pid, lambda x, y, z: ResponseCallback(self, x, y, z))
+
+    wrapper.Run()
+
+    sockets[0].close()
+    sockets[1].close()
+
+    self.assertTrue(results.gotrequest)
+    self.assertTrue(results.gotresponse)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/python/ola/RDMTest.py
+++ b/python/ola/RDMTest.py
@@ -202,9 +202,7 @@ class RDMTest(unittest.TestCase):
       results.got_response = True
       self.assertEqual(response.response_type, client.RDM_NACK_REASON)
       self.assertEqual(response.pid, 0xe0)
-      self.assertEqual(response.nack_reason,
-                       RDMNack.LookupCode(RDMNack.NACK_SYMBOLS_TO_VALUES
-                                          ['NR_DATA_OUT_OF_RANGE'][0]))
+      self.assertEqual(response.nack_reason, RDMNack.NR_DATA_OUT_OF_RANGE)
       wrapper.AddEvent(0, wrapper.Stop)
 
     wrapper._ss.AddReadDescriptor(sockets[1], lambda: DataCallback(self))

--- a/python/ola/RDMTest.py
+++ b/python/ola/RDMTest.py
@@ -23,6 +23,7 @@ import socket
 import unittest
 from ola import PidStore
 from ola.ClientWrapper import ClientWrapper
+from ola.OlaClient import RDMNack
 from ola.RDMAPI import RDMAPI
 from ola.UID import UID
 
@@ -201,6 +202,9 @@ class RDMTest(unittest.TestCase):
       results.got_response = True
       self.assertEqual(response.response_type, client.RDM_NACK_REASON)
       self.assertEqual(response.pid, 0xe0)
+      self.assertEqual(response.nack_reason,
+                       RDMNack.LookupCode(RDMNack.NACK_SYMBOLS_TO_VALUES
+                                          ['NR_DATA_OUT_OF_RANGE'][0]))
       wrapper.AddEvent(0, wrapper.Stop)
 
     wrapper._ss.AddReadDescriptor(sockets[1], lambda: DataCallback(self))

--- a/python/ola/RDMTest.py
+++ b/python/ola/RDMTest.py
@@ -13,7 +13,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
-# ClientWrapperTest.py
+# RDMTest.py
 # Copyright (C) 2019 Bruce Lowekamp
 
 import binascii
@@ -32,6 +32,7 @@ from ola.UID import UID
 __author__ = 'bruce@lowekamp.net (Bruce Lowekamp)'
 
 global pidStorePath
+
 
 class RDMTest(unittest.TestCase):
   # @timeout_decorator.timeout(2)

--- a/python/ola/RDMTest.py
+++ b/python/ola/RDMTest.py
@@ -134,7 +134,7 @@ class RDMTest(unittest.TestCase):
       response = binascii.unhexlify(
         "3d0000100802100022370800100018002210020005506572736f6e616c697479"
         "203228e101300038004a0908f0f4011500ffffff520908f0f40115ac107de058"
-        "29" )
+        "29")
       sent_bytes = sockets[1].send(response)
       self.assertEqual(sent_bytes, len(response))
 

--- a/python/ola/rpc/Makefile.mk
+++ b/python/ola/rpc/Makefile.mk
@@ -29,4 +29,5 @@ python/ola/rpc/SimpleRpcControllerTest.sh: python/ola/rpc/Makefile.mk
 	chmod +x $(top_builddir)/python/ola/rpc/SimpleRpcControllerTest.sh
 
 CLEANFILES += python/ola/rpc/SimpleRpcControllerTest.sh \
-              python/ola/rpc/*.pyc
+              python/ola/rpc/*.pyc \
+              python/ola/rpc/__pycache__/*

--- a/python/ola/rpc/StreamRpcChannel.py
+++ b/python/ola/rpc/StreamRpcChannel.py
@@ -51,8 +51,7 @@ class StreamRpcChannel(service.RpcChannel):
   SIZE_MASK = 0x0fffffff
   RECEIVE_BUFFER_SIZE = 8192
 
-  def __init__(self, socket, service_impl, close_callback=None,
-               log_msgs=False):
+  def __init__(self, socket, service_impl, close_callback=None):
     """Create a new StreamRpcChannel.
 
     Args:
@@ -68,7 +67,9 @@ class StreamRpcChannel(service.RpcChannel):
     self._expected_size = None  # The size of the message we're receiving
     self._skip_message = False  # Skip the current message
     self._close_callback = close_callback
-    self._log_msgs = log_msgs  # logs sent and rcvd messages for mocks
+    self._log_msgs = False  # set to enable wire message logging
+    if self._log_msgs:
+      logging.basicConfig(level=logging.DEBUG)
 
   def SocketReady(self):
     """Read data from the socket and handle when we get a full message.

--- a/python/ola/rpc/StreamRpcChannel.py
+++ b/python/ola/rpc/StreamRpcChannel.py
@@ -15,6 +15,7 @@
 # StreamRpcChannel.py
 # Copyright (C) 2005 Simon Newton
 
+import binascii
 import logging
 import struct
 from google.protobuf import service
@@ -170,6 +171,7 @@ class StreamRpcChannel(service.RpcChannel):
     data = message.SerializeToString()
     # combine into one buffer to send so we avoid sending two packets
     data = self._EncodeHeader(len(data)) + data
+    logging.debug("send->" + str(binascii.hexlify(data)))
 
     sent_bytes = self._socket.send(data)
     if sent_bytes != len(data):
@@ -240,6 +242,7 @@ class StreamRpcChannel(service.RpcChannel):
         if not raw_header:
           # not enough data yet
           return
+        logging.debug("recvhdr<-" + str(binascii.hexlify(raw_header)))
         header = struct.unpack('=L', raw_header)[0]
         version, size = self._DecodeHeader(header)
 
@@ -254,6 +257,7 @@ class StreamRpcChannel(service.RpcChannel):
         # not enough data yet
         return
 
+      logging.debug("recvmsg<-" + str(binascii.hexlify(data)))
       if not self._skip_message:
         self._HandleNewMessage(data)
       self._expected_size = 0

--- a/scripts/Makefile.mk
+++ b/scripts/Makefile.mk
@@ -1,0 +1,2 @@
+# uncomment when scripts is py3 compatible
+# PYTHON_BUILD_DIRS += scripts

--- a/tools/Makefile.mk
+++ b/tools/Makefile.mk
@@ -13,3 +13,6 @@ dist_noinst_DATA += \
     tools/ola_mon/index.html \
     tools/ola_mon/ola_mon.conf \
     tools/ola_mon/ola_mon.py
+
+# uncomment when tools is py3 compatible
+# PYTHON_BUILD_DIRS += tools


### PR DESCRIPTION
This takes the patches from @sdbbs required for the python rdm support to be py3 compatible.  Just a minor formatting change, remove the comparison fix, and fixing the rdm_get example for py3.

This has been manually tested using the python/examples code and the dummy plugin with olad.  Looking at code coverage, it still didn't exercise some of the RDM Frame code that I found concerning (discussed in #1615) but I don't actually know what paths would trigger that code, and don't know that I have the right devices to exercise it anyway.

Ideally this would have tests included.   I looked a bit at mocking, and I suspect it's possible by supplying a socket and sending packets manual, but pretty ugly and brittle.  My preferred way to automate it would be to stand up olad with the dummy plugin and use the python examples/python tests against the running olad.  AFAIK there aren't any automated tests that do that at present (except the ola client tests that use the olad library internally), and I decided against doing that without discussion.
