### PR TITLE
[RFC] Record v2

### DIFF
--- a/examples/ShowLoader.cpp
+++ b/examples/ShowLoader.cpp
@@ -81,6 +81,7 @@ bool ShowLoader::Load() {
 void ShowLoader::Reset() {
   m_show_file.clear();
   m_show_file.seekg(0, std::ios::beg);
+  m_line = 0;
   // skip over the first line
   string line;
   ReadLine(&line);

--- a/examples/ShowLoader.cpp
+++ b/examples/ShowLoader.cpp
@@ -136,12 +136,12 @@ ShowLoader::State ShowLoader::NextFrame(unsigned int *universe,
   ola::StringSplit(line, &inputs);
 
   if (inputs.size() != 2) {
-    OLA_WARN << "Line " << m_line << " invalid: " << line;
+    OLA_WARN << "Line " << GetCurrentLineNumber() << " invalid: " << line;
     return INVALID_LINE;
   }
 
   if (!ola::StringToInt(inputs[0], universe, true)) {
-    OLA_WARN << "Line " << m_line << " invalid: " << line;
+    OLA_WARN << "Line " << GetCurrentLineNumber() << " invalid: " << line;
     return INVALID_LINE;
   }
 

--- a/examples/ShowLoader.cpp
+++ b/examples/ShowLoader.cpp
@@ -246,9 +246,9 @@ ShowLoader::State ShowLoaderV2::NextTimeout(unsigned int *timeout) {
 
   vector<string> tv;
   ola::StringSplit(line, &tv);
-  int sec, usec;
+  int sec, msec;
   if (!ola::StringToInt(tv[0], &sec, true) ||
-      !ola::StringToInt(tv[1], &usec, true)) {
+      !ola::StringToInt(tv[1], &msec, true)) {
     OLA_WARN << "Timestamp component at line " << GetCurrentLineNumber()
              << " invalid: " << line;
     return INVALID_LINE;
@@ -256,7 +256,10 @@ ShowLoader::State ShowLoaderV2::NextTimeout(unsigned int *timeout) {
 
   struct timeval stv;
   stv.tv_sec = sec;
-  stv.tv_usec = usec;
+  stv.tv_usec = msec;
+  // Do mult separately to guarantee a cast to a wider type if int is not wide
+  // enough.
+  stv.tv_usec *= 1000;
   ola::TimeStamp ts(stv);
 
   *timeout = (ts - m_last_entry_time).InMilliSeconds();

--- a/examples/ShowLoader.cpp
+++ b/examples/ShowLoader.cpp
@@ -272,17 +272,17 @@ ShowLoader::State ShowLoaderV2::NextTimeout(unsigned int *timeout) {
 
 auto_ptr<ShowLoader> LoadShow(const string &filename) {
   typedef auto_ptr<ShowLoader> slp;
-  slp out;
+  slp null;
   {
     slp sl(new ShowLoaderV1(filename));
     if (sl->Load())
-      out = sl;
+      return sl;
   }
   {
     slp sl(new ShowLoaderV2(filename));
     if (sl->Load())
-      out = sl;
+      return sl;
   }
 
-  return out;
+  return null;
 }

--- a/examples/ShowLoader.h
+++ b/examples/ShowLoader.h
@@ -20,6 +20,7 @@
 
 #include <ola/DmxBuffer.h>
 
+#include <memory>
 #include <string>
 #include <fstream>
 
@@ -41,7 +42,7 @@ struct ShowEntry {
 class ShowLoader {
  public:
   explicit ShowLoader(const std::string &filename);
-  ~ShowLoader();
+  virtual ~ShowLoader();
 
   typedef enum {
     OK,
@@ -50,20 +51,31 @@ class ShowLoader {
   } State;
 
   bool Load();
-  void Reset();
+  virtual void Reset();
   unsigned int GetCurrentLineNumber() const;
 
   State NextEntry(ShowEntry *entry);
+
+ protected:
+  void ReadLine(std::string *line);
 
  private:
   const std::string m_filename;
   std::ifstream m_show_file;
   unsigned int m_line;
 
-  static const char OLA_SHOW_HEADER[];
-
-  void ReadLine(std::string *line);
-  State NextTimeout(unsigned int *timeout);
-  State NextFrame(unsigned int *universe, ola::DmxBuffer *data);
+  virtual bool VerifyVersion() = 0;
+  virtual State NextTimeout(unsigned int *timeout) = 0;
+  virtual State NextFrame(unsigned int *universe, ola::DmxBuffer *data);
 };
+
+/**
+ * LoadShow return an appropriate \c ShowLoader based on the format of the
+ * showfile.
+ *
+ * @param filename name of file
+ * @return Pointer to show loader. \c NULL if no show loader can be found.
+ */
+std::auto_ptr<ShowLoader> LoadShow(const std::string &filename);
+
 #endif  // EXAMPLES_SHOWLOADER_H_

--- a/examples/ShowLoader.h
+++ b/examples/ShowLoader.h
@@ -28,6 +28,23 @@
 #define EXAMPLES_SHOWLOADER_H_
 
 /**
+ * Show header for V1 showfiles.
+ *
+ * - Relative frame times (up to ms resolution).
+ * - DMX data in human-readable form.
+ */
+extern const char OLA_SHOW_HEADER_V1[];
+
+/**
+ * Show header for V2 showfiles.
+ *
+ * - Absolute frame times (up to ms resolution).
+ * - DMX data in human-readable form.
+ */
+extern const char OLA_SHOW_HEADER_V2[];
+
+
+/**
  * Holds a single entry in the show file
  */
 struct ShowEntry {

--- a/examples/ShowPlayer.cpp
+++ b/examples/ShowPlayer.cpp
@@ -218,7 +218,7 @@ ShowLoader::State ShowPlayer::SeekTo(uint64_t seek_time) {
   }
   uint64_t timeout = playhead_time - seek_time;
   m_playback_pos = playhead_time;
-  m_clock.CurrentTime(&m_start_ts);
+  m_clock.CurrentMonotonicTime(&m_start_ts);
   m_start_playback_pos = m_playback_pos - timeout;
 
   // Send data in the state it would be in at the given time
@@ -279,7 +279,7 @@ void ShowPlayer::SendEntry(const ShowEntry &entry) {
     // we have to lose 1 bit anyway as InMilliSeconds() returns a signed
     // 64-bit integer.
     ola::TimeStamp now;
-    m_clock.CurrentTime(&now);
+    m_clock.CurrentMonotonicTime(&now);
     int64_t target_delta = m_playback_pos - m_start_playback_pos;
     int64_t current_delta = (now - m_start_ts).InMilliSeconds();
     int64_t delay = target_delta - current_delta;

--- a/examples/ShowPlayer.cpp
+++ b/examples/ShowPlayer.cpp
@@ -216,9 +216,10 @@ ShowLoader::State ShowPlayer::SeekTo(uint64_t seek_time) {
       break;
     }
   }
+  uint64_t timeout = playhead_time - seek_time;
   m_playback_pos = playhead_time;
   m_clock.CurrentTime(&m_start_ts);
-  m_start_playback_pos = m_playback_pos;
+  m_start_playback_pos = m_playback_pos - timeout;
 
   // Send data in the state it would be in at the given time
   map<unsigned int, ShowEntry>::iterator entry_it;
@@ -226,7 +227,7 @@ ShowLoader::State ShowPlayer::SeekTo(uint64_t seek_time) {
     SendFrame(entry_it->second);
   }
   // Adjust the timeout to handle landing in the middle of the entry's timeout
-  RegisterNextTimeout(playhead_time-seek_time);
+  RegisterNextTimeout(timeout);
 
   return ShowLoader::OK;
 }

--- a/examples/ShowPlayer.cpp
+++ b/examples/ShowPlayer.cpp
@@ -283,8 +283,9 @@ void ShowPlayer::SendEntry(const ShowEntry &entry) {
     int64_t current_delta = (now - m_start_ts).InMilliSeconds();
     int64_t delay = target_delta - current_delta;
     if (delay < 0) {
-      OLA_WARN << "Current frame was meant to be played in the past:"
-                  " System too slow?";
+      OLA_WARN << "Frame at line " << m_loader.GetCurrentLineNumber()
+               << " was meant to have completed " << -delay << " ms ago."
+               << " System too slow?";
       delay = 0;
     }
     timeout = delay;

--- a/examples/ShowPlayer.h
+++ b/examples/ShowPlayer.h
@@ -23,6 +23,7 @@
 #include <ola/client/ClientWrapper.h>
 
 #include <map>
+#include <memory>
 #include <string>
 #include <fstream>
 
@@ -80,7 +81,7 @@ class ShowPlayer {
 
  private:
   ola::client::OlaClientWrapper m_client;
-  ShowLoader m_loader;
+  std::auto_ptr<ShowLoader> m_loader;
   bool m_infinite_loop;
   unsigned int m_iteration_remaining;
   uint64_t m_loop_delay;

--- a/examples/ShowPlayer.h
+++ b/examples/ShowPlayer.h
@@ -18,6 +18,7 @@
  * Copyright (C) 2011 Simon Newton
  */
 
+#include <ola/Clock.h>
 #include <ola/DmxBuffer.h>
 #include <ola/client/ClientWrapper.h>
 
@@ -89,6 +90,9 @@ class ShowPlayer {
   uint64_t m_run_time;
   std::map<unsigned int, uint64_t> m_frame_count;
   bool m_simulate;
+  ola::Clock m_clock;
+  ola::TimeStamp m_start_ts;
+  uint64_t m_start_playback_pos;
 
   /** Used for tracking simulation progress */
   typedef enum {

--- a/examples/ShowRecorder.cpp
+++ b/examples/ShowRecorder.cpp
@@ -46,9 +46,9 @@ using std::string;
 using std::vector;
 
 
-ShowRecorder::ShowRecorder(const string &filename,
-                           const vector<unsigned int> &universes)
-    : m_saver(filename),
+ShowRecorder::ShowRecorder(const vector<unsigned int> &universes,
+                           std::auto_ptr<ShowSaver> &saver)
+    : m_saver(saver),
       m_universes(universes),
       m_frame_count(0) {
 }
@@ -67,7 +67,7 @@ int ShowRecorder::Init() {
     return ola::EXIT_UNAVAILABLE;
   }
 
-  if (!m_saver.Open()) {
+  if (!m_saver->Open()) {
     return ola::EXIT_CANTCREAT;
   }
 
@@ -110,7 +110,7 @@ void ShowRecorder::NewFrame(const ola::client::DMXMetadata &meta,
                             const ola::DmxBuffer &data) {
   ola::TimeStamp now;
   m_clock.CurrentMonotonicTime(&now);
-  m_saver.NewFrame(now, meta.universe, data);
+  m_saver->NewFrame(now, meta.universe, data);
   m_frame_count++;
 }
 

--- a/examples/ShowRecorder.h
+++ b/examples/ShowRecorder.h
@@ -22,6 +22,7 @@
 #include <ola/DmxBuffer.h>
 #include <ola/client/ClientWrapper.h>
 #include <stdint.h>
+#include <memory>
 #include <string>
 #include <fstream>
 #include <vector>
@@ -36,8 +37,8 @@
  */
 class ShowRecorder {
  public:
-  ShowRecorder(const std::string &filename,
-               const std::vector<unsigned int> &universes);
+  ShowRecorder(const std::vector<unsigned int> &universes,
+               std::auto_ptr<ShowSaver> &saver);
   ~ShowRecorder();
 
   int Init();
@@ -48,7 +49,7 @@ class ShowRecorder {
 
  private:
   ola::client::OlaClientWrapper m_client;
-  ShowSaver m_saver;
+  std::auto_ptr<ShowSaver> m_saver;
   std::vector<unsigned int> m_universes;
   ola::Clock m_clock;
   uint64_t m_frame_count;

--- a/examples/ShowSaver.cpp
+++ b/examples/ShowSaver.cpp
@@ -115,7 +115,7 @@ bool ShowSaverV2::NewFrame(const ola::TimeStamp &arrival_time,
 
     struct timeval tv;
     delta.AsTimeval(&tv);
-    m_show_file << tv.tv_sec << " " << tv.tv_usec << endl;
+    m_show_file << tv.tv_sec << " " << (tv.tv_usec / 1000) << endl;
   } else {
     m_first_frame = arrival_time;
   }

--- a/examples/ShowSaver.cpp
+++ b/examples/ShowSaver.cpp
@@ -31,14 +31,13 @@
 #include <iostream>
 #include <string>
 
+#include "examples/ShowLoader.h"
 #include "examples/ShowSaver.h"
 
 using std::string;
 using ola::DmxBuffer;
 using std::endl;
 
-
-const char ShowSaver::OLA_SHOW_HEADER[] = "OLA Show";
 
 ShowSaver::ShowSaver(const string &filename)
     : m_filename(filename) {
@@ -61,10 +60,9 @@ bool ShowSaver::Open() {
     return false;
   }
 
-  m_show_file << OLA_SHOW_HEADER << endl;
+  m_show_file << GetHeader() << endl;
   return true;
 }
-
 
 
 /**
@@ -77,12 +75,14 @@ void ShowSaver::Close() {
 }
 
 
-/**
- * Write a new frame
- */
-bool ShowSaver::NewFrame(const ola::TimeStamp &arrival_time,
-                         unsigned int universe,
-                         const ola::DmxBuffer &data) {
+ShowSaverV1::ShowSaverV1(const string &filename)
+    : ShowSaver(filename) {
+}
+
+
+bool ShowSaverV1::NewFrame(const ola::TimeStamp &arrival_time,
+                           unsigned int universe,
+                           const ola::DmxBuffer &data) {
   // TODO(simon): add much better error handling here
   if (m_last_frame.IsSet()) {
     // this is not the first frame so write the delay in ms
@@ -94,3 +94,9 @@ bool ShowSaver::NewFrame(const ola::TimeStamp &arrival_time,
   m_show_file << universe << " " << data.ToString() << endl;
   return true;
 }
+
+
+string ShowSaverV1::GetHeader() {
+  return string(OLA_SHOW_HEADER_V1);
+}
+

--- a/examples/ShowSaver.cpp
+++ b/examples/ShowSaver.cpp
@@ -100,3 +100,30 @@ string ShowSaverV1::GetHeader() {
   return string(OLA_SHOW_HEADER_V1);
 }
 
+
+ShowSaverV2::ShowSaverV2(const string &filename) 
+    : ShowSaver(filename) {
+}
+
+
+bool ShowSaverV2::NewFrame(const ola::TimeStamp &arrival_time,
+                           unsigned int universe,
+                           const ola::DmxBuffer &data) {
+  // TODO(shenghao): add much better error handling here
+  if (m_first_frame.IsSet()) {
+    const ola::TimeInterval delta = arrival_time - m_first_frame;
+
+    struct timeval tv;
+    delta.AsTimeval(&tv);
+    m_show_file << tv.tv_sec << " " << tv.tv_usec << endl;
+  } else {
+    m_first_frame = arrival_time;
+  }
+
+  m_show_file << universe << " " << data.ToString() << endl;
+  return true;
+}
+
+string ShowSaverV2::GetHeader() {
+  return string(OLA_SHOW_HEADER_V2);
+}

--- a/examples/ShowSaver.h
+++ b/examples/ShowSaver.h
@@ -62,6 +62,14 @@ class ShowSaverV1: public ShowSaver {
 };
 
 
-  static const char OLA_SHOW_HEADER[];
+class ShowSaverV2: public ShowSaver {
+ public:
+  explicit ShowSaverV2(const std::string &filename);
+  virtual bool NewFrame(const ola::TimeStamp &arrival_time,
+                        unsigned int universe,
+                        const ola::DmxBuffer &data);
+ private:
+  ola::TimeStamp m_first_frame;
+  virtual std::string GetHeader();
 };
 #endif  // EXAMPLES_SHOWSAVER_H_

--- a/examples/ShowSaver.h
+++ b/examples/ShowSaver.h
@@ -33,19 +33,34 @@
 class ShowSaver {
  public:
   explicit ShowSaver(const std::string &filename);
-  ~ShowSaver();
+  virtual ~ShowSaver();
 
   bool Open();
   void Close();
 
-  bool NewFrame(const ola::TimeStamp &arrival_time,
-                unsigned int universe,
-                const ola::DmxBuffer &data);
-
- private:
+  virtual bool NewFrame(const ola::TimeStamp &arrival_time,
+                        unsigned int universe,
+                        const ola::DmxBuffer &data) = 0;
+ protected:
   const std::string m_filename;
   std::ofstream m_show_file;
+
+ private:
+  virtual std::string GetHeader() = 0;
+};
+
+
+class ShowSaverV1: public ShowSaver {
+ public:
+  explicit ShowSaverV1(const std::string &filename);
+  virtual bool NewFrame(const ola::TimeStamp &arrival_time,
+                        unsigned int universe,
+                        const ola::DmxBuffer &data);
+ private:
   ola::TimeStamp m_last_frame;
+  virtual std::string GetHeader();
+};
+
 
   static const char OLA_SHOW_HEADER[];
 };

--- a/examples/ola-recorder.cpp
+++ b/examples/ola-recorder.cpp
@@ -106,6 +106,9 @@ int RecordShow() {
     case 1:
       saver.reset(new ShowSaverV1(FLAGS_record.str()));
       break;
+    case 2:
+      saver.reset(new ShowSaverV2(FLAGS_record.str()));
+      break;
     default:
       OLA_FATAL << "Show file version " << FLAGS_record_version
                 << " is not supported";


### PR DESCRIPTION
Adds a V2 show file format that uses absolute timestamps from the start of the recording.

No core changes are required in the recorder's playback engine. The loader automatically converts the absolute timestamps into frame timeouts.

The layout of the show files are unchanged except the header is changed to `OLA Show V2` and the timings are now recorded in `<second> <ms>` format, similar how `struct timeval` stores them as two separate values.

The player automatically detects the file format by inspecting the header and should handle both types automatically.

The recorder gained an option to select the recording file format, defaulting to the v1 relative timestamp format.

This helps make the playback of a recording more accurate as we eliminate accumulated roundoff errors caused by storing relative timestamps.

Depends on #1680 