### PR TITLE
Fix Python tests for Python 2.6

### DIFF
--- a/python/ola/ClientWrapperTest.py
+++ b/python/ola/ClientWrapperTest.py
@@ -21,7 +21,11 @@ import binascii
 import datetime
 import socket
 # import timeout_decorator
-import unittest
+try:
+  # Python 2.6 needs backport
+  import unittest2 as unittest
+except ImportError:
+  import unittest
 from ola.ClientWrapper import ClientWrapper
 from ola.ClientWrapper import _Event
 

--- a/python/ola/PidStoreTest.py
+++ b/python/ola/PidStoreTest.py
@@ -18,7 +18,11 @@
 
 import binascii
 import os
-import unittest
+try:
+  # Python 2.6 needs backport
+  import unittest2 as unittest
+except ImportError:
+  import unittest
 import ola.PidStore as PidStore
 from ola.TestUtils import allNotEqual, allHashNotEqual
 


### PR DESCRIPTION
Python 2.6 needs the backport called unittest2 (to handle assertIsNone for example).