### PR TITLE
usbdmx: Move widget deletion to main thread

### DIFF
--- a/plugins/usbdmx/AsyncPluginImpl.h
+++ b/plugins/usbdmx/AsyncPluginImpl.h
@@ -37,7 +37,6 @@
 #include "libs/usb/HotplugAgent.h"
 
 #include "ola/base/Macro.h"
-#include "ola/thread/Future.h"
 #include "olad/Preferences.h"
 #include "plugins/usbdmx/PluginImplInterface.h"
 #include "plugins/usbdmx/SynchronizedWidgetObserver.h"
@@ -111,7 +110,7 @@ class AsyncPluginImpl: public PluginImplInterface, public WidgetObserver {
   template <typename Widget>
   bool StartAndRegisterDevice(Widget *widget, Device *device);
 
-  void ShutdownDevice(Device *device, ola::thread::Future<void> *f);
+  void ShutdownDeviceState(DeviceState *state);
 
   DISALLOW_COPY_AND_ASSIGN(AsyncPluginImpl);
 };


### PR DESCRIPTION
Currently when a usb device is remove the libusb event thread, though the
hotplug handler, will cause the widget's Device to be deleted in the main
thread and wait for this to complete in the libusb thread.

If any of the destructors triggered by device deletion causes libusb_close
to be called this causes a deadlock as libusb_close will try to take over
handling of events in the main thread while the libusb thread is waiting
for libusb_close, via the destructors, to finish.

Just move both widget and device deletion to the main thread to prevent
this scenario.