### PR TITLE
Set a default value for the enabling Eurolite Mk2 preference

### DIFF
--- a/plugins/usbdmx/EuroliteProFactory.h
+++ b/plugins/usbdmx/EuroliteProFactory.h
@@ -45,6 +45,8 @@ class EuroliteProFactory : public BaseWidgetFactory<class EurolitePro> {
 
   static bool IsEuroliteMk2Enabled(Preferences *preferences);
 
+  static const char ENABLE_EUROLITE_MK2_KEY[];
+
  private:
   ola::usb::LibUsbAdaptor *m_adaptor;
   bool m_enable_eurolite_mk2;
@@ -58,8 +60,6 @@ class EuroliteProFactory : public BaseWidgetFactory<class EurolitePro> {
   static const uint16_t VENDOR_ID_MK2;
   static const char EXPECTED_MANUFACTURER_MK2[];
   static const char EXPECTED_PRODUCT_MK2[];
-
-  static const char ENABLE_EUROLITE_MK2_KEY[];
 
   DISALLOW_COPY_AND_ASSIGN(EuroliteProFactory);
 };

--- a/plugins/usbdmx/UsbDmxPlugin.cpp
+++ b/plugins/usbdmx/UsbDmxPlugin.cpp
@@ -102,6 +102,11 @@ bool UsbDmxPlugin::SetDefaultPreferences() {
       UIntValidator(LIBUSB_DEFAULT_DEBUG_LEVEL, LIBUSB_MAX_DEBUG_LEVEL),
       LIBUSB_DEFAULT_DEBUG_LEVEL);
 
+  save |= m_preferences->SetDefaultValue(
+      EuroliteProFactory::ENABLE_EUROLITE_MK2_KEY,
+      BoolValidator(),
+      false);
+
   if (save) {
     m_preferences->Save();
   }


### PR DESCRIPTION
CC @ridicolos and @aroffringa

This sets a default value (of false) for enable_eurolite_mk2 and writes it into the relevant conf file making things easier for the user.

Sorry @aroffringa I'm not sure why I didn't suggest this before.