### PR TITLE
Attempt to enable native UART on modern systems

### DIFF
--- a/common/io/ExtendedSerial.cpp
+++ b/common/io/ExtendedSerial.cpp
@@ -85,7 +85,7 @@ bool LinuxHelper::SetDmxBaud(int fd) {
   }
   return true;
 #else
-  OLA_INFO << "Failed to set baud rate, due to missing stropts.h or termios2";
+  OLA_INFO << "Failed to set baud rate, missing termios2";
   return false;
   (void) fd;
 #endif  // defined(HAVE_TERMIOS2)

--- a/common/io/ExtendedSerial.cpp
+++ b/common/io/ExtendedSerial.cpp
@@ -32,6 +32,10 @@
 #ifdef HAVE_STROPTS_H
 // this provides ioctl() definition without conflicting with asm/termios.h
 #include <stropts.h>
+#else
+// this provides a minimal ioctl() definition for modern systems
+// which don't have <stropts.h> anymore
+#include <ola/io/IOCtl.h>
 #endif  // HAVE_STROPTS_H
 
 #ifdef HAVE_ASM_TERMIOS_H
@@ -52,7 +56,7 @@ namespace ola {
 namespace io {
 
 bool LinuxHelper::SetDmxBaud(int fd) {
-#if defined(HAVE_STROPTS_H) && defined(HAVE_TERMIOS2)
+#if defined(HAVE_TERMIOS2)
   static const int rate = 250000;
 
   struct termios2 tio;  // linux-specific terminal stuff
@@ -84,7 +88,7 @@ bool LinuxHelper::SetDmxBaud(int fd) {
   OLA_INFO << "Failed to set baud rate, due to missing stropts.h or termios2";
   return false;
   (void) fd;
-#endif  // defined(HAVE_STROPTS_H) && defined(HAVE_TERMIOS2)
+#endif  // defined(HAVE_TERMIOS2)
 }
 }  // namespace io
 }  // namespace ola

--- a/include/ola/io/IOCtl.h
+++ b/include/ola/io/IOCtl.h
@@ -23,7 +23,7 @@
 #define INCLUDE_OLA_IO_IOCTL_H_
 
 extern "C" {
-  extern int ioctl(int __fd, unsigned long int __request, ...) __THROW;  // NOLINT(runtime/int)
+  extern int ioctl(int f, unsigned long r, ...) __THROW;  // NOLINT(runtime/int)
 }
 
 #endif  // INCLUDE_OLA_IO_IOCTL_H_

--- a/include/ola/io/IOCtl.h
+++ b/include/ola/io/IOCtl.h
@@ -1,0 +1,29 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * IOCtl.h
+ * This is a minimal definition of ioctl() to allow the UART DMX plugin
+ * to compile with custom baud rate support on newer systems which don't
+ * have <stropts.h>.
+ */
+
+#ifndef INCLUDE_OLA_IO_IOCTL_H_
+#define INCLUDE_OLA_IO_IOCTL_H_
+
+extern "C" {
+  extern int ioctl(int __fd, unsigned long int __request, ...) __THROW;  // NOLINT(runtime/int)
+}
+
+#endif  // INCLUDE_OLA_IO_IOCTL_H_

--- a/include/ola/io/Makefile.mk
+++ b/include/ola/io/Makefile.mk
@@ -4,6 +4,7 @@ olaioinclude_HEADERS = \
     include/ola/io/ByteString.h \
     include/ola/io/Descriptor.h \
     include/ola/io/ExtendedSerial.h \
+    include/ola/io/IOCtl.h \
     include/ola/io/IOQueue.h \
     include/ola/io/IOStack.h \
     include/ola/io/IOUtils.h \


### PR DESCRIPTION
Both current Raspberry Pi OS and Ubuntu for the Pi are missing the `stropts.h` header file, which causes the OLA ExtendedSerial helper to be compiled to always return `false` from `LinuxHelper::SetDmxBaud()`. This in turn makes it impossible to use the native UART DMX output plugin. This PR is an attempt to fix that by including an alternative bundled header file which defines the `ioctl()` function, which is the only thing needed out of `stropts.h`.

I'd like to say up front that I'm not a C/C++ developer - in fact this is only the second time in my life that I'm attempting to mess around with C code - so please don't be too harsh with me if I've made newbie mistakes! As it is, the code compiles on Ubuntu 21.10 for RPi without errors and from the output of `olad` it is apparent that the issue is fixed by this workaround - that is, where previously the UART DMX plugin logged a warning about being unable to set the correct baud rate for the UART device, now the plugin outputs the expected line about the input and output rates being the expected `250000`. I've tried to provide a "minimal" fix which would only be applied when `stropts.h` isn't present, so it should compile on other and / or older systems exactly as before, unless I'm mistaken.

Of course, the usual UART configuration still applies - you still need to modify `/boot/firmware/config.txt` to disable bluetooth via a `dtoverlay`, enable UART and set the appropriate UART clock, and disable the `hciuart` service - but even with all those things in place, neither the distribution `ola` package nor a fresh compile of OLA produced the expected result.

Thanks everyone on the OLA team for creating and maintaining this project!