### PR TITLE
Fix UB in TimeoutManager::ExecuteTimeouts

### DIFF
--- a/.codespellignorewords
+++ b/.codespellignorewords
@@ -1,3 +1,4 @@
-thead
 acn
 ACN
+inflight
+thead

--- a/.travis.yml
+++ b/.travis.yml
@@ -349,6 +349,13 @@ jobs:
            - lintian
            - moreutils
   allow_failures:
+    - os: linux
+      dist: bionic
+      arch: arm64
+      env: TASK='jshint'
+      addons:
+        apt:
+          packages:
 #    - os: osx
 #      osx_image: xcode9.4
 #      compiler: clang

--- a/common/io/TimeoutManager.cpp
+++ b/common/io/TimeoutManager.cpp
@@ -97,8 +97,8 @@ TimeInterval TimeoutManager::ExecuteTimeouts(TimeStamp *now) {
   if (m_events.empty())
     return TimeInterval();
 
-  for (e = m_events.top(); !m_events.empty() && (e->NextTime() <= *now);
-       e = m_events.top()) {
+  // make sure we only try to access m_events.top() if m_events isn't empty
+  while (!m_events.empty() && ((e = m_events.top())->NextTime() <= *now)) {
     m_events.pop();
 
     // if this was removed, skip it

--- a/include/ola/base/FlagsPrivate.h
+++ b/include/ola/base/FlagsPrivate.h
@@ -307,7 +307,7 @@ bool Flag<T>::SetValue(const std::string &input) {
 
 
 /**
- * @brief This class holds all the flags, and is responsbile for parsing the
+ * @brief This class holds all the flags, and is responsible for parsing the
  * command line.
  */
 class FlagRegistry {

--- a/javascript/ola/full/dmx_console_tab.js
+++ b/javascript/ola/full/dmx_console_tab.js
@@ -66,7 +66,7 @@ ola.DmxConsoleTab.prototype.setUniverse = function(universe_id) {
 
 
 /**
- * Called when the tab changes visibiliy.
+ * Called when the tab changes visibility.
  */
 ola.DmxConsoleTab.prototype.setActive = function(state) {
   ola.DmxConsoleTab.superClass_.setActive.call(this, state);

--- a/javascript/ola/full/dmx_monitor_tab.js
+++ b/javascript/ola/full/dmx_monitor_tab.js
@@ -38,7 +38,7 @@ goog.inherits(ola.DmxMonitorTab, ola.common.BaseUniverseTab);
 
 
 /**
- * Called when the tab changes visibiliy.
+ * Called when the tab changes visibility.
  */
 ola.DmxMonitorTab.prototype.setActive = function(state) {
   ola.DmxMonitorTab.superClass_.setActive.call(this, state);


### PR DESCRIPTION
The outer for loop would call `m_events.top()` before checking if it's empty, which raises an exception when compiled with `-D_GLIBCXX_ASSERTIONS`.