### PR TITLE
currentThread is deprecated, so let's use current_thread (should work…

### DIFF
--- a/python/ola/ClientWrapper.py
+++ b/python/ola/ClientWrapper.py
@@ -267,7 +267,7 @@ class SelectServer(object):
       runnable()
 
   def _GetThreadID(self):
-    return threading.currentThread().ident
+    return threading.current_thread().ident
 
   def _Stop(self):
     self._quit = True


### PR DESCRIPTION
… with Python 2.6+)