### PR TITLE
Fix UART DMX plugin on Bullseye and more recent Linux distributions

### DIFF
--- a/common/io/ExtendedSerial.cpp
+++ b/common/io/ExtendedSerial.cpp
@@ -68,7 +68,9 @@ namespace ola {
 namespace io {
 
 bool LinuxHelper::SetDmxBaud(int fd) {
-#if (defined(HAVE_STROPTS_H) || (defined(HAVE_SYS_IOCTL_H) && defined(HAVE_ASM_TERMBITS_H))) && defined(HAVE_TERMIOS2)
+#if (defined(HAVE_STROPTS_H) || \
+     (defined(HAVE_SYS_IOCTL_H) && defined(HAVE_ASM_TERMBITS_H))) && \
+    defined(HAVE_TERMIOS2)
   static const int rate = 250000;
 
   struct termios2 tio;  // linux-specific terminal stuff
@@ -107,7 +109,9 @@ bool LinuxHelper::SetDmxBaud(int fd) {
            << "termios2";
   return false;
   (void) fd;
-#endif  // (defined(HAVE_STROPTS_H) || (defined(HAVE_SYS_IOCTL_H) && defined(HAVE_ASM_TERMBITS_H))) && defined(HAVE_TERMIOS2)
+#endif  // (defined(HAVE_STROPTS_H) ||
+//  (defined(HAVE_SYS_IOCTL_H) && defined(HAVE_ASM_TERMBITS_H))) &&
+// defined(HAVE_TERMIOS2)
 }
 }  // namespace io
 }  // namespace ola

--- a/common/io/ExtendedSerial.cpp
+++ b/common/io/ExtendedSerial.cpp
@@ -32,10 +32,26 @@
 #ifdef HAVE_STROPTS_H
 // this provides ioctl() definition without conflicting with asm/termios.h
 #include <stropts.h>
+#else
+// otherwise use the sys/ioctl.h version for newer Linux which has dropped the
+// stropts.h version
+// N.B. This will pull in the kernel definition of struct termios, which may
+// conflict with the libc version, so we wouldn't be able to use both in the
+// same file
+#ifdef HAVE_SYS_IOCTL_H
+#include <sys/ioctl.h>
+#endif  // HAVE_SYS_IOCTL_H
+#ifdef HAVE_ASM_TERMBITS_H
+#include <asm/termbits.h>
+#endif  // HAVE_ASM_TERMBITS_H
 #endif  // HAVE_STROPTS_H
 
-#ifdef HAVE_ASM_TERMIOS_H
-// use this not standard termios for custom baud rates
+#if defined(HAVE_STROPTS_H) && defined(HAVE_ASM_TERMIOS_H)
+// use this non-standard termios for custom baud rates
+//
+// On newer Linux, this duplicates winsize and termio as they're also defined
+// in bits/ioctl-types.h, so only include this header if we also have the
+// stropts.h sourced version of ioctl()
 //
 // On mips architectures, <asm/termios.h> sets some cpp macros which cause
 // <cerrno> (included by <ostream>, used by <ola/Logging.h>) to not define
@@ -52,7 +68,7 @@ namespace ola {
 namespace io {
 
 bool LinuxHelper::SetDmxBaud(int fd) {
-#if defined(HAVE_STROPTS_H) && defined(HAVE_TERMIOS2)
+#if (defined(HAVE_STROPTS_H) || (defined(HAVE_SYS_IOCTL_H) && defined(HAVE_ASM_TERMBITS_H))) && defined(HAVE_TERMIOS2)
   static const int rate = 250000;
 
   struct termios2 tio;  // linux-specific terminal stuff
@@ -81,10 +97,17 @@ bool LinuxHelper::SetDmxBaud(int fd) {
   }
   return true;
 #else
-  OLA_INFO << "Failed to set baud rate, due to missing stropts.h or termios2";
+  OLA_INFO << "Failed to set baud rate, due to missing "
+#if !defined(HAVE_STROPTS_H)
+           << "stropts.h or "
+#endif
+#if !(defined(HAVE_SYS_IOCTL_H) && defined(HAVE_ASM_TERMBITS_H))
+           << "sys/ioctl.h or asm/termbits.h or "
+#endif
+           << "termios2";
   return false;
   (void) fd;
-#endif  // defined(HAVE_STROPTS_H) && defined(HAVE_TERMIOS2)
+#endif  // (defined(HAVE_STROPTS_H) || (defined(HAVE_SYS_IOCTL_H) && defined(HAVE_ASM_TERMBITS_H))) && defined(HAVE_TERMIOS2)
 }
 }  // namespace io
 }  // namespace ola

--- a/configure.ac
+++ b/configure.ac
@@ -145,9 +145,10 @@ AC_CHECK_HEADERS([arpa/inet.h bits/sockaddr.h fcntl.h float.h limits.h \
                   malloc.h netinet/in.h stdint.h stdlib.h string.h strings.h \
                   sys/file.h sys/ioctl.h sys/socket.h sys/time.h sys/timeb.h \
                   syslog.h termios.h unistd.h])
-AC_CHECK_HEADERS([asm/termios.h assert.h dlfcn.h endian.h execinfo.h \
-                  linux/if_packet.h math.h net/ethernet.h stropts.h \
-                  sys/param.h sys/types.h sys/uio.h sysexits.h])
+AC_CHECK_HEADERS([asm/termbits.h asm/termios.h assert.h dlfcn.h endian.h \
+                  execinfo.h linux/if_packet.h math.h net/ethernet.h \
+                  stropts.h sys/ioctl.h sys/param.h sys/types.h sys/uio.h \
+                  sysexits.h])
 AC_CHECK_HEADERS([winsock2.h winerror.h])
 AC_CHECK_HEADERS([random])
 


### PR DESCRIPTION
Essentially just include a different combination of headers, but add some required cotton wool around this.

Closes #1749

With huge thanks to @plugz for mcallegari/qlcplus@5116d98