### PR TITLE
Use flock() instead of UUCP-style locking for serial devices

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -787,6 +787,22 @@ AC_ARG_ENABLE(
   [AS_HELP_STRING([--disable-doxygen-version],
   [Substitute the Doxygen version with latest, for the website])])
 
+# Use UUCP locking?
+AC_ARG_ENABLE(
+  [uucp-locking],
+  [AS_HELP_STRING([--enable-uucp-locking],
+  [Use UUCP locking instead of flock()])])
+
+AC_CHECK_FUNC([flock], [AC_DEFINE([HAVE_FLOCK], [1],
+                                  [Define if flock() is available])
+                        have_flock=yes], [])
+
+AS_IF([test "x$enable_uucp_locking" = xyes || test "x$have_flock" != xyes],
+      [AC_DEFINE([UUCP_LOCKING], [1],
+                 [Define if UUCP locking should be used instead of flock()])
+       SERIAL_LOCK_METHOD=UUCP],
+      [SERIAL_LOCK_METHOD=flock])
+
 # UUCP Lock directory
 AC_ARG_WITH([uucp-lock],
             [AS_HELP_STRING([--with-uucp-lock],
@@ -1022,6 +1038,7 @@ Enable HTTP Server: ${have_microhttpd}
 RDM Responder Tests: ${enable_rdm_tests}
 Ja Rule: ${BUILDING_JA_RULE}
 Enabled Plugins:${PLUGINS}
+Serial port locking: $SERIAL_LOCK_METHOD
 UUCP Lock Directory: $UUCPLOCK
 
 Now type 'make @<:@<target>@:>@'

--- a/include/ola/io/Serial.h
+++ b/include/ola/io/Serial.h
@@ -60,21 +60,27 @@ typedef enum {
 bool UIntToSpeedT(uint32_t value, speed_t *output);
 
 /**
- * @brief Try to open the path, respecting UUCP locking.
+ * @brief Try to open the path and obtain a lock to control access
  * @param path the path to open
  * @param oflag flags passed to open
  * @param[out] fd a pointer to the fd which is returned.
  * @returns true if the open succeeded, false otherwise.
  *
+ * Depending on the compile-time configuration, this will use either flock()
+ * (the default) or UUCP locking.  See: ./configure --enable-uucp-locking.
+ *
  * This fails-fast, it we can't get the lock immediately, we'll return false.
  */
-bool AcquireUUCPLockAndOpen(const std::string &path, int oflag, int *fd);
+bool AcquireLockAndOpen(const std::string &path, int oflag, int *fd);
 
 /**
  * @brief Remove a UUCP lock file for the device.
  * @param path The path to unlock.
  *
  * The lock is only removed if the PID matches.
+ *
+ * Does nothing if UUCP locking is not in use
+ * (see ./configure --enable-uucp-locking).
  */
 void ReleaseUUCPLock(const std::string &path);
 }  // namespace io

--- a/plugins/stageprofi/StageProfiDetector.cpp
+++ b/plugins/stageprofi/StageProfiDetector.cpp
@@ -164,9 +164,9 @@ ConnectedDescriptor* StageProfiDetector::ConnectToUSB(
   struct termios newtio;
 
   int fd;
-  if (!ola::io::AcquireUUCPLockAndOpen(widget_path,
-                                       O_RDWR | O_NONBLOCK | O_NOCTTY,
-                                       &fd)) {
+  if (!ola::io::AcquireLockAndOpen(widget_path,
+                                   O_RDWR | O_NONBLOCK | O_NOCTTY,
+                                   &fd)) {
     return NULL;
   }
 

--- a/plugins/usbpro/BaseUsbProWidget.cpp
+++ b/plugins/usbpro/BaseUsbProWidget.cpp
@@ -129,8 +129,7 @@ ola::io::ConnectedDescriptor *BaseUsbProWidget::OpenDevice(
     const string &path) {
   struct termios newtio;
   int fd;
-  if (!ola::io::AcquireUUCPLockAndOpen(path, O_RDWR | O_NONBLOCK | O_NOCTTY,
-                                       &fd)) {
+  if (!ola::io::AcquireLockAndOpen(path, O_RDWR | O_NONBLOCK | O_NOCTTY, &fd)) {
     return NULL;
   }
 


### PR DESCRIPTION
This replaces AcquireUUCPLockAndOpen() with AcquireLockAndOpen().  Depending on a compile-time option (--enable-uucp-locking), either flock() or UUCP-style lockfiles will be used as the underlying lock mechanism.  The default is to use flock().  The configure script will fall back on UUCP locking if flock() is not found.

It would also be possible to preserve the API by naming the top-level open/lock routine AcquireUUCPLockAndOpen, but then the routine name would not be an accurate description.  I've updated the plugins using these routines (only two of them, StageProfi and UsbPro).

ReleaseUUCPLock() is still present, becoming a no-op if flock() is being used.  With flock(), the lock is automatically released when the file descriptor is closed.

In practice, the TIOCEXCL lock (when available) is much more helpful, because it prevents any other process from opening the device and doesn't rely on all processes using the same locking scheme.  This lock is still used when flock() is available.

Fixes #1189, #1674 and many related problems on various platforms (e.g. running in a Toolbox container on Fedora Silverlight).