### PR TITLE
USB DMX Free the transfer first to avoid segfaults in libusb >= 1.0.25

### DIFF
--- a/plugins/usbdmx/AsyncUsbTransceiverBase.cpp
+++ b/plugins/usbdmx/AsyncUsbTransceiverBase.cpp
@@ -57,8 +57,9 @@ AsyncUsbTransceiverBase::AsyncUsbTransceiverBase(LibUsbAdaptor *adaptor,
 
 AsyncUsbTransceiverBase::~AsyncUsbTransceiverBase() {
   CancelTransfer();
-  m_adaptor->UnrefDevice(m_usb_device);
+  // Free the transfer first to avoid segfaults in libusb >= 1.0.25
   m_adaptor->FreeTransfer(m_transfer);
+  m_adaptor->UnrefDevice(m_usb_device);
 }
 
 bool AsyncUsbTransceiverBase::Init() {


### PR DESCRIPTION
Closes #1771 (hopefully)