### PR TITLE
 Clarify and expand Debian Package build instructions

### DIFF
--- a/README
+++ b/README
@@ -74,6 +74,10 @@ python/examples.
 There is an experimental Java library which can be built by running configure
 with --enable-java-libs.
 
+## Build it yourself
+
+There are some instructions on how to build Debian packages in the [README.debian](README.debian)
+
 ## Credits
 
 The AUTHORS files contains a list of code contributors. A [full list of

--- a/README.debian
+++ b/README.debian
@@ -22,6 +22,17 @@ If autoreconf reports missing things, you can add the -i option.
 Running configure might report missing utilities and libraries. You
 can install these with apt-get.
 
+You should not run debuild as root, as it will fail tests. You can disable testing by editing `debian/rules` and adding 
+```
+override_dh_auto_configure:
+    dh_auto_configure -- --disable-unittests
+```
+
+If you are not a package maintainer, it is recommend to disable package signing and linting:
+`debuild --no-lintian -us -uc`
+On newer debuild releases (Ubuntu 22.04+) you might also want to add `--no-tgz-check`. 
+Otherwise you can rename `ola-0.X.Y.tar.gz` to `ola_0.X.Y.orig.tar.gz` to satisfy debuild requirements.
+
 The list below is probably not complete. Some of the package-names
 may differ between Debian and Debian-like distributions. Adjust
 as necessary.
@@ -30,7 +41,8 @@ $ sudo apt-get install libcppunit-dev libcppunit-1.13-0 uuid-dev pkg-config \
       libncurses5-dev libtool autoconf automake g++ libmicrohttpd-dev \
       libmicrohttpd10 protobuf-compiler libprotobuf-lite10 python-protobuf \
       libprotobuf-dev libprotoc-dev zlib1g-dev bison flex make libftdi-dev \
-      libftdi1 libusb-1.0-0-dev liblo-dev libavahi-client-dev python-numpy
+      libftdi1 libusb-1.0-0-dev liblo-dev libavahi-client-dev python-numpy \
+      bash-completion dh-autoreconf debhelper devscripts
 
 Note: Some distributions may offer older or newer versions of packages.
 For example, libprotobuf-lite6 or libprotobuf-lite7 instead of libprotobuf-lite8.


### PR DESCRIPTION
I tried to make the .deb build instruction more understandable for non-package-maintainers. I also added a link to the build instruction to the main README.