### PR TITLE
Update JUnit in pom.xml. Fixes https://github.com/OpenLightingProject/ola/security/dependabot/1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.2</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Since I'm able to build & test in master branch (in contrast to 0.10, see https://github.com/OpenLightingProject/ola/issues/1829), I did the bump here. Should probably be back-ported to 0.10 as well but without the changes done in master to the Java build system, I cannot test.
Lots of other dependencies in pom.xml could have been updated as well but since I don't know the implications, I'd rather leave them alone for now.
With updated JUnit, the two "offline" test case pass. I also enabled the "online" test cases (which need a running olad) and they passed as well. A surefire-report is also still generated fine so I don't expect any breakages. Also, since it's no "major-version-bump", a breaking change in jUnit would be surprising.