### PR TITLE
Add a missing file to the Python install list

### DIFF
--- a/python/ola/Makefile.mk
+++ b/python/ola/Makefile.mk
@@ -33,6 +33,7 @@ pkgpython_PYTHON = \
     python/ola/RDMAPI.py \
     python/ola/RDMConstants.py \
     python/ola/PidStore.py \
+    python/ola/StringUtils.py \
     python/ola/UID.py \
     python/ola/__init__.py
 endif


### PR DESCRIPTION
At leas this file is missing and means that when you `make install` it fails to run the RDM tests. There's a chance we've missed other files too, so ideally we'd check that (e.g. from 0.10.8 to 0.10.9 and go from there...)