### PR TITLE
GitHub Actions Build: distcheck, check, verify-trees, coverage, coveralls

### DIFF
--- a/.github/problem-matcher-build-verify-trees.json
+++ b/.github/problem-matcher-build-verify-trees.json
@@ -1,0 +1,15 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "build-verify-trees",
+            "severity": "error",
+            "pattern": [
+                {
+                    "regexp": "^(Missing from tarball)(\\s+)(.+)$",
+                    "message": 1,
+                    "file": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -183,6 +183,6 @@ jobs:
         run: tar -xvzf $GH_OLA_VERIFY_TREES_TARBALL
       - name: Verify trees
         shell: bash
-        # Always succeed for now until verify trees is fixed
+        # TODO(Perry): Always succeed for now until verify trees is fixed
         # run: ./scripts/verify_trees.py ./ $(echo $GH_OLA_VERIFY_TREES_TARBALL | sed 's/.tar.gz$//')
         run: "./scripts/verify_trees.py ./ $(echo $GH_OLA_VERIFY_TREES_TARBALL | sed 's/.tar.gz$//') || true"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ jobs:
     name: "distcheck ${{ matrix.id }}"
     runs-on: ubuntu-latest
     container: debian:stable
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: debian:stable-amd64-gcc,   compiler: { cc: "gcc",   cxx: "g++"     } }
-          - { id: debian:stable-amd64-clang, compiler: { cc: "clang", cxx: "clang++" } }
+          - { id: "debian:stable-amd64-gcc",   compiler: { cc: "gcc",   cxx: "g++"     } }
+          - { id: "debian:stable-amd64-clang", compiler: { cc: "clang", cxx: "clang++" } }
     env:
       CC: "{{ matrix.compiler.cc }}"
       CXX: "{{ matrix.compiler.cxx }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
         run: ./configure $GH_OLA_CONFIGURE_ARGS
       - name: check
         # TODO(Perry): Parallelization causes GH Actions to hang -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }}
-        run: make {{ matrix.task }} -j1 VERBOSE=1
+        run: make ${{ matrix.task }} -j1 VERBOSE=1
       - name: Display structure of the built files
         if: always() && env.ACTIONS_STEP_DEBUG == 'true'
         run: ls -alR

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: "${{ matrix.id }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     timeout-minutes: 360
     strategy:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,10 +2,21 @@ name: build
 on: [push, pull_request]
 jobs:
   distcheck:
-    name: Distcheck
+    name: "distcheck {{ matrix.id }}"
     runs-on: ubuntu-latest
     container: debian:stable
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { id: debian:stable-amd64-gcc,   compiler: { cc: "gcc",   cxx: "g++"     }}
+          - { id: debian:stable-amd64-clang, compiler: { cc: "clang", cxx: "clang++" }}
+    env:
+      CC: "{{ matrix.compiler.cc }}"
+      CXX: "{{ matrix.compiler.cxx }}"
     steps:
+      - name: Get number of CPU cores
+        run: echo "NUM_CPU_CORES=$(grep -c processor /proc/cpuinfo)" >> $GITHUB_OUTPUT
       - name: Update package database
         run: apt-get update -y
       # See comments beginning at
@@ -30,7 +41,7 @@ jobs:
             libmicrohttpd-dev protobuf-compiler python3-protobuf \
             libprotobuf-dev libprotoc-dev zlib1g-dev libftdi-dev \
             libusb-1.0-0-dev liblo-dev libavahi-client-dev python3-numpy \
-            default-jdk-headless
+            default-jdk-headless maven
       - name: Autoreconf
         run: autoreconf -i
       - name: Set configure arguments
@@ -45,5 +56,30 @@ jobs:
         run: echo "./configure $GH_OLA_CONFIGURE_ARGS"
       - name: Configure
         run: ./configure $GH_OLA_CONFIGURE_ARGS
-      - name: Distcheck
-        run: make distcheck VERBOSE=1
+      - name: distcheck
+        run: make distcheck -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
+      - name: Display structure of the built files
+        if: always() && env.ACTIONS_STEP_DEBUG == 'true'
+        run: ls -alR
+      - name: Archive artifacts to speed up slow GH Actions upload/download
+        if: always()
+        shell: bash
+        # If the file does not exist when tar excludes it, then it will not
+        # actually exclude it, so it must first be touched
+        run: |
+          touch ola-{{ matrix.id }}-distcheck-source-tree.tar.gz
+          tar --exclude=ola-{{ matrix.id }}-distcheck-source-tree.tar.gz -cvzf ola-{{ matrix.id }}-distcheck-source-tree.tar.gz .
+      - name: SHA256 artifact archives
+        if: always()
+        run: sha256sum ola-*.tar.gz
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ola-{{ matrix.id }}-distcheck-source-tree
+          path: ola-{{ matrix.id }}-distcheck-source-tree.tar.gz
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ola-{{ matrix.id }}-distcheck
+          path: |
+            ola-*.tar.gz
+            !ola-{{ matrix.id }}-distcheck-source-tree.tar.gz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Update package database
         run: apt-get update -y
       - name: Install coverage tools
-        run: apt-get -y install curl gcov-10 python3-pip
+        run: apt-get -y install curl gcc-10 python3-pip
       - name: Install Python coverage tools
         run: python3 -m pip install --no-input gcovr
       - name: Run gcovr

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Python venv
         shell: bash
         run: |
-          python3 -m venv ../venv
+          python3 -m venv --system-site-packages ../venv
           source ../venv/bin/activate
           echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Install Python build tools

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,10 +49,8 @@ jobs:
       - name: Autoreconf
         run: autoreconf -i
       - name: Set configure arguments
-        # usbdmx may cause GH action build to hang and fail
-        # TODO(Perry): re-renable ja-rule, usbdmx, and usbpro
         run: |
-          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-e133 --disable-usbdmx --disable-usbpro" >> $GITHUB_ENV
+          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133" >> $GITHUB_ENV
       - name: Set additional Linux configure arguments
         if: runner.os == 'Linux'
         # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long
@@ -63,7 +61,9 @@ jobs:
       - name: Configure
         run: ./configure $GH_OLA_CONFIGURE_ARGS
       - name: check
-        run: make check -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
+        # TODO(Perry): Parallelization causes GH Actions to hang
+        # run: make check -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
+        run: make check -j1 VERBOSE=1
       - name: Display structure of the built files
         if: always() && env.ACTIONS_STEP_DEBUG == 'true'
         run: ls -alR

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,8 @@ jobs:
           apt-get -y install libcppunit-dev uuid-dev libncurses5-dev \
             libmicrohttpd-dev protobuf-compiler python3-protobuf \
             libprotobuf-dev libprotoc-dev zlib1g-dev libftdi-dev \
-            libusb-1.0-0-dev liblo-dev libavahi-client-dev python3-numpy
+            libusb-1.0-0-dev liblo-dev libavahi-client-dev python3-numpy \
+            javacc
       - name: Autoreconf
         run: autoreconf -i
       - name: Set configure arguments
@@ -40,6 +41,8 @@ jobs:
         # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long
         run: |
           echo "GH_OLA_CONFIGURE_ARGS=$GH_OLA_CONFIGURE_ARGS CPPFLAGS=-Wno-deprecated-declarations" >> $GITHUB_ENV
+      - name: Print configure command
+        run: echo "./configure $GH_OLA_CONFIGURE_ARGS"
       - name: Configure
         run: ./configure $GH_OLA_CONFIGURE_ARGS
       - name: Distcheck

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
         run: echo "./configure $GH_OLA_CONFIGURE_ARGS"
       - name: Configure
         run: ./configure $GH_OLA_CONFIGURE_ARGS
-      - name: check
+      - name: ${{ matrix.task }}
         # TODO(Perry): Parallelization causes GH Actions to hang -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }}
         run: make ${{ matrix.task }} -j1 VERBOSE=1
       - name: Display structure of the built files
@@ -74,8 +74,8 @@ jobs:
         # If the file does not exist when tar excludes it, then it will not
         # actually exclude it, so it must first be touched
         run: |
-          touch ola-${{ matrix.id }}-check-source-tree.tar.gz
-          tar --exclude=ola-${{ matrix.id }}-check-source-tree.tar.gz -cvzf ola-${{ matrix.id }}-check-source-tree.tar.gz .
+          touch ola-${{ matrix.id }}-source-tree.tar.gz
+          tar --exclude=ola-${{ matrix.id }}-source-tree.tar.gz -cvzf ola-${{ matrix.id }}-source-tree.tar.gz .
       - name: SHA256 artifact archives
         if: always()
         run: sha256sum ola-*.tar.gz
@@ -83,15 +83,15 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ola-${{ matrix.id }}-check-source-tree
-          path: ola-${{ matrix.id }}-check-source-tree.tar.gz
+          name: ola-${{ matrix.id }}-source-tree
+          path: ola-${{ matrix.id }}-source-tree.tar.gz
       - name: Upload built artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ola-${{ matrix.id }}-check
+          name: ola-${{ matrix.id }}
           path: |
             ola-*.tar.gz
-            !ola-${{ matrix.id }}-check-source-tree.tar.gz
+            !ola-${{ matrix.id }}-source-tree.tar.gz
       - name: Install dependencies to verify trees
         run: apt-get install -y python-is-python3
       - name: Verify trees

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,11 +119,14 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ola-${{ matrix.id }}-source-tree
-          path: built
+          path: artifact
       - name: Display structure of artifact files
-        if: always() && env.ACTIONS_STEP_DEBUG == 'true'
         run: ls -alR
-        working-directory: built
+        working-directory: download
+      - name: Extract the source tree
+        shell: bash
+        run: tar -xvzf ola-${{ matrix.id }}-source-tree.tar.gz
+        working-directory: artifact
       - name: Update package database
         run: apt-get update -y
       - name: Install dependencies to verify trees
@@ -131,14 +134,14 @@ jobs:
       - name: Find dist build tarball
         run: |
           echo "GH_OLA_VERIFY_TREES_TARBALL=$(ls --time=birth ola*.tar.gz| head -1)" >> $GITHUB_ENV
-        working-directory: built
+        working-directory: artifact/ola-${{ matrix.id }}-source-tree
       - name: Print dist build tarball name
         run: echo "$GH_OLA_VERIFY_TREES_TARBALL"
-        working-directory: built
+        working-directory: artifact/ola-${{ matrix.id }}-source-tree
       - name: Extract dist build
-        run: tar -zxvf $GH_OLA_VERIFY_TREES_TARBALL
-        working-directory: built
+        run: tar -xvzf $GH_OLA_VERIFY_TREES_TARBALL
+        working-directory: artifact/ola-${{ matrix.id }}-source-tree
       - name: Verify trees
         shell: bash
         run: ./scripts/verify_trees.py ./ $(echo $GH_OLA_VERIFY_TREES_TARBALL | sed 's/.tar.gz$//')
-        working-directory: built
+        working-directory: artifact/ola-${{ matrix.id }}-source-tree

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -149,7 +149,7 @@ jobs:
           # Coveralls GitHub action does not support its own format
           # see: https://github.com/coverallsapp/github-action/issues/104
           # file: coverage.coveralls.json
-          file: coverage.txt
+          file: coverage/coverage.xml
           format: gcov
           flag-name: ${{ matrix.id }}
       - name: Upload coverage artifacts
@@ -157,13 +157,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ola-${{ matrix.id }}-coverage
-          path: |
-            coverage.txt
-            coverage.csv
-            coverage.json
-            coverage.xml
-            coverage.html
-            coverage.coveralls.json
+          path: coverage/
   verify-trees:
     name: 'Verify trees for ${{ matrix.id }}'
     needs: build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,7 +96,7 @@ jobs:
           path: |
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz
-      - name: Upload built artifact
+      - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         if: always() && contains(matrix.configure-args, '--enable-gcov')
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: "check-debian-stable-amd64-gcc",       task: "check",     container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
-          - { id: "check-debian-stable-amd64-clang",     task: "check",     container: "debian:stable", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
-          - { id: "distcheck-debian-stable-amd64-gcc",   task: "distcheck", container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
-          - { id: "distcheck-debian-stable-amd64-clang", task: "distcheck", container: "debian:stable", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
+          - { id: "check-debian-stable-amd64-gcc",       task: "check",     configure-args: "--enable-ja-rule --enable-e133 --enable-gcov",                         container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
+          - { id: "check-debian-stable-amd64-clang",     task: "check",     configure-args: "--enable-ja-rule --enable-e133 --enable-gcov",                         container: "debian:stable", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
+          - { id: "distcheck-debian-stable-amd64-gcc",   task: "distcheck", configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs", container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
+          - { id: "distcheck-debian-stable-amd64-clang", task: "distcheck", configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs", container: "debian:stable", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
     env:
       CC: "${{ matrix.compiler.CC }}"
       CXX: "${{ matrix.compiler.CXX }}"
@@ -57,7 +57,7 @@ jobs:
         run: sudo -u builduser autoreconf -i
       - name: Set configure arguments
         run: |
-          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133" >> $GITHUB_ENV
+          echo "GH_OLA_CONFIGURE_ARGS=${{ matrix.configure-args }}" >> $GITHUB_ENV
       - name: Set additional Linux configure arguments
         if: runner.os == 'Linux'
         # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,8 @@
 name: build
 on: [push, pull_request]
 jobs:
-  check:
-    name: "check ${{ matrix.id }}"
+  build:
+    name: "${{ matrix.id }}"
     runs-on: ubuntu-20.04
     container: debian:stable
     timeout-minutes: 360
@@ -10,8 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: "debian-stable-amd64-gcc",   compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
-          - { id: "debian-stable-amd64-clang", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
+          - { id: "check-debian-stable-amd64-gcc",       task: "check",     compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
+          - { id: "check-debian-stable-amd64-clang",     task: "check",     compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
+          - { id: "distcheck-debian-stable-amd64-gcc",   task: "distcheck", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
+          - { id: "distcheck-debian-stable-amd64-clang", task: "distcheck", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
     env:
       CC: "${{ matrix.compiler.CC }}"
       CXX: "${{ matrix.compiler.CXX }}"
@@ -61,9 +63,8 @@ jobs:
       - name: Configure
         run: ./configure $GH_OLA_CONFIGURE_ARGS
       - name: check
-        # TODO(Perry): Parallelization causes GH Actions to hang
-        # run: make check -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
-        run: make check -j1 VERBOSE=1
+        # TODO(Perry): Parallelization causes GH Actions to hang -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }}
+        run: make {{ matrix.task }} -j1 VERBOSE=1
       - name: Display structure of the built files
         if: always() && env.ACTIONS_STEP_DEBUG == 'true'
         run: ls -alR

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,13 +126,13 @@ jobs:
       - name: Update package database
         run: apt-get update -y
       - name: Install coverage tools
-        run: apt-get -y install curl gcc-10 python3-pip
+        run: apt-get -y install curl gcc python3-pip libcppunit-dev
       - name: Install Python coverage tools
         run: python3 -m pip install --no-input gcovr
       - name: Run gcovr
         shell: bash
         run: |
-          python3 -m gcovr --print-summary --txt coverage.txt --csv coverage.csv --json coverage.json --xml coverage.xml --html coverage.html --html-self-contained --coveralls coverage.coveralls.json --gcov-executable /usr/bin/gcov-10 --root . -e '.*Test\.cpp$' -e '.*\.pb\.cc$' -e '.*\.pb\.cpp$' -e '.*\.pb\.h$' -e '.*\.yy\.cpp$' -e '.*\.tab\.cpp$' -e '.*\.tab\.h$' -e '.*/doxygen/examples.*$'
+          python3 -m gcovr --print-summary --txt coverage.txt --csv coverage.csv --json coverage.json --xml coverage.xml --html coverage.html --html-self-contained --coveralls coverage.coveralls.json --gcov-executable /usr/bin/gcov --root . -e '.*Test\.cpp$' -e '.*\.pb\.cc$' -e '.*\.pb\.cpp$' -e '.*\.pb\.h$' -e '.*\.yy\.cpp$' -e '.*\.tab\.cpp$' -e '.*\.tab\.h$' -e '.*/doxygen/examples.*$'
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,13 +28,13 @@ jobs:
       # create a .git folder or .git.config. The Problem Matcher looks for
       # .git/config to find where the root of the repo is, so it must be
       # present.
-      - name: Install Git and adduser
+      - name: Install Git
         run: apt-get -y install git
       - uses: actions/checkout@v3
       - name: Install build tools
         shell: bash
         run: |
-          apt-get -y install adduser pkg-config libtool autoconf \
+          apt-get -y install adduser sudo pkg-config libtool autoconf \
             automake g++ bison flex make bash-completion dh-autoreconf \
             debhelper devscripts wget python3-pip
       - name: Install build dependencies
@@ -48,7 +48,7 @@ jobs:
       - name: Install compiler
         shell: bash
         run: apt-get -y install ${{ matrix.compiler.pkg }}
-      - name: Set up build user
+      - name: Set up build user # CredentialsTest cannot run as root
         run: |
           adduser --disabled-password --gecos "" builduser
           chown -R builduser:builduser .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,8 +49,9 @@ jobs:
       - name: Autoreconf
         run: autoreconf -i
       - name: Set configure arguments
+        # usbdmx may cause GH action build to hang and fail
         run: |
-          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133" >> $GITHUB_ENV
+          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133 --disable-usbdmx" >> $GITHUB_ENV
       - name: Set additional Linux configure arguments
         if: runner.os == 'Linux'
         # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,9 +10,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: "coverage-debian-stable-amd64-gcc",    task: "check",     configure-args: "--enable-ja-rule --enable-e133 --enable-gcov",                         container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
-          - { id: "distcheck-debian-stable-amd64-gcc",   task: "distcheck", configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs", container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
-          - { id: "distcheck-debian-stable-amd64-clang", task: "distcheck", configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs", container: "debian:stable", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
+          - id: "coverage-debian-stable-amd64-gcc"
+            task: "check"
+            configure-args: "--enable-ja-rule --enable-e133 --enable-gcov"
+            container: "debian:stable"
+            compiler: 
+              CC: "/usr/bin/gcc"
+              CXX: "/usr/bin/g++"
+              pkg: "gcc g++"
+          - id: "distcheck-debian-stable-amd64-gcc"
+            task: "distcheck"
+            configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs"
+            container: "debian:stable"
+            compiler:
+              CC: "/usr/bin/gcc"
+              CXX: "/usr/bin/g++"
+              pkg: "gcc g++"
+          - id: "distcheck-debian-stable-amd64-clang"
+            task: "distcheck"
+            configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs"
+            container: "debian:stable"
+            compiler:
+              CC: "/usr/bin/clang"
+              CXX: "/usr/bin/clang++"
+              pkg: "clang"
     env:
       CC: "${{ matrix.compiler.CC }}"
       CXX: "${{ matrix.compiler.CXX }}"
@@ -109,7 +130,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: "coverage-debian-stable-amd64-gcc" }
+          - id: "coverage-debian-stable-amd64-gcc"
     steps:
       - name: Download built source tree archive
         uses: actions/download-artifact@v3
@@ -168,8 +189,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: "distcheck-debian-stable-amd64-gcc"   }
-          - { id: "distcheck-debian-stable-amd64-clang" }
+          - id: "distcheck-debian-stable-amd64-gcc"
+          - id: "distcheck-debian-stable-amd64-clang"
     steps:
       - name: Download built source tree archive
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -114,34 +114,34 @@ jobs:
           - { id: "distcheck-debian-stable-amd64-gcc"   }
           - { id: "distcheck-debian-stable-amd64-clang" }
     steps:
-      - uses: actions/checkout@master
-      - name: Download build artifact
+      - name: Download built source tree archive
         uses: actions/download-artifact@v3
         with:
           name: ola-${{ matrix.id }}-source-tree
-          path: artifact
-      - name: Display structure of artifact files
-        run: ls -alR
-        working-directory: download
-      - name: Extract the source tree
+          path: .
+      - name: SHA256 artifact archive
+        run: sha256sum ola-${{ matrix.id }}-source-tree.tar.gz
+      - name: Unarchive artifacts and delete archive
         shell: bash
-        run: tar -xvzf ola-${{ matrix.id }}-source-tree.tar.gz
-        working-directory: artifact
+        run: |
+          tar -xvzfola-${{ matrix.id }}-source-tree.tar.gz .
+          rm ola-${{ matrix.id }}-source-tree.tar.gz
+      - name: Display structure of extracted files
+        if: env.ACTIONS_STEP_DEBUG == 'true'
+        run: ls -alR
       - name: Update package database
         run: apt-get update -y
-      - name: Install dependencies to verify trees
-        run: apt-get install -y python-is-python3
+      - name: Install Python
+        run: apt-get -y install python3 python-is-python3
+      - name: Enable Problem Matcher for GitHub annotations
+        run: echo "::add-matcher::.github/problem-matcher-build-verify-trees.json"
       - name: Find dist build tarball
         run: |
-          echo "GH_OLA_VERIFY_TREES_TARBALL=$(ls --time=birth ola*.tar.gz| head -1)" >> $GITHUB_ENV
-        working-directory: artifact/ola-${{ matrix.id }}-source-tree
+          echo "GH_OLA_VERIFY_TREES_TARBALL=$(ls -t --time=birth ola*.tar.gz| head -1)" >> $GITHUB_ENV
       - name: Print dist build tarball name
         run: echo "$GH_OLA_VERIFY_TREES_TARBALL"
-        working-directory: artifact/ola-${{ matrix.id }}-source-tree
       - name: Extract dist build
         run: tar -xvzf $GH_OLA_VERIFY_TREES_TARBALL
-        working-directory: artifact/ola-${{ matrix.id }}-source-tree
       - name: Verify trees
         shell: bash
         run: ./scripts/verify_trees.py ./ $(echo $GH_OLA_VERIFY_TREES_TARBALL | sed 's/.tar.gz$//')
-        working-directory: artifact/ola-${{ matrix.id }}-source-tree

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,11 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: "debian:stable-amd64-gcc",   compiler: { cc: "gcc",   cxx: "g++"     } }
-          - { id: "debian:stable-amd64-clang", compiler: { cc: "clang", cxx: "clang++" } }
+          - { id: "debian-stable-amd64-gcc",   compiler: { CC: "/usr/bin/gcc",   CXX: "g++",     pkg: "gcc g++" } }
+          - { id: "debian-stable-amd64-clang", compiler: { CC: "/usr/bin/clang", CXX: "clang++", pkg: "clang"   } }
     env:
-      CC: "{{ matrix.compiler.cc }}"
-      CXX: "{{ matrix.compiler.cxx }}"
+      CC: "{{ matrix.compiler.CC }}"
+      CXX: "{{ matrix.compiler.CXX }}"
     steps:
       - name: Get number of CPU cores
         run: echo "NUM_CPU_CORES=$(grep -c processor /proc/cpuinfo)" >> $GITHUB_OUTPUT
@@ -42,6 +42,9 @@ jobs:
             libprotobuf-dev libprotoc-dev zlib1g-dev libftdi-dev \
             libusb-1.0-0-dev liblo-dev libavahi-client-dev python3-numpy \
             default-jdk-headless maven
+      - name: Install compiler
+        shell: bash
+        run: apt-get -y install ${{ matrix.compiler.pkg }}
       - name: Autoreconf
         run: autoreconf -i
       - name: Set configure arguments

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,7 @@ jobs:
       CXX: "${{ matrix.compiler.CXX }}"
     steps:
       - name: Get number of CPU cores
+        id: num-cpu-cores
         # TODO(Perry): Parallelization causes GH Actions to hang -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }}
         # run: echo "NUM_CPU_CORES=$(grep -c processor /proc/cpuinfo)" >> $GITHUB_OUTPUT
         run: echo "NUM_CPU_CORES=1" >> $GITHUB_OUTPUT
@@ -101,7 +102,7 @@ jobs:
       - name: Configure
         run: sudo --preserve-env -u builduser env "PATH=$PATH" ./configure $GH_OLA_CONFIGURE_ARGS
       - name: ${{ matrix.task }}
-        run: sudo --preserve-env -u builduser env "PATH=$PATH" make ${{ matrix.task }} -j1 VERBOSE=1
+        run: sudo --preserve-env -u builduser env "PATH=$PATH" make ${{ matrix.task }} -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
       - name: Display structure of the built files
         if: always() && env.ACTIONS_STEP_DEBUG == 'true'
         run: ls -alR

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,17 +125,31 @@ jobs:
         run: ls -alR
       - name: Update package database
         run: apt-get update -y
-      - name: Install coverage dependencies
-        run: apt-get -y install curl gcov-10
-      - name: Run gcov
+      - name: Install coverage tools
+        run: apt-get -y install curl gcov-10 python3-pip
+      - name: Install Python coverage tools
+        run: python3 -m pip install --no-input gcovr
+      - name: Run gcovr
         shell: bash
         run: |
-          /usr/bin/gcov-10 --long-file-names --preserve-paths --root . -e '.*Test\.cpp$' -e '.*\.pb\.cc$' -e '.*\.pb\.cpp$' -e '.*\.pb\.h$' -e '.*\.yy\.cpp$' -e '.*\.tab\.cpp$' -e '.*\.tab\.h$' -e '.*/doxygen/examples.*$'
+          python3 -m gcovr --print-summary --txt coverage.txt --csv coverage.csv --json coverage.json --xml coverage.xml --html coverage.html --html-self-contained --coveralls coverage.coveralls.json --gcov-executable /usr/bin/gcov-10 --root . -e '.*Test\.cpp$' -e '.*\.pb\.cc$' -e '.*\.pb\.cpp$' -e '.*\.pb\.h$' -e '.*\.yy\.cpp$' -e '.*\.tab\.cpp$' -e '.*\.tab\.h$' -e '.*/doxygen/examples.*$'
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:
-          format: gcov
+          file: coverage.coveralls.json
           flag-name: ${{ matrix.id }}
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ola-${{ matrix.id }}-coverage
+          path: |
+            coverage.txt
+            coverage.csv
+            coverage.json
+            coverage.xml
+            coverage.html
+            coverage.coveralls.json
   verify-trees:
     name: 'Verify trees for ${{ matrix.id }}'
     needs: build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,3 +88,12 @@ jobs:
           path: |
             ola-*.tar.gz
             !ola-${{ matrix.id }}-distcheck-source-tree.tar.gz
+      - name: Install dependencies to verify trees
+        run: apt-get install -y python-is-python3
+      - name: Verify trees
+        shell: bash
+        run: |
+          tarball=$(ls -Ut ola*.tar.gz | head -1)
+          tar -zxf $tarball;
+          tarball_root=$(echo $tarball | sed 's/.tar.gz$//')
+          ./scripts/verify_trees.py ./ $tarball_root

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -182,7 +182,7 @@ jobs:
         run: apt-get update -y
       - name: Install Python
         run: apt-get -y install python3 python-is-python3
-      # Disable problem matcher for now until verify trees is fixed
+      # TODO(Perry): Disable problem matcher for now until verify trees is fixed
       # - name: Enable Problem Matcher for GitHub annotations
       #   run: echo "::add-matcher::.github/problem-matcher-build-verify-trees.json"
       - name: Find dist build tarball

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,8 @@ jobs:
           apt-get -y install adduser sudo pkg-config libtool autoconf \
             automake g++ bison flex make bash-completion dh-autoreconf \
             debhelper devscripts wget python3-pip
+      - name: Install Python build tools
+        run: python3 -m pip install --no-input gcovr
       - name: Install build dependencies
         shell: bash
         run: |
@@ -126,13 +128,20 @@ jobs:
       - name: Update package database
         run: apt-get update -y
       - name: Install coverage tools
-        run: apt-get -y install curl gcc python3-pip libcppunit-dev
+        run: apt-get -y install curl gcc python3-pip
       - name: Install Python coverage tools
         run: python3 -m pip install --no-input gcovr
-      - name: Run gcovr
+      - name: Install build dependencies
         shell: bash
         run: |
-          python3 -m gcovr --print-summary --txt coverage.txt --csv coverage.csv --json coverage.json --xml coverage.xml --html coverage.html --html-self-contained --coveralls coverage.coveralls.json --gcov-executable /usr/bin/gcov --root . -e '.*Test\.cpp$' -e '.*\.pb\.cc$' -e '.*\.pb\.cpp$' -e '.*\.pb\.h$' -e '.*\.yy\.cpp$' -e '.*\.tab\.cpp$' -e '.*\.tab\.h$' -e '.*/doxygen/examples.*$'
+          apt-get -y install libcppunit-dev uuid-dev libncurses5-dev \
+            libmicrohttpd-dev protobuf-compiler python3-protobuf \
+            libprotobuf-dev libprotoc-dev zlib1g-dev libftdi-dev \
+            libusb-1.0-0-dev liblo-dev libavahi-client-dev python3-numpy \
+            default-jdk-headless maven
+      - name: Generate coverage
+        shell: bash
+        run: make coverage VERBOSE=1
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,7 @@ jobs:
   build:
     name: "${{ matrix.id }}"
     runs-on: ubuntu-20.04
-    container:
-      image: debian:stable
-      options: --user 1000 # cannot run CredentialsTest as root
+    container: debian:stable
     timeout-minutes: 360
     strategy:
       fail-fast: false
@@ -30,13 +28,13 @@ jobs:
       # create a .git folder or .git.config. The Problem Matcher looks for
       # .git/config to find where the root of the repo is, so it must be
       # present.
-      - name: Install Git
+      - name: Install Git and adduser
         run: apt-get -y install git
       - uses: actions/checkout@v3
       - name: Install build tools
         shell: bash
         run: |
-          apt-get -y install pkg-config libtool autoconf \
+          apt-get -y install adduser pkg-config libtool autoconf \
             automake g++ bison flex make bash-completion dh-autoreconf \
             debhelper devscripts wget python3-pip
       - name: Install build dependencies
@@ -50,8 +48,13 @@ jobs:
       - name: Install compiler
         shell: bash
         run: apt-get -y install ${{ matrix.compiler.pkg }}
+      - name: Set up build user
+        run: |
+          adduser --disabled-password --gecos "" builduser
+          chown -R builduser:builduser .
+          chown builduser:builduser ..
       - name: Autoreconf
-        run: autoreconf -i
+        run: sudo -u builduser autoreconf -i
       - name: Set configure arguments
         run: |
           echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133" >> $GITHUB_ENV
@@ -63,10 +66,10 @@ jobs:
       - name: Print configure command
         run: echo "./configure $GH_OLA_CONFIGURE_ARGS"
       - name: Configure
-        run: ./configure $GH_OLA_CONFIGURE_ARGS
+        run: sudo -u builduser ./configure $GH_OLA_CONFIGURE_ARGS
       - name: ${{ matrix.task }}
         # TODO(Perry): Parallelization causes GH Actions to hang -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }}
-        run: make ${{ matrix.task }} -j1 VERBOSE=1
+        run: sudo -u builduser make ${{ matrix.task }} -j1 VERBOSE=1
       - name: Display structure of the built files
         if: always() && env.ACTIONS_STEP_DEBUG == 'true'
         run: ls -alR

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Set configure arguments
         # usbdmx may cause GH action build to hang and fail
         run: |
-          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133 --disable-usbdmx" >> $GITHUB_ENV
+          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133 --disable-usbdmx --disable-usbpro" >> $GITHUB_ENV
       - name: Set additional Linux configure arguments
         if: runner.os == 'Linux'
         # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,6 +96,9 @@ jobs:
           path: |
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz
+      - name: Install curl
+        if: always() && contains(matrix.configure-args, '--enable-gcov')
+        run: apt-get -y install curl
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         if: always() && contains(matrix.configure-args, '--enable-gcov')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,10 +121,10 @@ jobs:
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz
       - name: Install coverage tools
-        if: contains(matrix.configure-args, '--enable-gcov')
+        if: matrix.task == 'coverage'
         run: apt-get -y install curl
       - name: Upload coverage to Coveralls
-        if: contains(matrix.configure-args, '--enable-gcov')
+        if: matrix.task == 'coverage'
         uses: coverallsapp/github-action@v2
         with:
           # Coveralls GitHub action does not support its own format
@@ -134,7 +134,7 @@ jobs:
           format: cobertura
           flag-name: ${{ matrix.id }}
       - name: Upload coverage artifacts
-        if: always() && contains(matrix.configure-args, '--enable-gcov')
+        if: always() && matrix.task == 'coverage'
         uses: actions/upload-artifact@v3
         with:
           name: ola-${{ matrix.id }}-coverage

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,10 +98,10 @@ jobs:
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz
       - name: Install dependencies to verify trees
-        if: ${{ matrix.task == "distcheck" }}
+        if: matrix.task == 'distcheck'
         run: apt-get install -y python-is-python3
       - name: Verify trees
-        if: ${{ matrix.task == "distcheck" }}
+        if: matrix.task == 'distcheck'
         shell: bash
         # Use second-most-recently-created file; first is the source tree
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         run: autoreconf -i
       - name: Set configure arguments
         run: |
-          echo "GH_OLA_CONFIGURE_ARGS="--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133" >> $GITHUB_ENV
+          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133" >> $GITHUB_ENV
       - name: Set additional Linux configure arguments
         if: runner.os == 'Linux'
         # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,8 +50,9 @@ jobs:
         run: autoreconf -i
       - name: Set configure arguments
         # usbdmx may cause GH action build to hang and fail
+        # TODO(Perry): re-renable ja-rule and usbdmx
         run: |
-          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133 --disable-usbdmx --disable-usbpro" >> $GITHUB_ENV
+          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-e133 --disable-usbdmx" >> $GITHUB_ENV
       - name: Set additional Linux configure arguments
         if: runner.os == 'Linux'
         # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,9 @@ jobs:
       CXX: "${{ matrix.compiler.CXX }}"
     steps:
       - name: Get number of CPU cores
-        run: echo "NUM_CPU_CORES=$(grep -c processor /proc/cpuinfo)" >> $GITHUB_OUTPUT
+        # TODO(Perry): Parallelization causes GH Actions to hang -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }}
+        # run: echo "NUM_CPU_CORES=$(grep -c processor /proc/cpuinfo)" >> $GITHUB_OUTPUT
+        run: echo "NUM_CPU_CORES=1" >> $GITHUB_OUTPUT
       - name: Update package database
         run: apt-get update -y
       # See comments beginning at
@@ -90,8 +92,7 @@ jobs:
       - name: Configure
         run: sudo -u builduser ./configure $GH_OLA_CONFIGURE_ARGS
       - name: ${{ matrix.task }}
-        # TODO(Perry): Parallelization causes GH Actions to hang -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }}
-        run: sudo -u builduser make ${{ matrix.task }} -j1 VERBOSE=1
+        run: sudo -u builduser make ${{ matrix.task }} -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
       - name: Display structure of the built files
         if: always() && env.ACTIONS_STEP_DEBUG == 'true'
         run: ls -alR

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: "coverage-debian-stable-amd64-gcc",    task: "coverage",  configure-args: "--enable-ja-rule --enable-e133 --enable-gcov",                         container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
+          - { id: "coverage-debian-stable-amd64-gcc",    task: "check",     configure-args: "--enable-ja-rule --enable-e133 --enable-gcov",                         container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
           - { id: "distcheck-debian-stable-amd64-gcc",   task: "distcheck", configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs", container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
           - { id: "distcheck-debian-stable-amd64-clang", task: "distcheck", configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs", container: "debian:stable", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
     env:
@@ -98,7 +98,7 @@ jobs:
             !ola-${{ matrix.id }}-source-tree.tar.gz
       - name: Upload built artifact
         uses: coverallsapp/github-action@v2
-        if: always() && matrix.id == 'coverage'
+        if: always() && contains(matrix.configure-args, '--enable-gcov')
         with:
           flag-name: ${{ matrix.id }}
   verify-trees:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -149,8 +149,8 @@ jobs:
           # Coveralls GitHub action does not support its own format
           # see: https://github.com/coverallsapp/github-action/issues/104
           # file: coverage.coveralls.json
-          file: coverage/coverage.xml
-          format: gcov
+          file: coverage/coverage.cobertura.xml
+          format: cobertura
           flag-name: ${{ matrix.id }}
       - name: Upload coverage artifacts
         if: always()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,16 +4,16 @@ jobs:
   build:
     name: "${{ matrix.id }}"
     runs-on: ubuntu-20.04
-    container: debian:stable
+    container: ${{ matrix.container }}
     timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { id: "check-debian-stable-amd64-gcc",       task: "check",     compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
-          - { id: "check-debian-stable-amd64-clang",     task: "check",     compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
-          - { id: "distcheck-debian-stable-amd64-gcc",   task: "distcheck", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
-          - { id: "distcheck-debian-stable-amd64-clang", task: "distcheck", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
+          - { id: "check-debian-stable-amd64-gcc",       task: "check",     container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
+          - { id: "check-debian-stable-amd64-clang",     task: "check",     container: "debian:stable", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
+          - { id: "distcheck-debian-stable-amd64-gcc",   task: "distcheck", container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
+          - { id: "distcheck-debian-stable-amd64-clang", task: "distcheck", container: "debian:stable", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
     env:
       CC: "${{ matrix.compiler.CC }}"
       CXX: "${{ matrix.compiler.CXX }}"
@@ -98,11 +98,14 @@ jobs:
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz
       - name: Install dependencies to verify trees
+        if: ${{ matrix.task }} == "distcheck"
         run: apt-get install -y python-is-python3
       - name: Verify trees
+        if: ${{ matrix.task }} == "distcheck
         shell: bash
+        # Use second-most-recently-created file; first is the source tree
         run: |
-          tarball=$(ls -Ut ola*.tar.gz | head -1)
+          tarball=$(ls --time=birth ola*.tar.gz | sed -n '2 p')
           tar -zxf $tarball;
           tarball_root=$(echo $tarball | sed 's/.tar.gz$//')
           ./scripts/verify_trees.py ./ $tarball_root

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,9 +50,9 @@ jobs:
         run: autoreconf -i
       - name: Set configure arguments
         # usbdmx may cause GH action build to hang and fail
-        # TODO(Perry): re-renable ja-rule and usbdmx
+        # TODO(Perry): re-renable ja-rule, usbdmx, and usbpro
         run: |
-          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-e133 --disable-usbdmx" >> $GITHUB_ENV
+          echo "GH_OLA_CONFIGURE_ARGS=--enable-rdm-tests --enable-java-libs --enable-e133 --disable-usbdmx --disable-usbpro" >> $GITHUB_ENV
       - name: Set additional Linux configure arguments
         if: runner.os == 'Linux'
         # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,8 @@ jobs:
           - id: "coverage-debian-stable-amd64-gcc"
             task: "coverage"
             configure-args: "--enable-ja-rule --enable-e133 --enable-unittests --enable-gcov"
-            container: "debian:stable"
+            # TODO(Perry): Fix Debian 12 OOM issue on GitHub Actions
+            container: "debian:11"
             compiler: 
               CC: "/usr/bin/gcc"
               CXX: "/usr/bin/g++"
@@ -21,7 +22,8 @@ jobs:
           - id: "distcheck-debian-stable-amd64-gcc"
             task: "distcheck"
             configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs"
-            container: "debian:stable"
+            # TODO(Perry): Fix Debian 12 OOM issue on GitHub Actions
+            container: "debian:11"
             compiler:
               CC: "/usr/bin/gcc"
               CXX: "/usr/bin/g++"
@@ -29,7 +31,8 @@ jobs:
           - id: "distcheck-debian-stable-amd64-clang"
             task: "distcheck"
             configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs"
-            container: "debian:stable"
+            # TODO(Perry): Fix Debian 12 OOM issue on GitHub Actions
+            container: "debian:11"
             compiler:
               CC: "/usr/bin/clang"
               CXX: "/usr/bin/clang++"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,15 +97,44 @@ jobs:
           path: |
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz
+  verify-trees:
+    name: 'Verify trees for ${{ matrix.id }}'
+    needs: build
+    if: "always()" # Run if some builds fail but ensure they all complete first
+    container: debian:stable
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { id: "distcheck-debian-stable-amd64-gcc"   }
+          - { id: "distcheck-debian-stable-amd64-clang" }
+    steps:
+      - uses: actions/checkout@master
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ola-${{ matrix.id }}-source-tree
+          path: built
+      - name: Display structure of artifact files
+        if: always() && env.ACTIONS_STEP_DEBUG == 'true'
+        run: ls -alR
+        working-directory: built
+      - name: Update package database
+        run: apt-get update -y
       - name: Install dependencies to verify trees
-        if: matrix.task == 'distcheck'
         run: apt-get install -y python-is-python3
-      - name: Verify trees
-        if: matrix.task == 'distcheck'
-        shell: bash
-        # Use second-most-recently-created file; first is the source tree
+      - name: Find dist build tarball
         run: |
-          tarball=$(ls --time=birth ola*.tar.gz | sed -n '2 p')
-          tar -zxf $tarball;
-          tarball_root=$(echo $tarball | sed 's/.tar.gz$//')
-          ./scripts/verify_trees.py ./ $tarball_root
+          echo "GH_OLA_VERIFY_TREES_TARBALL=$(ls --time=birth ola*.tar.gz| head -1)" >> $GITHUB_ENV
+        working-directory: built
+      - name: Print dist build tarball name
+        run: echo "$GH_OLA_VERIFY_TREES_TARBALL"
+        working-directory: built
+      - name: Extract dist build
+        run: tar -zxvf $GH_OLA_VERIFY_TREES_TARBALL
+        working-directory: built
+      - name: Verify trees
+        shell: bash
+        run: ./scripts/verify_trees.py ./ $(echo $GH_OLA_VERIFY_TREES_TARBALL | sed 's/.tar.gz$//')
+        working-directory: built

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Configure
         run: sudo --preserve-env -u builduser env "PATH=$PATH" ./configure $GH_OLA_CONFIGURE_ARGS
       - name: ${{ matrix.task }}
-        run: sudo --preserve-env -u builduser env "PATH=$PATH" make ${{ matrix.task }} -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
+        run: sudo --preserve-env -u builduser env "PATH=$PATH" make ${{ matrix.task }} -j1 VERBOSE=1
       - name: Display structure of the built files
         if: always() && env.ACTIONS_STEP_DEBUG == 'true'
         run: ls -alR

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
           chown -R builduser:builduser .
           chown builduser:builduser ..
       - name: Autoreconf
-        run: sudo -u builduser autoreconf -i
+        run: sudo --preserve-env -u builduser env "PATH=$PATH" autoreconf -i
       - name: Set configure arguments
         run: |
           echo "GH_OLA_CONFIGURE_ARGS=${{ matrix.configure-args }}" >> $GITHUB_ENV
@@ -96,9 +96,9 @@ jobs:
       - name: Print configure command
         run: echo "./configure $GH_OLA_CONFIGURE_ARGS"
       - name: Configure
-        run: sudo -u builduser ./configure $GH_OLA_CONFIGURE_ARGS
+        run: sudo --preserve-env -u builduser env "PATH=$PATH" ./configure $GH_OLA_CONFIGURE_ARGS
       - name: ${{ matrix.task }}
-        run: sudo -u builduser make ${{ matrix.task }} -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
+        run: sudo --preserve-env -u builduser env "PATH=$PATH" make ${{ matrix.task }} -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
       - name: Display structure of the built files
         if: always() && env.ACTIONS_STEP_DEBUG == 'true'
         run: ls -alR

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,6 +92,7 @@ jobs:
           name: ola-${{ matrix.id }}-source-tree
           path: ola-${{ matrix.id }}-source-tree.tar.gz
       - name: Upload built artifact
+        if: matrix.task == 'distcheck' or matrix.task == 'dist'
         uses: actions/upload-artifact@v3
         with:
           name: ola-${{ matrix.id }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,7 +148,7 @@ jobs:
         with:
           # Coveralls GitHub action does not support its own format
           # see: https://github.com/coverallsapp/github-action/issues/104
-          # file: coverage.coveralls.json
+          # file: coverage/coverage.coveralls.json
           file: coverage/coverage.cobertura.xml
           format: cobertura
           flag-name: ${{ matrix.id }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,13 +96,45 @@ jobs:
           path: |
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz
-      - name: Install curl
-        if: always() && contains(matrix.configure-args, '--enable-gcov')
-        run: apt-get -y install curl
+  coverage:
+    name: 'Coverage for ${{ matrix.id }}'
+    needs: build
+    if: "always()" # Run if some builds fail but ensure they all complete first
+    container: debian:stable
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { id: "coverage-debian-stable-amd64-gcc" }
+    steps:
+      - name: Download built source tree archive
+        uses: actions/download-artifact@v3
+        with:
+          name: ola-${{ matrix.id }}-source-tree
+          path: .
+      - name: SHA256 artifact archive
+        run: sha256sum ola-${{ matrix.id }}-source-tree.tar.gz
+      - name: Unarchive artifacts and delete archive
+        shell: bash
+        run: |
+          tar -xvzf ola-${{ matrix.id }}-source-tree.tar.gz .
+          rm ola-${{ matrix.id }}-source-tree.tar.gz
+      - name: Display structure of extracted files
+        if: env.ACTIONS_STEP_DEBUG == 'true'
+        run: ls -alR
+      - name: Update package database
+        run: apt-get update -y
+      - name: Install coverage dependencies
+        run: apt-get -y install curl gcov-10
+      - name: Run gcov
+        shell: bash
+        run: |
+          /usr/bin/gcov-10 --long-file-names --preserve-paths --root . -e '.*Test\.cpp$' -e '.*\.pb\.cc$' -e '.*\.pb\.cpp$' -e '.*\.pb\.h$' -e '.*\.yy\.cpp$' -e '.*\.tab\.cpp$' -e '.*\.tab\.h$' -e '.*/doxygen/examples.*$'
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
-        if: always() && contains(matrix.configure-args, '--enable-gcov')
         with:
+          format: gcov
           flag-name: ${{ matrix.id }}
   verify-trees:
     name: 'Verify trees for ${{ matrix.id }}'
@@ -127,7 +159,7 @@ jobs:
       - name: Unarchive artifacts and delete archive
         shell: bash
         run: |
-          tar -xvzfola-${{ matrix.id }}-source-tree.tar.gz .
+          tar -xvzf ola-${{ matrix.id }}-source-tree.tar.gz .
           rm ola-${{ matrix.id }}-source-tree.tar.gz
       - name: Display structure of extracted files
         if: env.ACTIONS_STEP_DEBUG == 'true'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,9 @@ jobs:
   build:
     name: "${{ matrix.id }}"
     runs-on: ubuntu-20.04
-    container: debian:stable
+    container:
+      image: debian:stable
+      options: --user 1000 # cannot run CredentialsTest as root
     timeout-minutes: 360
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   distcheck:
     name: "distcheck ${{ matrix.id }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: debian:stable
     timeout-minutes: 360
     strategy:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,8 @@
 name: build
 on: [push, pull_request]
 jobs:
-  distcheck:
-    name: "distcheck ${{ matrix.id }}"
+  check:
+    name: "check ${{ matrix.id }}"
     runs-on: ubuntu-20.04
     container: debian:stable
     timeout-minutes: 360
@@ -60,8 +60,8 @@ jobs:
         run: echo "./configure $GH_OLA_CONFIGURE_ARGS"
       - name: Configure
         run: ./configure $GH_OLA_CONFIGURE_ARGS
-      - name: distcheck
-        run: make distcheck -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
+      - name: check
+        run: make check -j${{ steps.num-cpu-cores.outputs.NUM_CPU_CORES }} VERBOSE=1
       - name: Display structure of the built files
         if: always() && env.ACTIONS_STEP_DEBUG == 'true'
         run: ls -alR
@@ -71,8 +71,8 @@ jobs:
         # If the file does not exist when tar excludes it, then it will not
         # actually exclude it, so it must first be touched
         run: |
-          touch ola-${{ matrix.id }}-distcheck-source-tree.tar.gz
-          tar --exclude=ola-${{ matrix.id }}-distcheck-source-tree.tar.gz -cvzf ola-${{ matrix.id }}-distcheck-source-tree.tar.gz .
+          touch ola-${{ matrix.id }}-check-source-tree.tar.gz
+          tar --exclude=ola-${{ matrix.id }}-check-source-tree.tar.gz -cvzf ola-${{ matrix.id }}-check-source-tree.tar.gz .
       - name: SHA256 artifact archives
         if: always()
         run: sha256sum ola-*.tar.gz
@@ -80,15 +80,15 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ola-${{ matrix.id }}-distcheck-source-tree
-          path: ola-${{ matrix.id }}-distcheck-source-tree.tar.gz
+          name: ola-${{ matrix.id }}-check-source-tree
+          path: ola-${{ matrix.id }}-check-source-tree.tar.gz
       - name: Upload built artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ola-${{ matrix.id }}-distcheck
+          name: ola-${{ matrix.id }}-check
           path: |
             ola-*.tar.gz
-            !ola-${{ matrix.id }}-distcheck-source-tree.tar.gz
+            !ola-${{ matrix.id }}-check-source-tree.tar.gz
       - name: Install dependencies to verify trees
         run: apt-get install -y python-is-python3
       - name: Verify trees

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         include:
           - id: "coverage-debian-stable-amd64-gcc"
-            task: "check"
-            configure-args: "--enable-ja-rule --enable-e133 --enable-gcov"
+            task: "coverage"
+            configure-args: "--enable-ja-rule --enable-e133 --enable-unittests --enable-gcov"
             container: "debian:stable"
             compiler: 
               CC: "/usr/bin/gcc"
@@ -120,51 +120,11 @@ jobs:
           path: |
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz
-  coverage:
-    name: 'Coverage for ${{ matrix.id }}'
-    needs: build
-    if: "always()" # Run if some builds fail but ensure they all complete first
-    container: debian:stable
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - id: "coverage-debian-stable-amd64-gcc"
-    steps:
-      - name: Download built source tree archive
-        uses: actions/download-artifact@v3
-        with:
-          name: ola-${{ matrix.id }}-source-tree
-          path: .
-      - name: SHA256 artifact archive
-        run: sha256sum ola-${{ matrix.id }}-source-tree.tar.gz
-      - name: Unarchive artifacts and delete archive
-        shell: bash
-        run: |
-          tar -xvzf ola-${{ matrix.id }}-source-tree.tar.gz .
-          rm ola-${{ matrix.id }}-source-tree.tar.gz
-      - name: Display structure of extracted files
-        if: env.ACTIONS_STEP_DEBUG == 'true'
-        run: ls -alR
-      - name: Update package database
-        run: apt-get update -y
       - name: Install coverage tools
-        run: apt-get -y install curl gcc python3-pip
-      - name: Install Python coverage tools
-        run: python3 -m pip install --no-input gcovr
-      - name: Install build dependencies
-        shell: bash
-        run: |
-          apt-get -y install libcppunit-dev uuid-dev libncurses5-dev \
-            libmicrohttpd-dev protobuf-compiler python3-protobuf \
-            libprotobuf-dev libprotoc-dev zlib1g-dev libftdi-dev \
-            libusb-1.0-0-dev liblo-dev libavahi-client-dev python3-numpy \
-            default-jdk-headless maven
-      - name: Generate coverage
-        shell: bash
-        run: make coverage VERBOSE=1
+        if: contains(matrix.configure-args, '--enable-gcov')
+        run: apt-get -y install curl
       - name: Upload coverage to Coveralls
+        if: contains(matrix.configure-args, '--enable-gcov')
         uses: coverallsapp/github-action@v2
         with:
           # Coveralls GitHub action does not support its own format
@@ -174,7 +134,7 @@ jobs:
           format: cobertura
           flag-name: ${{ matrix.id }}
       - name: Upload coverage artifacts
-        if: always()
+        if: always() && contains(matrix.configure-args, '--enable-gcov')
         uses: actions/upload-artifact@v3
         with:
           name: ola-${{ matrix.id }}-coverage

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -211,8 +211,9 @@ jobs:
         run: apt-get update -y
       - name: Install Python
         run: apt-get -y install python3 python-is-python3
-      - name: Enable Problem Matcher for GitHub annotations
-        run: echo "::add-matcher::.github/problem-matcher-build-verify-trees.json"
+      # Disable problem matcher for now until verify trees is fixed
+      # - name: Enable Problem Matcher for GitHub annotations
+      #   run: echo "::add-matcher::.github/problem-matcher-build-verify-trees.json"
       - name: Find dist build tarball
         run: |
           echo "GH_OLA_VERIFY_TREES_TARBALL=$(ls -t --time=birth ola*.tar.gz| head -1)" >> $GITHUB_ENV
@@ -222,4 +223,6 @@ jobs:
         run: tar -xvzf $GH_OLA_VERIFY_TREES_TARBALL
       - name: Verify trees
         shell: bash
-        run: ./scripts/verify_trees.py ./ $(echo $GH_OLA_VERIFY_TREES_TARBALL | sed 's/.tar.gz$//')
+        # Always succeed for now until verify trees is fixed
+        # run: ./scripts/verify_trees.py ./ $(echo $GH_OLA_VERIFY_TREES_TARBALL | sed 's/.tar.gz$//')
+        run: "./scripts/verify_trees.py ./ $(echo $GH_OLA_VERIFY_TREES_TARBALL | sed 's/.tar.gz$//') || true"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,8 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: "check-debian-stable-amd64-gcc",       task: "check",     configure-args: "--enable-ja-rule --enable-e133 --enable-gcov",                         container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
-          - { id: "check-debian-stable-amd64-clang",     task: "check",     configure-args: "--enable-ja-rule --enable-e133 --enable-gcov",                         container: "debian:stable", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
+          - { id: "coverage-debian-stable-amd64-gcc",    task: "coverage",  configure-args: "--enable-ja-rule --enable-e133 --enable-gcov",                         container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
           - { id: "distcheck-debian-stable-amd64-gcc",   task: "distcheck", configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs", container: "debian:stable", compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
           - { id: "distcheck-debian-stable-amd64-clang", task: "distcheck", configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs", container: "debian:stable", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
     env:
@@ -97,6 +96,11 @@ jobs:
           path: |
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz
+      - name: Upload built artifact
+        uses: coverallsapp/github-action@v2
+        if: always() && matrix.id == 'coverage'
+        with:
+          flag-name: ${{ matrix.id }}
   verify-trees:
     name: 'Verify trees for ${{ matrix.id }}'
     needs: build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
             task: "coverage"
             configure-args: "--enable-ja-rule --enable-e133 --enable-unittests --enable-gcov"
             # TODO(Perry): Fix Debian 12 OOM issue on GitHub Actions
-            container: "debian:11"
+            container: "debian:stable"
             compiler: 
               CC: "/usr/bin/gcc"
               CXX: "/usr/bin/g++"
@@ -23,7 +23,7 @@ jobs:
             task: "distcheck"
             configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs"
             # TODO(Perry): Fix Debian 12 OOM issue on GitHub Actions
-            container: "debian:11"
+            container: "debian:stable"
             compiler:
               CC: "/usr/bin/gcc"
               CXX: "/usr/bin/g++"
@@ -32,7 +32,7 @@ jobs:
             task: "distcheck"
             configure-args: "--enable-ja-rule --enable-e133 --enable-rdm-tests --enable-java-libs"
             # TODO(Perry): Fix Debian 12 OOM issue on GitHub Actions
-            container: "debian:11"
+            container: "debian:stable"
             compiler:
               CC: "/usr/bin/clang"
               CXX: "/usr/bin/clang++"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,13 @@ jobs:
         run: |
           apt-get -y install adduser sudo pkg-config libtool autoconf \
             automake g++ bison flex make bash-completion dh-autoreconf \
-            debhelper devscripts wget python3-pip
+            debhelper devscripts wget python3-full python3-pip
+      - name: Setup Python venv
+        shell: bash
+        run: |
+          python3 -m venv ../venv
+          source ../venv/bin/activate
+          echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Install Python build tools
         run: python3 -m pip install --no-input gcovr
       - name: Install build dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
           name: ola-${{ matrix.id }}-source-tree
           path: ola-${{ matrix.id }}-source-tree.tar.gz
       - name: Upload built artifact
-        if: matrix.task == 'distcheck' or matrix.task == 'dist'
+        if: matrix.task == 'distcheck' || matrix.task == 'dist'
         uses: actions/upload-artifact@v3
         with:
           name: ola-${{ matrix.id }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: build
 on: [push, pull_request]
 jobs:
   distcheck:
-    name: "distcheck {{ matrix.id }}"
+    name: "distcheck ${{ matrix.id }}"
     runs-on: ubuntu-latest
     container: debian:stable
     strategy:
@@ -67,19 +67,19 @@ jobs:
         # If the file does not exist when tar excludes it, then it will not
         # actually exclude it, so it must first be touched
         run: |
-          touch ola-{{ matrix.id }}-distcheck-source-tree.tar.gz
-          tar --exclude=ola-{{ matrix.id }}-distcheck-source-tree.tar.gz -cvzf ola-{{ matrix.id }}-distcheck-source-tree.tar.gz .
+          touch ola-${{ matrix.id }}-distcheck-source-tree.tar.gz
+          tar --exclude=ola-${{ matrix.id }}-distcheck-source-tree.tar.gz -cvzf ola-${{ matrix.id }}-distcheck-source-tree.tar.gz .
       - name: SHA256 artifact archives
         if: always()
         run: sha256sum ola-*.tar.gz
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ola-{{ matrix.id }}-distcheck-source-tree
-          path: ola-{{ matrix.id }}-distcheck-source-tree.tar.gz
+          name: ola-${{ matrix.id }}-distcheck-source-tree
+          path: ola-${{ matrix.id }}-distcheck-source-tree.tar.gz
       - uses: actions/upload-artifact@v3
         with:
-          name: ola-{{ matrix.id }}-distcheck
+          name: ola-${{ matrix.id }}-distcheck
           path: |
             ola-*.tar.gz
-            !ola-{{ matrix.id }}-distcheck-source-tree.tar.gz
+            !ola-${{ matrix.id }}-distcheck-source-tree.tar.gz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,8 +12,8 @@ jobs:
           - { id: "debian-stable-amd64-gcc",   compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
           - { id: "debian-stable-amd64-clang", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
     env:
-      CC: "{{ matrix.compiler.CC }}"
-      CXX: "{{ matrix.compiler.CXX }}"
+      CC: "${{ matrix.compiler.CC }}"
+      CXX: "${{ matrix.compiler.CXX }}"
     steps:
       - name: Get number of CPU cores
         run: echo "NUM_CPU_CORES=$(grep -c processor /proc/cpuinfo)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
         if: matrix.task == 'distcheck' || matrix.task == 'dist'
         uses: actions/upload-artifact@v3
         with:
-          name: ola-${{ matrix.id }}
+          name: ola-${{ matrix.id }}-dist
           path: |
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,10 +98,10 @@ jobs:
             ola-*.tar.gz
             !ola-${{ matrix.id }}-source-tree.tar.gz
       - name: Install dependencies to verify trees
-        if: ${{ matrix.task }} == "distcheck"
+        if: ${{ matrix.task == "distcheck" }}
         run: apt-get install -y python-is-python3
       - name: Verify trees
-        if: ${{ matrix.task }} == "distcheck
+        if: ${{ matrix.task == "distcheck" }}
         shell: bash
         # Use second-most-recently-created file; first is the source tree
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: "debian-stable-amd64-gcc",   compiler: { CC: "/usr/bin/gcc",   CXX: "g++",     pkg: "gcc g++" } }
-          - { id: "debian-stable-amd64-clang", compiler: { CC: "/usr/bin/clang", CXX: "clang++", pkg: "clang"   } }
+          - { id: "debian-stable-amd64-gcc",   compiler: { CC: "/usr/bin/gcc",   CXX: "/usr/bin/g++",     pkg: "gcc g++" } }
+          - { id: "debian-stable-amd64-clang", compiler: { CC: "/usr/bin/clang", CXX: "/usr/bin/clang++", pkg: "clang"   } }
     env:
       CC: "{{ matrix.compiler.CC }}"
       CXX: "{{ matrix.compiler.CXX }}"
@@ -75,12 +75,14 @@ jobs:
       - name: SHA256 artifact archives
         if: always()
         run: sha256sum ola-*.tar.gz
-      - uses: actions/upload-artifact@v3
+      - name: Upload source tree artifact
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: ola-${{ matrix.id }}-distcheck-source-tree
           path: ola-${{ matrix.id }}-distcheck-source-tree.tar.gz
-      - uses: actions/upload-artifact@v3
+      - name: Upload built artifact
+        uses: actions/upload-artifact@v3
         with:
           name: ola-${{ matrix.id }}-distcheck
           path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: debian:stable-amd64-gcc,   compiler: { cc: "gcc",   cxx: "g++"     }}
-          - { id: debian:stable-amd64-clang, compiler: { cc: "clang", cxx: "clang++" }}
+          - { id: debian:stable-amd64-gcc,   compiler: { cc: "gcc",   cxx: "g++"     } }
+          - { id: debian:stable-amd64-clang, compiler: { cc: "clang", cxx: "clang++" } }
     env:
       CC: "{{ matrix.compiler.cc }}"
       CXX: "{{ matrix.compiler.cxx }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,7 +146,11 @@ jobs:
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:
-          file: coverage.coveralls.json
+          # Coveralls GitHub action does not support its own format
+          # see: https://github.com/coverallsapp/github-action/issues/104
+          # file: coverage.coveralls.json
+          file: coverage.txt
+          format: gcov
           flag-name: ${{ matrix.id }}
       - name: Upload coverage artifacts
         if: always()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,12 +34,12 @@ jobs:
         run: autoreconf -i
       - name: Set configure arguments
         run: |
-          echo "GH_OLA_CONFIGURE_ARGS=\"--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133\"" >> $GITHUB_ENV
+          echo "GH_OLA_CONFIGURE_ARGS="--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133" >> $GITHUB_ENV
       - name: Set additional Linux configure arguments
         if: runner.os == 'Linux'
         # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long
         run: |
-          echo "GH_OLA_CONFIGURE_ARGS=\"$GH_OLA_CONFIGURE_ARGS CPPFLAGS=-Wno-deprecated-declarations\"" >> $GITHUB_ENV
+          echo "GH_OLA_CONFIGURE_ARGS=$GH_OLA_CONFIGURE_ARGS CPPFLAGS=-Wno-deprecated-declarations" >> $GITHUB_ENV
       - name: Configure
         run: ./configure $GH_OLA_CONFIGURE_ARGS
       - name: Distcheck

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
             libmicrohttpd-dev protobuf-compiler python3-protobuf \
             libprotobuf-dev libprotoc-dev zlib1g-dev libftdi-dev \
             libusb-1.0-0-dev liblo-dev libavahi-client-dev python3-numpy \
-            javacc
+            default-jdk-headless
       - name: Autoreconf
         run: autoreconf -i
       - name: Set configure arguments

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Python venv
         shell: bash
         run: |
-          python3 -m venv ../venv
+          python3 -m venv --system-site-packages ../venv
           source ../venv/bin/activate
           echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Install Python lint tools
@@ -144,7 +144,7 @@ jobs:
       - name: Setup Python venv
         shell: bash
         run: |
-          python3 -m venv ../venv
+          python3 -m venv --system-site-packages ../venv
           source ../venv/bin/activate
           echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Install Python lint tools
@@ -181,7 +181,7 @@ jobs:
       - name: Setup Python venv
         shell: bash
         run: |
-          python3 -m venv ../venv
+          python3 -m venv --system-site-packages ../venv
           source ../venv/bin/activate
           echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Install Python lint tools
@@ -247,7 +247,7 @@ jobs:
       - name: Setup Python venv
         shell: bash
         run: |
-          python3 -m venv ../venv
+          python3 -m venv --system-site-packages ../venv
           source ../venv/bin/activate
           echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Install Python lint tools

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,13 @@ jobs:
         run: |
           apt-get -y install pkg-config libtool autoconf \
             automake g++ bison flex make bash-completion dh-autoreconf \
-            debhelper devscripts wget python3-pip
+            debhelper devscripts wget python3-full python3-pip
+      - name: Setup Python venv
+        shell: bash
+        run: |
+          python3 -m venv ../venv
+          source ../venv/bin/activate
+          echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Install Python lint tools
         run: python3 -m pip install --no-input cpplint flake8
       - name: Install build dependencies
@@ -134,9 +140,13 @@ jobs:
       - name: Update package database
         run: apt-get update -y
       - name: Install build tools
+        run: apt-get -y install make python3-full python3-pip
+      - name: Setup Python venv
         shell: bash
         run: |
-          apt-get -y install make python3-pip
+          python3 -m venv ../venv
+          source ../venv/bin/activate
+          echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Install Python lint tools
         run: python3 -m pip install --no-input cpplint
       - name: Enable Problem Matcher for GitHub annotations
@@ -167,9 +177,13 @@ jobs:
       - name: Update package database
         run: apt-get update -y
       - name: Install build tools
+        run: apt-get -y install make python3-full python3-pip
+      - name: Setup Python venv
         shell: bash
         run: |
-          apt-get -y install make python3-pip
+          python3 -m venv ../venv
+          source ../venv/bin/activate
+          echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Install Python lint tools
         run: python3 -m pip install --no-input flake8
       - name: Setup flake8 annotations
@@ -229,7 +243,13 @@ jobs:
       - name: Update package database
         run: apt-get update -y
       - name: Install lint tools
-        run: apt-get -y install python3-pip git moreutils
+        run: apt-get -y install python3-full python3-pip git moreutils
+      - name: Setup Python venv
+        shell: bash
+        run: |
+          python3 -m venv ../venv
+          source ../venv/bin/activate
+          echo "PATH=$PATH" >> $GITHUB_ENV
       - name: Install Python lint tools
         run: python3 -m pip install --no-input git+https://github.com/codespell-project/codespell.git
       - name: Setup codespell annotations

--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,9 @@ javascript/new-src/node_modules
 .autotools
 .cproject
 .settings
+coverage.txt
+coverage.csv
+coverage.json
+coverage.xml
+coverage.html
+coverage.coveralls.json

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ config.h.in~
 config.log
 config.status
 configure
+coverage/
 cpplint.py
 doxygen_entrydb_*.tmp
 doxygen_objdb_*.tmp
@@ -250,9 +251,3 @@ javascript/new-src/node_modules
 .autotools
 .cproject
 .settings
-coverage.txt
-coverage.csv
-coverage.json
-coverage.xml
-coverage.html
-coverage.coveralls.json

--- a/Makefile.am
+++ b/Makefile.am
@@ -281,10 +281,14 @@ COVERAGE_FILTERS=-e '.*Test\.cpp$$' \
 	-e '.*\.tab\.h$$' \
 	-e '.*/doxygen/examples.*$$'
 .PHONY : coverage
-coverage: Makefile.am
+coverage: all
+if !BUILD_GCOV
+	$(error Generating coverage requires configuring with --enable-gcov)
+else
 if FOUND_GCOVR
 	mkdir -p coverage/details.html/
 	gcovr --print-summary $(COVERAGE_OUTPUTS) $(COVERAGE_GCOV_EXE) --root . $(COVERAGE_FILTERS)
 else
 	$(error gcovr not found. Install gcovr (e.g. via pip for the latest version) and re-run configure.)
+endif
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -268,7 +268,7 @@ endif
 COVERAGE_OUTPUTS = --txt coverage/coverage.txt \
 	--csv coverage/coverage.csv \
 	--json coverage/coverage.json \
-	--xml coverage/coverage.xml \
+	--cobertura coverage/coverage.cobertura.xml \
 	--html-details coverage/details.html/coverage.details.html \
 	--coveralls coverage/coverage.coveralls.json
 COVERAGE_GCOV_EXE=--gcov-executable /usr/bin/gcov

--- a/Makefile.am
+++ b/Makefile.am
@@ -265,12 +265,12 @@ else
 endif
 
 # coverage
-COVERAGE_OUTPUTS = --txt coverage.txt \
-	--csv coverage.csv \
-	--json coverage.json \
-	--xml coverage.xml \
-	--html coverage.html --html-self-contained \
-	--coveralls coverage.coveralls.json
+COVERAGE_OUTPUTS = --txt coverage/coverage.txt \
+	--csv coverage/coverage.csv \
+	--json coverage/coverage.json \
+	--xml coverage/coverage.xml \
+	--html-details coverage/details.html/coverage.details.html \
+	--coveralls coverage/coverage.coveralls.json
 COVERAGE_GCOV_EXE=--gcov-executable /usr/bin/gcov
 COVERAGE_FILTERS=-e '.*Test\.cpp$$' \
 	-e '.*\.pb\.cc$$' \
@@ -283,6 +283,7 @@ COVERAGE_FILTERS=-e '.*Test\.cpp$$' \
 .PHONY : coverage
 coverage: Makefile.am
 if FOUND_GCOVR
+	mkdir -p coverage/details.html/
 	gcovr --print-summary $(COVERAGE_OUTPUTS) $(COVERAGE_GCOV_EXE) --root . $(COVERAGE_FILTERS)
 else
 	$(error gcovr not found. Install gcovr (e.g. via pip for the latest version) and re-run configure.)

--- a/Makefile.am
+++ b/Makefile.am
@@ -281,7 +281,7 @@ COVERAGE_FILTERS=-e '.*Test\.cpp$$' \
 	-e '.*\.tab\.h$$' \
 	-e '.*/doxygen/examples.*$$'
 .PHONY : coverage
-coverage: all
+coverage: Makefile.am check
 if !BUILD_GCOV
 	$(error Generating coverage requires configuring with --enable-gcov)
 else

--- a/Makefile.am
+++ b/Makefile.am
@@ -263,3 +263,27 @@ if FOUND_CPPLINT
 else
 	$(error cpplint not found. Install the forked cpplint (e.g. via pip for the latest version) and re-run configure.)
 endif
+
+# coverage
+COVERAGE_OUTPUTS = --txt coverage.txt \
+	--csv coverage.csv \
+	--json coverage.json \
+	--xml coverage.xml \
+	--html coverage.html --html-self-contained \
+	--coveralls coverage.coveralls.json
+COVERAGE_GCOV_EXE=--gcov-executable /usr/bin/gcov
+COVERAGE_FILTERS=-e '.*Test\.cpp$$' \
+	-e '.*\.pb\.cc$$' \
+	-e '.*\.pb\.cpp$$' \
+	-e '.*\.pb\.h$$' \
+	-e '.*\.yy\.cpp$$' \
+	-e '.*\.tab\.cpp$$' \
+	-e '.*\.tab\.h$$' \
+	-e '.*/doxygen/examples.*$$'
+.PHONY : coverage
+coverage: Makefile.am
+if FOUND_GCOVR
+	gcovr --print-summary $(COVERAGE_OUTPUTS) $(COVERAGE_GCOV_EXE) --root . $(COVERAGE_FILTERS)
+else
+	$(error gcovr not found. Install gcovr (e.g. via pip for the latest version) and re-run configure.)
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -1039,7 +1039,7 @@ Now type 'make @<:@<target>@:>@'
   where the optional <target> is:
     all          - build everything
     check        - run the tests
-    coverage     - build and generate coverage
+    coverage     - build tests and generate coverage
     doxygen-doc  - generate the HTML documentation
     lint         - run the linters
 -------------------------------------------------------"

--- a/configure.ac
+++ b/configure.ac
@@ -608,6 +608,7 @@ AS_IF([test "x$enable_gcov" = xyes],
       [CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
        CXXFLAGS="$CXXFLAGS -fprofile-arcs -ftest-coverage"
        LIBS="$LIBS -lgcov"])
+AM_CONDITIONAL([BUILD_GCOV], [test "x$enable_gcov" = xyes])
 
 # Enable HTTP support. This requires libmicrohttpd.
 AC_ARG_ENABLE(
@@ -1038,7 +1039,7 @@ Now type 'make @<:@<target>@:>@'
   where the optional <target> is:
     all          - build everything
     check        - run the tests
+    coverage     - build and generate coverage
     doxygen-doc  - generate the HTML documentation
     lint         - run the linters
-    coverage     - generate coverage post --enable-gcov
 -------------------------------------------------------"

--- a/configure.ac
+++ b/configure.ac
@@ -962,6 +962,10 @@ AM_CONDITIONAL([FOUND_FLAKE8], [test "x$flake8" = xyes])
 AC_CHECK_PROG([cpplint],[cpplint],[yes],[no])
 AM_CONDITIONAL([FOUND_CPPLINT], [test "x$cpplint" = xyes])
 
+# Coverage
+AC_CHECK_PROG([gcovr],[gcovr],[yes],[no])
+AM_CONDITIONAL([FOUND_GCOVR], [test "x$gcovr" = xyes])
+
 # Output
 #####################################################
 # Hack alert!
@@ -1036,4 +1040,5 @@ Now type 'make @<:@<target>@:>@'
     check        - run the tests
     doxygen-doc  - generate the HTML documentation
     lint         - run the linters
+    coverage     - generate coverage post --enable-gcov
 -------------------------------------------------------"


### PR DESCRIPTION
This is just a draft! Still lots to do, but it should go quickly once I fix this pesky GH Actions cancel issue.

Only problem right now is getting GitHub not to cancel the build after 45 minutes. It must be OOM or some other resource; GitHub usually allows jobs to run for a very, very long time.

Example cancelled build (not by me!):
 - Rerunning this one now, maybe it will work: https://github.com/DaAwesomeP/ola/actions/runs/4355751567
 - https://github.com/DaAwesomeP/ola/actions/runs/4339605290