### PR TITLE
Run CI Daily

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,10 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
 jobs:
   build:
     name: "${{ matrix.id }}"

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -2,7 +2,12 @@
 # https://salsa.debian.org/wouter/ola/-/blob/a38a396f6994b2b1af8efec9e208aee4e67f77aa/.gitlab-ci.yml
 
 name: debian
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
 jobs:
   debian-build:
     name: 'Debian Build ${{ matrix.image_tag }} ${{ matrix.architecture }}'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,10 @@
 name: lint
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
 jobs:
   build:
     name: Build for Lint Tasks


### PR DESCRIPTION
This pull causes the CI to run everyday at 12am UTC. This should hopefully help catch issues before they end up failing in unrelated pull requests. This should definitely help catch the frequent new codespell matches.