### PR TITLE
Codespell Ignore package-lock.json

### DIFF
--- a/scripts/spelling.sh
+++ b/scripts/spelling.sh
@@ -64,6 +64,7 @@ SPELLINGBLACKLIST=$(cat <<-BLACKLIST
       -wholename "./configure" -or \
       -wholename "./java/Makefile" -or \
       -wholename "./java/Makefile.in" -or \
+      -wholename "./javascript/new-src/package-lock.json" -or \
       -wholename "./libtool" -or \
       -wholename "./olad/www/mobile.js" -or \
       -wholename "./olad/www/new/js/app.min.js" -or \


### PR DESCRIPTION
Found in #1868. Technically the `0.10` branch passes lint without this, but this file should never be checked regardless (machine generated).