### PR TITLE
Track Eurolite MK2 by actual serial number where available

### DIFF
--- a/plugins/usbdmx/AVLdiyD512Factory.cpp
+++ b/plugins/usbdmx/AVLdiyD512Factory.cpp
@@ -63,6 +63,9 @@ bool AVLdiyD512Factory::DeviceAdded(
   // Some AVLdiy devices don't have serial numbers. Since there isn't another
   // good way to uniquely identify a USB device, we only support one of these
   // types of devices per host.
+  // TODO(Peter): We could instead use the device & bus number (like the
+  // Eurolite plugin). You could use more than one device, but the patch
+  // wouldn't follow if you plugged it into a different port
   if (info.serial.empty()) {
     if (m_missing_serial_number) {
       OLA_WARN << "Failed to read serial number or serial number empty. "

--- a/plugins/usbdmx/AnymauDMXFactory.cpp
+++ b/plugins/usbdmx/AnymauDMXFactory.cpp
@@ -63,6 +63,9 @@ bool AnymauDMXFactory::DeviceAdded(
   // Some Anyma devices don't have serial numbers. Since there isn't another
   // good way to uniquely identify a USB device, we only support one of these
   // types of devices per host.
+  // TODO(Peter): We could instead use the device & bus number (like the
+  // Eurolite plugin). You could use more than one device, but the patch
+  // wouldn't follow if you plugged it into a different port
   if (info.serial.empty()) {
     if (m_missing_serial_number) {
       OLA_WARN << "Failed to read serial number or serial number empty. "

--- a/plugins/usbdmx/DMXCreator512BasicFactory.cpp
+++ b/plugins/usbdmx/DMXCreator512BasicFactory.cpp
@@ -55,6 +55,9 @@ bool DMXCreator512BasicFactory::DeviceAdded(
   // vendor and product ids. Also, since DMXCreator 512 Basic devices don't have
   // serial numbers and there is no other good way to uniquely identify a USB
   // device, we only support one of these types of devices per host.
+  // TODO(Peter): We could instead use the device & bus number (like the
+  // Eurolite plugin). You could use more than one device, but the patch
+  // wouldn't follow if you plugged it into a different port
   if (info.serial.empty()) {
     if (m_missing_serial_number) {
       OLA_WARN << "We can only support one device without a serial number.";

--- a/plugins/usbdmx/EuroliteProFactory.cpp
+++ b/plugins/usbdmx/EuroliteProFactory.cpp
@@ -150,17 +150,21 @@ bool EuroliteProFactory::DeviceAdded(
     return false;
   }
 
-  // The Eurolite doesn't have a serial number, so instead we use the device &
-  // bus number.
+  // The original Eurolite doesn't have a serial number, so instead we use the
+  // device & bus number. The MK2 does, so we use that where available.
   // TODO(simon): check if this supports the SERIAL NUMBER label and use that
   // instead.
 
-  // There is no Serialnumber--> work around: bus+device number
-  int bus_number = libusb_get_bus_number(usb_device);
-  int device_address = libusb_get_device_address(usb_device);
-
   std::ostringstream serial_str;
-  serial_str << bus_number << "-" << device_address;
+  if (is_mk2 && !info.serial.empty()) {
+    serial_str << info.serial;
+  } else {
+    // Original, there is no Serialnumber--> work around: bus+device number
+    int bus_number = libusb_get_bus_number(usb_device);
+    int device_address = libusb_get_device_address(usb_device);
+
+    serial_str << bus_number << "-" << device_address;
+  }
 
   EurolitePro *widget = NULL;
   if (FLAGS_use_async_libusb) {

--- a/plugins/usbdmx/EuroliteProFactory.cpp
+++ b/plugins/usbdmx/EuroliteProFactory.cpp
@@ -92,11 +92,11 @@ bool EuroliteProFactory::DeviceAdded(
     libusb_device *usb_device,
     const struct libusb_device_descriptor &descriptor) {
   bool is_mk2 = false;
+  LibUsbAdaptor::DeviceInformation info;
 
   // Eurolite USB-DMX512-PRO?
   if (descriptor.idVendor == VENDOR_ID && descriptor.idProduct == PRODUCT_ID) {
     OLA_INFO << "Found a new Eurolite USB-DMX512-PRO device";
-    LibUsbAdaptor::DeviceInformation info;
     if (!m_adaptor->GetDeviceInfo(usb_device, descriptor, &info)) {
       return false;
     }
@@ -112,7 +112,6 @@ bool EuroliteProFactory::DeviceAdded(
   // Eurolite USB-DMX512-PRO MK2?
   } else if (descriptor.idVendor == VENDOR_ID_MK2 &&
              descriptor.idProduct == PRODUCT_ID_MK2) {
-    LibUsbAdaptor::DeviceInformation info;
     if (!m_adaptor->GetDeviceInfo(usb_device, descriptor, &info)) {
       return false;
     }

--- a/plugins/usbdmx/ScanlimeFadecandyFactory.cpp
+++ b/plugins/usbdmx/ScanlimeFadecandyFactory.cpp
@@ -64,6 +64,9 @@ bool ScanlimeFadecandyFactory::DeviceAdded(
   // Fadecandy devices may be missing serial numbers. Since there isn't another
   // good way to uniquely identify a USB device, we only support one of these
   // types of devices per host.
+  // TODO(Peter): We could instead use the device & bus number (like the
+  // Eurolite plugin). You could use more than one device, but the patch
+  // wouldn't follow if you plugged it into a different port
   if (info.serial.empty()) {
     if (m_missing_serial_number) {
       OLA_WARN << "Failed to read serial number or serial number empty. "


### PR DESCRIPTION
@aroffringa can you give this a test as mentioned in #1888 please.

This should mean the patch persists even when you plug it into a different USB port, which it won't do currently.

You should be able to see that either way as the serial number should show in the device name/description in OLA.

_Originally posted by @peternewman in https://github.com/OpenLightingProject/ola/pull/1888#discussion_r1404340274_