### PR TITLE
Workaround gcovr parse race condition bug

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -272,9 +272,9 @@ COVERAGE_OUTPUTS = --txt coverage/coverage.txt \
 	--html-details coverage/details.html/coverage.details.html \
 	--coveralls coverage/coverage.coveralls.json
 # See https://gcovr.com/en/stable/guide/gcov_parser.html#negative-hit-counts
-COVERAGE_FLAGS=--gcov-ignore-parse-errors=negative_hits.warn_once_per_file
-COVERAGE_GCOV_EXE=--gcov-executable /usr/bin/gcov
-COVERAGE_FILTERS=-e '.*Test\.cpp$$' \
+COVERAGE_FLAGS = --gcov-ignore-parse-errors=negative_hits.warn_once_per_file
+COVERAGE_GCOV_EXE = --gcov-executable /usr/bin/gcov
+COVERAGE_FILTERS = -e '.*Test\.cpp$$' \
 	-e '.*\.pb\.cc$$' \
 	-e '.*\.pb\.cpp$$' \
 	-e '.*\.pb\.h$$' \

--- a/Makefile.am
+++ b/Makefile.am
@@ -271,6 +271,8 @@ COVERAGE_OUTPUTS = --txt coverage/coverage.txt \
 	--cobertura coverage/coverage.cobertura.xml \
 	--html-details coverage/details.html/coverage.details.html \
 	--coveralls coverage/coverage.coveralls.json
+# See https://gcovr.com/en/stable/guide/gcov_parser.html#negative-hit-counts
+COVERAGE_FLAGS=--gcov-ignore-parse-errors=negative_hits.warn_once_per_file
 COVERAGE_GCOV_EXE=--gcov-executable /usr/bin/gcov
 COVERAGE_FILTERS=-e '.*Test\.cpp$$' \
 	-e '.*\.pb\.cc$$' \
@@ -287,7 +289,7 @@ if !BUILD_GCOV
 else
 if FOUND_GCOVR
 	mkdir -p coverage/details.html/
-	gcovr --print-summary $(COVERAGE_OUTPUTS) $(COVERAGE_GCOV_EXE) --root . $(COVERAGE_FILTERS)
+	gcovr $(COVERAGE_FLAGS) --print-summary $(COVERAGE_OUTPUTS) $(COVERAGE_GCOV_EXE) --root . $(COVERAGE_FILTERS)
 else
 	$(error gcovr not found. Install gcovr (e.g. via pip for the latest version) and re-run configure.)
 endif


### PR DESCRIPTION
This bug is causing the coverage run to fail every so often. Using an officially documented workaround from here: https://gcovr.com/en/stable/guide/gcov_parser.html#negative-hit-counts

See also a similar bug in another project: https://github.com/zephyrproject-rtos/zephyr/issues/64396