### PR TITLE
Fix template usage with % in OSC device listing

### DIFF
--- a/plugins/osc/OSCPlugin.cpp
+++ b/plugins/osc/OSCPlugin.cpp
@@ -158,8 +158,8 @@ bool OSCPlugin::SetDefaultPreferences() {
 
   for (unsigned int i = 0; i < GetPortCount(INPUT_PORT_COUNT_KEY); i++) {
     const string key = ExpandTemplate(PORT_ADDRESS_TEMPLATE, i);
-    save |= m_preferences->SetDefaultValue(key, StringValidator(),
-                                           DEFAULT_ADDRESS_TEMPLATE);
+    const string value = ExpandTemplate(DEFAULT_ADDRESS_TEMPLATE, i);
+    save |= m_preferences->SetDefaultValue(key, StringValidator(), value);
   }
 
   set<string> valid_formats;


### PR DESCRIPTION
ola_dev_info was showing un unexpanded '%d':

    Device 8: OSC Device
      port 0, IN /dmx/universe/%d, priority 100
      port 1, IN /dmx/universe/%d, priority 100
      port 2, IN /dmx/universe/%d, priority 100