### PR TITLE
Add DMXControl Projects e.V. Nodle R4S

### DIFF
--- a/debian/ola.udev
+++ b/debian/ola.udev
@@ -18,6 +18,9 @@ SUBSYSTEM=="usb|usb_device", ACTION=="add", ATTRS{idVendor}=="10cf", ATTRS{idPro
 # udev rules for the ShowJockey-DMX-U1 device
 SUBSYSTEM=="usb|usb_device", ACTION=="add", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="57fe", GROUP="plugdev"
 
+# udev rules for the DMXControl Projects e.V. Nodle R4S
+SUBSYSTEM=="usb|usb_device", ACTION=="add", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="0833", GROUP="plugdev", TAG+="uaccess"
+
 # udev rules for the DMXControl Projects e.V. Nodle U1
 SUBSYSTEM=="usb|usb_device", ACTION=="add", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="0830", GROUP="plugdev", TAG+="uaccess"
 

--- a/debian/org.openlighting.ola.ola.metainfo.xml
+++ b/debian/org.openlighting.ola.ola.metainfo.xml
@@ -27,6 +27,7 @@
     <modalias>usb:v0962p*</modalias> <!-- USBDMX2 -->
     <modalias>usb:v10CFp8062d*</modalias> <!-- Velleman -->
     <modalias>usb:v0a30p0002d*</modalias> <!-- DMXCreator 512 Basic -->
+    <modalias>usb:v16D0p0833d*</modalias> <!-- DMXControl Projects e.V. Nodle R4S -->
     <modalias>usb:v16D0p0830d*</modalias> <!-- DMXControl Projects e.V. Nodle U1 -->
     <modalias>usb:v04B4p0F1Fd*</modalias> <!-- Digital Enlightenment DMX-USB -->
     <modalias>usb:v16C0p088Bd*</modalias> <!-- FX5 DMX -->

--- a/plugins/usbdmx/DMXCProjectsNodleU1Factory.cpp
+++ b/plugins/usbdmx/DMXCProjectsNodleU1Factory.cpp
@@ -32,6 +32,7 @@ namespace usbdmx {
 
 const uint16_t DMXCProjectsNodleU1Factory::VENDOR_ID_DMXC_PROJECTS = 0x16d0;
 const uint16_t DMXCProjectsNodleU1Factory::PRODUCT_ID_DMXC_P_NODLE_U1 = 0x0830;
+const uint16_t DMXCProjectsNodleU1Factory::PRODUCT_ID_DMXC_P_NODLE_R4S = 0x0833;
 
 const uint16_t DMXCProjectsNodleU1Factory::VENDOR_ID_DE = 0x4b4;
 const uint16_t DMXCProjectsNodleU1Factory::PRODUCT_ID_DE_USB_DMX = 0xf1f;
@@ -45,6 +46,8 @@ bool DMXCProjectsNodleU1Factory::DeviceAdded(
     const struct libusb_device_descriptor &descriptor) {
   if (!((descriptor.idVendor == VENDOR_ID_DMXC_PROJECTS &&
          descriptor.idProduct == PRODUCT_ID_DMXC_P_NODLE_U1) ||
+        (descriptor.idVendor == VENDOR_ID_DMXC_PROJECTS &&
+         descriptor.idProduct == PRODUCT_ID_DMXC_P_NODLE_R4S) ||
         (descriptor.idVendor == VENDOR_ID_DE &&
          descriptor.idProduct == PRODUCT_ID_DE_USB_DMX) ||
         (descriptor.idVendor == VENDOR_ID_FX5 &&

--- a/plugins/usbdmx/DMXCProjectsNodleU1Factory.h
+++ b/plugins/usbdmx/DMXCProjectsNodleU1Factory.h
@@ -61,6 +61,7 @@ class DMXCProjectsNodleU1Factory :
   static const uint16_t VENDOR_ID_DE;
   static const uint16_t VENDOR_ID_FX5;
   static const uint16_t PRODUCT_ID_DMXC_P_NODLE_U1;
+  static const uint16_t PRODUCT_ID_DMXC_P_NODLE_R4S;
   static const uint16_t PRODUCT_ID_DE_USB_DMX;
   static const uint16_t PRODUCT_ID_FX5_DMX;
 

--- a/plugins/usbdmx/README.md
+++ b/plugins/usbdmx/README.md
@@ -6,6 +6,7 @@ This plugin supports various USB DMX devices including:
 * Anyma uDMX
 * AVLdiy D512
 * Digital Enlightenment USB-DMX
+* DMXControl Projects e.V. Nodle R4S
 * DMXControl Projects e.V. Nodle U1
 * DMXCreator 512 Basic
 * Eurolite USB-DMX512 PRO

--- a/plugins/usbdmx/UsbDmxPlugin.h
+++ b/plugins/usbdmx/UsbDmxPlugin.h
@@ -38,6 +38,7 @@ namespace usbdmx {
  * This plugin supports a number of USB dongles including
  *   - Anyma uDMX.
  *   - AVLdiy D512.
+ *   - DMXControl Projects e.V. Nodle R4S.
  *   - DMXControl Projects e.V. Nodle U1.
  *   - DMXCreator 512 Basic USB.
  *   - Eurolite DMX USB Pro.


### PR DESCRIPTION
Our "new" readymade USB DMX Interface "Nodle R4S" has a different PID than the Nodle U1, but otherwise is compatible.
So I just added the additional PID and list the R4S along with the U1.