### PR TITLE
Added plugin-related functions to the Java client

### DIFF
--- a/config/ola.m4
+++ b/config/ola.m4
@@ -25,10 +25,10 @@ AC_REQUIRE_CPP()
 PKG_CHECK_MODULES(libprotobuf, [protobuf >= $1])
 
 AC_MSG_CHECKING([protobuf library version])
-PROTOBUF_VERSION=`pkg-config --modversion protobuf`;
+PROTOBUF_VERSION=`protoc --version | awk '{print [$]2}'`;
+AC_MSG_NOTICE([PROTOBUF VERSION $PROTOBUF_VERSION])
 AC_MSG_RESULT([$PROTOBUF_VERSION])
 AC_SUBST([PROTOBUF_VERSION])
-
 AC_SUBST([libprotobuf_CFLAGS])
 
 AC_ARG_WITH([protoc],

--- a/java/ChangeLog
+++ b/java/ChangeLog
@@ -1,3 +1,9 @@
+02/10/2024 Moritz Vieli <moritz.vieli@gmail.com>
+ * v0.0.23
+  - Add OlaClient.reloadPlugins()
+  - Add OlaClient.getPluginState()
+  - Add OlaClient.setPluginState()
+
 04/22/2017 Erez Makavy <hepi.yellow@gmail.com>
  * v0.0.2 
   - Add OlaClient.getUniverseList()

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ola</groupId>
   <artifactId>ola-java-client</artifactId>
-  <version>0.1.0</version>
+  <version>0.0.3</version>
   <description>Java implementation of OLA RPC</description>
   <properties>
    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -36,8 +36,8 @@
        <artifactId>maven-compiler-plugin</artifactId>
        <version>2.5.1</version>
        <configuration>
-         <source>1.6</source>
-         <target>1.6</target>
+         <source>1.7</source>
+         <target>1.7</target>
        </configuration>
      </plugin>
      <plugin>

--- a/java/src/main/java/ola/OlaClient.java
+++ b/java/src/main/java/ola/OlaClient.java
@@ -120,7 +120,7 @@ public class OlaClient {
     /**
      * Reload the plugins.
      *
-     * @return The list of plugings.
+     * @return Acknowledgement.
      */
     public Ack reloadPlugins() {
         return (Ack) callRpcMethod("ReloadPlugins", PluginReloadRequest.newBuilder().build());
@@ -131,7 +131,7 @@ public class OlaClient {
      * Get a plugin description from olad.
      *
      * @param pluginId number of the plugin for which to receive the description
-     * @return The list of plugings.
+     * @return The description of the plugin.
      */
     public PluginDescriptionReply getPluginDescription(int pluginId) {
         PluginDescriptionRequest request = PluginDescriptionRequest.newBuilder()
@@ -162,7 +162,7 @@ public class OlaClient {
      *
      * @param pluginId number of the plugin for which to change the state
      * @param enabled  whether the plugin should be enabled or not
-     * @return The list of plugings.
+     * @return Acknowledgement.
      */
     public Ack setPluginState(int pluginId, boolean enabled) {
         PluginStateChangeRequest request = Ola.PluginStateChangeRequest.newBuilder()


### PR DESCRIPTION
- Add OlaClient.reloadPlugins()
- Add OlaClient.getPluginState()
- Add OlaClient.setPluginState()
- Changed evaluation of PROTOBUF_VERSION, because pkg-config adds trailing ".0" to the version, which is not compatible with the available Java dependencies

The last change needs to be checked carefully. I tried building it on a Mac and it failed with the pkg-config version, because of the trailing ".0". Using "protoc --version" works, but might introduce other issues.