### PR TITLE
Add conditionals for Protobuf 22+ API changes

### DIFF
--- a/protoc/ServiceGenerator.cpp
+++ b/protoc/ServiceGenerator.cpp
@@ -130,7 +130,12 @@ void ServiceGenerator::GenerateInterface(Printer* printer) {
   printer->Print(vars_,
     "\n"
     " private:\n"
+#if GOOGLE_PROTOBUF_VERSION < 4022000
     "  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS($classname$);\n"
+#else
+    "  $classname$(const $classname$&) = delete;\n"
+    "  $classname$& operator=(const $classname$&) = delete;\n"
+#endif
     "};\n"
     "\n");
 }
@@ -178,7 +183,12 @@ void ServiceGenerator::GenerateStubDefinition(Printer* printer) {
     " private:\n"
     "  ola::rpc::RpcChannel* channel_;\n"
     "  bool owns_channel_;\n"
+#if GOOGLE_PROTOBUF_VERSION < 4022000
     "  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS($classname$_Stub);\n"
+#else
+    "  $classname$_Stub(const $classname$_Stub&) = delete;\n"
+    "  $classname$_Stub& operator=(const $classname$_Stub&) = delete;\n"
+#endif
     "};\n"
     "\n");
 }
@@ -291,7 +301,11 @@ void ServiceGenerator::GenerateCallMethod(Printer* printer) {
     "    const ::google::protobuf::Message* request,\n"
     "    ::google::protobuf::Message* response,\n"
     "    ola::rpc::RpcService::CompletionCallback* done) {\n"
+#if GOOGLE_PROTOBUF_VERSION < 4022000
     "  GOOGLE_DCHECK_EQ(method->service(), $classname$_descriptor_);\n"
+#else
+    "  ABSL_DCHECK_EQ(method->service(), $classname$_descriptor_);\n"
+#endif
     "  switch (method->index()) {\n");
 
   for (int i = 0; i < descriptor_->method_count(); i++) {
@@ -308,17 +322,28 @@ void ServiceGenerator::GenerateCallMethod(Printer* printer) {
       "    case $index$:\n"
       "      $name$(\n"
       "          controller,\n"
+#if GOOGLE_PROTOBUF_VERSION < 4022000
       "          ::google::protobuf::down_cast<\n"
       "              const $input_type$*>(request),\n"
       "          ::google::protobuf::down_cast<\n"
       "              $output_type$*>(response),\n"
+#else
+      "          ::google::protobuf::internal::DownCast<\n"
+      "              const $input_type$*>(request),\n"
+      "          ::google::protobuf::internal::DownCast<\n"
+      "              $output_type$*>(response),\n"
+#endif
       "          done);\n"
       "      break;\n");
   }
 
   printer->Print(vars_,
     "    default:\n"
+#if GOOGLE_PROTOBUF_VERSION < 4022000
     "      GOOGLE_LOG(FATAL) << \"Bad method index; this should never "
+#else
+    "      ABSL_LOG(FATAL) << \"Bad method index; this should never "
+#endif
     "happen.\";\n"
     "      break;\n"
     "  }\n"
@@ -339,7 +364,11 @@ void ServiceGenerator::GenerateGetPrototype(RequestOrResponse which,
 
   printer->Print(vars_,
     "    const ::google::protobuf::MethodDescriptor* method) const {\n"
+#if GOOGLE_PROTOBUF_VERSION < 4022000
     "  GOOGLE_DCHECK_EQ(method->service(), descriptor());\n"
+#else
+    "  ABSL_DCHECK_EQ(method->service(), descriptor());\n"
+#endif
     "  switch (method->index()) {\n");
 
   for (int i = 0; i < descriptor_->method_count(); i++) {
@@ -358,7 +387,11 @@ void ServiceGenerator::GenerateGetPrototype(RequestOrResponse which,
 
   printer->Print(vars_,
     "    default:\n"
+#if GOOGLE_PROTOBUF_VERSION < 4022000
     "      GOOGLE_LOG(FATAL) << \"Bad method index; this should never happen."
+#else
+    "      ABSL_LOG(FATAL) << \"Bad method index; this should never happen."
+#endif
     "\";\n"
     "      return *static_cast< ::google::protobuf::Message*>(NULL);\n"
     "  }\n"

--- a/protoc/ServiceGenerator.h
+++ b/protoc/ServiceGenerator.h
@@ -114,7 +114,12 @@ class ServiceGenerator {
   const ServiceDescriptor* descriptor_;
   std::map<string, string> vars_;
 
+#if GOOGLE_PROTOBUF_VERSION < 4022000
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ServiceGenerator);
+#else
+  ServiceGenerator(const ServiceGenerator&) = delete;
+  ServiceGenerator& operator=(const ServiceGenerator&) = delete;
+#endif
 };
 
 }  // namespace ola

--- a/protoc/StrUtil.cpp
+++ b/protoc/StrUtil.cpp
@@ -56,6 +56,14 @@
 #include <google/protobuf/stubs/stl_util.h>
 #endif  // HAVE_GOOGLE_PROTOBUF_STUBS_STL_UTIL_H
 
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+#include <absl/log/absl_check.h>
+#include <absl/log/absl_log.h>
+#define GOOGLE_CHECK ABSL_CHECK
+#define GOOGLE_DCHECK_LT ABSL_CHECK_LT
+#define GOOGLE_LOG_IF(LEVEL, VECTOR) ABSL_LOG_IF(LEVEL, VECTOR)
+#endif
+
 #ifdef _WIN32
 // MSVC has only _snprintf, not snprintf.
 //


### PR DESCRIPTION
May need to check on some of these like if Abseil's once is equivalent.

Still needs build script fixes/workarounds to actually compile (workarounds specifically for C++17 removed functions assuming Abseil was built with that standard).

On macOS, I was able to build substituting `s/-std=gnu++11/-std=gnu++17/g` in configure.ac and restoring some removed functions in LLVM libc++:
```
CXXFLAGS=-D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR \
  -D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION \
  -D_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS
```

---

```
============================================================================
Testsuite summary for OLA 0.10.9
============================================================================
# TOTAL: 83
# PASS:  83
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```