### PR TITLE
Temporarily remove whitespace/indent_namespace from cpplint

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -246,7 +246,7 @@ else
 endif
 
 # cpplint linter
-CPP_LINT_FILTER = "-legal/copyright,-readability/streams,-runtime/arrays"
+CPP_LINT_FILTER = "-legal/copyright,-readability/streams,-runtime/arrays,-whitespace/indent_namespace"
 CPP_LINT_FILES = $(shell find . \( -name "*.h" -or -name "*.cpp" \) -and ! \( \
         -wholename "./common/protocol/Ola.pb.*" -or \
         -wholename "./common/rpc/Rpc.pb.*" -or \


### PR DESCRIPTION
See #1997

Due to potential false positives