### PR TITLE
Enable deprecation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,11 +99,6 @@ jobs:
         # Env var name DISTCHECK_CONFIGURE_FLAGS must be used, see #1881 and #1883
         run: |
           echo "DISTCHECK_CONFIGURE_FLAGS=${{ matrix.configure-args }}" >> $GITHUB_ENV
-      - name: Set additional Linux configure arguments
-        if: runner.os == 'Linux'
-        # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long
-        run: |
-          echo "DISTCHECK_CONFIGURE_FLAGS=$DISTCHECK_CONFIGURE_FLAGS CPPFLAGS=-Wno-deprecated-declarations" >> $GITHUB_ENV
       - name: Print configure command
         run: echo "./configure $DISTCHECK_CONFIGURE_FLAGS"
       - name: Configure

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -294,7 +294,7 @@ else
   # Env var name DISTCHECK_CONFIGURE_FLAGS must be used, see #1881 and #1883
   if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then
     # Silence all deprecated declarations on Linux due to auto_ptr making the build log too long
-    export DISTCHECK_CONFIGURE_FLAGS='--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133 CPPFLAGS=-Wno-deprecated-declarations'
+    export DISTCHECK_CONFIGURE_FLAGS='--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133'
   else
     export DISTCHECK_CONFIGURE_FLAGS='--enable-rdm-tests --enable-java-libs --enable-ja-rule --enable-e133'
   fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,19 +65,10 @@ if ! USING_WIN32
 if FATAL_WARNINGS
   COMMON_CXXFLAGS += -Werror
   COMMON_PROTOBUF_CXXFLAGS += -Werror -Wno-error=unused-parameter \
-                              -Wno-error=deprecated-declarations \
                               -Wno-error=sign-compare \
                               -Wno-error=ignored-qualifiers
   COMMON_TESTING_FLAGS += -Werror
-  COMMON_TESTING_PROTOBUF_FLAGS += -Werror -Wno-error=unused-parameter \
-                                   -Wno-error=deprecated-declarations
-
-if GNU_PLUS_PLUS_11_DEPRECATIONS
-    # We have to use gnu++11 for some reason, so stop it complaining about
-    # auto_ptr
-    COMMON_CXXFLAGS += -Wno-error=deprecated-declarations
-    COMMON_TESTING_FLAGS += -Wno-error=deprecated-declarations
-endif
+  COMMON_TESTING_PROTOBUF_FLAGS += -Werror -Wno-error=unused-parameter
 endif
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,6 @@ AS_IF([test "x$ac_cv_gnu_plus_plus_11" = xyes],
       ])
 AS_IF([test "x$require_gnu_plus_plus_11" = xyes],
       [CXXFLAGS="$CXXFLAGS -std=gnu++11"])
-AM_CONDITIONAL([GNU_PLUS_PLUS_11_DEPRECATIONS], [test "x$require_gnu_plus_plus_11" = xyes])
 
 # Checks for header files.
 AC_HEADER_DIRENT

--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@ export VERBOSE=1
 	dh $@ --parallel --with autotools_dev,autoreconf,bash_completion,python3
 
 override_dh_auto_configure:
-	dh_auto_configure -- --enable-python-libs --enable-rdm-tests CXXFLAGS='-Wno-error=deprecated-declarations -Wno-error=unused-parameter' pythondir='/usr/lib/python3/dist-packages'
+	dh_auto_configure -- --enable-python-libs --enable-rdm-tests CXXFLAGS='-Wno-error=unused-parameter' pythondir='/usr/lib/python3/dist-packages'
 
 override_dh_installinit:
 	dh_installinit -p ola --name=olad


### PR DESCRIPTION
It seems that we missed a lot of the deprecation warnings because they were turned off. Now that we have settled on minimum compiler support in #2005, it seems appropriate to turn these on and not ignore them. If we run into something specific that is deprecated in modern GCC/Clang but has no replacement for the minimum compiler version we support, we can handle those case-by-case.

The build for this PR will intentionally fail until many of @aroffringa's PRs are merged. Once those are merged I will rebase and we can see if we missed anything.